### PR TITLE
INGM-258 Set a fix jinja2 version

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -7,3 +7,4 @@ nbsphinx==0.8.7
 rst2pdf==0.98
 wheel==0.37.1
 m2r2==0.3.2
+jinja2==3.0.3


### PR DESCRIPTION
The documentation generation process is failing due to [this ](https://github.com/sphinx-doc/sphinx/issues/10291).

Solution:
Decrease the jinja2 library version.