### PR TITLE
[INGM-197] Add exceptions at write_disturbance_data and map_registers

### DIFF
--- a/ingeniamotion/disturbance.py
+++ b/ingeniamotion/disturbance.py
@@ -120,7 +120,6 @@ class Disturbance:
 
         Raises:
             IMDisturbanceError: If the register list is empty.
-
             IMDisturbanceError: If the register is not allowed to be mapped as
                 a disturbance register.
         """
@@ -180,7 +179,6 @@ class Disturbance:
         Raises:
             IMDisturbanceError: If the registers are not correctly 
                 configured.
-
             IMDisturbanceError: If buffer size is not enough for all the
                 registers and samples.
         """

--- a/ingeniamotion/disturbance.py
+++ b/ingeniamotion/disturbance.py
@@ -119,11 +119,15 @@ class Disturbance:
             int: max number of samples
 
         Raises:
+            IMDisturbanceError: If the register list is empty.
+
             IMDisturbanceError: If the register is not allowed to be mapped as
                 a disturbance register.
         """
         if not isinstance(registers, list):
             registers = [registers]
+        if len(registers) == 0:
+            raise IMDisturbanceError("registers list is empty")
         drive = self.mc.servos[self.servo]
         drive.disturbance_remove_all_mapped_registers()
         total_sample_size = 0
@@ -174,11 +178,16 @@ class Disturbance:
                 as in :func:`map_registers`.
 
         Raises:
+            IMDisturbanceError: If the registers are not correctly 
+                configured.
+
             IMDisturbanceError: If buffer size is not enough for all the
                 registers and samples.
         """
         registers_data = self.__registers_data_adapter(registers_data)
         drive = self.mc.servos[self.servo]
+        if len(registers_data) != len(self.mapped_registers):
+            raise IMDisturbanceError("The registers are not correctly configured")
         self.__check_buffer_size_is_enough(registers_data)
         idx_list = list(range(len(registers_data)))
         dtype_list = [REG_DTYPE(x["dtype"]) for x in self.mapped_registers]

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -12,6 +12,7 @@ def disturbance_map_registers(disturbance):
 @pytest.fixture
 def disturbance(motion_controller):
     mc, alias = motion_controller
+    mc.capture.clean_monitoring(servo=alias)
     return Disturbance(mc, alias)
 
 
@@ -112,11 +113,9 @@ def test_disturbance_map_registers_exception(disturbance):
         disturbance.map_registers(registers)
 
 
-@pytest.mark.skip("Exception is not implemented yet")
 @pytest.mark.soem
 @pytest.mark.eoe
 def test_disturbance_map_registers_empty(disturbance):
-    # TODO Add exception in function for this test case
     registers = []
     with pytest.raises(IMDisturbanceError):
         disturbance.map_registers(registers)
@@ -130,11 +129,9 @@ def test_write_disturbance_data_buffer_exception(disturbance):
         disturbance.write_disturbance_data([0] * disturbance.max_sample_number)
 
 
-@pytest.mark.skip("Exception is not implemented yet")
 @pytest.mark.soem
 @pytest.mark.eoe
 def test_write_disturbance_data_not_configured(disturbance):
-    # TODO Add exception in function for this test case
     with pytest.raises(IMDisturbanceError):
         disturbance.write_disturbance_data([0] * 100)
 


### PR DESCRIPTION
Two exceptions were added:

- write_disturbance_data: when the length of `registers `and `self.mapped_registers` do not coincide. We assume the registers are not correctly configured in this case.
- map_registers: if the `registers` list is empty