### PR TITLE
INGM-254 Combine test reports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,13 +101,12 @@ pipeline {
                             move .coverage .coverage_ethercat
                             exit /b 0
                         '''
-                        junit 'pytest_ethercat_0_report.xml'
-                        junit 'pytest_ethercat_1_report.xml'
                     }
                 }
                 stage('Save test results') {
                     steps {
                         stash includes: '.coverage_ethercat', name: 'coverage_reports'
+                        stash includes: '*.xml', name: 'test_reports'
                     }
                 }
             }
@@ -148,8 +147,6 @@ pipeline {
                             move .coverage .coverage_canopen
                             exit /b 0
                         '''
-                        junit 'pytest_canopen_0_report.xml'
-                        junit 'pytest_canopen_1_report.xml'
                     }
                 }
                 stage('Run Ethernet tests') {
@@ -160,8 +157,6 @@ pipeline {
                             move .coverage .coverage_ethernet
                             exit /b 0
                         '''
-                        junit 'pytest_ethernet_0_report.xml'
-                        junit 'pytest_ethernet_1_report.xml'
                     }
                 }
                 stage('Save test results') {
@@ -172,6 +167,11 @@ pipeline {
                             venv\\Scripts\\python.exe -m coverage xml --include=ingeniamotion/*
                         '''
                         publishCoverage adapters: [coberturaReportAdapter('coverage.xml')]
+                        unstash 'test_reports'
+                        bat '''
+                            venv\\Scripts\\python.exe -m tests.combine_reports -i pytest_ethernet_0_report.xml pytest_ethernet_1_report.xml pytest_canopen_0_report.xml pytest_canopen_1_report.xml pytest_ethercat_0_report.xml pytest_ethercat_1_report.xml -o combined_report.xml
+                        '''
+                        junit 'combined_report.xml'
                         archiveArtifacts artifacts: '*.xml'
                     }
                 }

--- a/ingeniamotion/monitoring/base_monitoring.py
+++ b/ingeniamotion/monitoring/base_monitoring.py
@@ -247,9 +247,7 @@ class Monitoring(ABC):
 
         """
         if total_time / 2 < abs(trigger_delay):
-            raise ValueError(
-                "trigger_delay value should be between -total_time/2 and total_time/2"
-            )
+            raise ValueError("trigger_delay value should be between -total_time/2 and total_time/2")
         total_num_samples = int(self.sampling_freq * total_time)
         trigger_delay_samples = int(((total_time / 2) - trigger_delay) * self.sampling_freq)
         self.configure_number_samples(total_num_samples, trigger_delay_samples)

--- a/ingeniamotion/wizard_tests/phase_calibration.py
+++ b/ingeniamotion/wizard_tests/phase_calibration.py
@@ -112,9 +112,7 @@ class Phasing(BaseTest):
                 self.MAX_CURRENT_ON_PHASING_SEQUENCE_REGISTER, servo=self.servo, axis=self.axis
             )
             if self.pha_current > max_test_current:
-                raise TestError(
-                    "Defined phasing current is higher than configured maximum current"
-                )
+                raise TestError("Defined phasing current is higher than configured maximum current")
         if self.default_phasing_timeout:
             self.mc.communication.set_register(
                 self.PHASING_TIMEOUT_REGISTER,
@@ -284,9 +282,7 @@ class Phasing(BaseTest):
                 break
 
         if not phasing_bit_latched:
-            self.logger.info(
-                "ERROR: Phasing process has failed. Review your motor configuration."
-            )
+            self.logger.info("ERROR: Phasing process has failed. Review your motor configuration.")
             return self.ResultType.FAIL
 
         self.mc.motion.motor_disable(servo=self.servo, axis=self.axis)

--- a/tests/combine_reports.py
+++ b/tests/combine_reports.py
@@ -106,22 +106,29 @@ def combine_reports(test_reports):
                 combined_report["testcases"][classname] = {}
             for name in report_dict["testcases"][classname].keys():
                 if name not in combined_report["testcases"][classname]:
-                    combined_report["testcases"][classname][name] = {
-                        "result": report_dict["testcases"][classname][name]["result"],
-                        "message": "\n PROTOCOL: {} - SLAVE: {} --> {} \n {} \n {}".format(
+                    result = report_dict["testcases"][classname][name]["result"]
+                    if result != "PASSED":
+                        message = "PROTOCOL: {} - SLAVE: {} --> {} ({})".format(
                             str(protocol),
                             str(slave),
                             report_dict["testcases"][classname][name]["result"],
-                            SEPARATOR,
                             report_dict["testcases"][classname][name]["message"]
-                        ),
-                        "output": "\n PROTOCOL: {} - SLAVE: {} --> {} \n {} \n {}".format(
+                        )
+                        output =  "\n PROTOCOL: {} - SLAVE: {} --> {} \n {} \n {}".format(
                             str(protocol),
                             str(slave),
                             report_dict["testcases"][classname][name]["result"],
                             SEPARATOR,
                             report_dict["testcases"][classname][name]["output"]
-                        ),
+                        )
+                    else:
+                        message = ""
+                        output = ""
+                    
+                    combined_report["testcases"][classname][name] = {
+                        "result": report_dict["testcases"][classname][name]["result"],
+                        "message": message,
+                        "output": output,
                         "time": report_dict["testcases"][classname][name]["time"]
                     }
                 else:
@@ -143,24 +150,30 @@ def combine_reports(test_reports):
                         if combined_report["testcases"][classname][name]["result"] == "PASSED":
                             result = "PASSED"
 
-                    combined_report["testcases"][classname][name] = {
-                        "result": result,
-                        "message": "{} \n\n PROTOCOL: {} - SLAVE: {} --> {} \n {} \n {}".format(
+                    if report_dict["testcases"][classname][name]["result"] != "PASSED":
+                        message = "{} // PROTOCOL: {} - SLAVE: {} --> {} ({})".format(
                             combined_report["testcases"][classname][name]["message"],
                             str(protocol),
                             str(slave),
                             report_dict["testcases"][classname][name]["result"],
-                            SEPARATOR,
                             report_dict["testcases"][classname][name]["message"]
-                        ),
-                        "output": "{} \n\n PROTOCOL: {} - SLAVE: {} --> {} \n {} \n {}".format(
+                        )
+                        output = "{} \n\n PROTOCOL: {} - SLAVE: {} --> {} \n {} \n {}".format(
                             combined_report["testcases"][classname][name]["output"],
                             str(protocol),
                             str(slave),
                             report_dict["testcases"][classname][name]["result"],
                             SEPARATOR,
                             report_dict["testcases"][classname][name]["output"]
-                        ),
+                        )
+                    else:
+                        message = combined_report["testcases"][classname][name]["message"]
+                        output = combined_report["testcases"][classname][name]["output"]
+
+                    combined_report["testcases"][classname][name] = {
+                        "result": result,
+                        "message": message,
+                        "output": output,
                         "time": combined_report["testcases"][classname][name]["time"] + report_dict["testcases"][classname][name]["time"]
                     }
 

--- a/tests/combine_reports.py
+++ b/tests/combine_reports.py
@@ -82,6 +82,21 @@ def load_reports(input_reports):
     return test_reports
 
 
+def get_result_based_on_previous(previous_result, actual_result):
+    if previous_result == "ERROR" or actual_result == "ERROR":
+        result = "ERROR"
+    elif previous_result == "FAILED" or actual_result == "FAILED":
+        result = "FAILED"
+    elif previous_result == "SKIPPED" and actual_result == "SKIPPED":
+        result = "SKIPPED"
+    elif previous_result == "SKIPPED" and actual_result == "PASSED":
+        result = "PASSED"
+    elif previous_result == "PASSED" and actual_result == "PASSED":
+        result = "PASSED"
+
+    return result
+
+
 def combine_reports(test_reports):
     combined_report = {
         "time": 0,
@@ -132,23 +147,9 @@ def combine_reports(test_reports):
                         "time": report_dict["testcases"][classname][name]["time"]
                     }
                 else:
-                    if combined_report["testcases"][classname][name]["result"] == "ERROR":
-                        result = "ERROR" # ERROR before
-                    elif report_dict["testcases"][classname][name]["result"] == "ERROR":
-                        result = "ERROR" # ERROR now
-                    elif combined_report["testcases"][classname][name]["result"] == "FAILED":
-                        result = "FAILED" # FAILED before
-                    elif report_dict["testcases"][classname][name]["result"] == "FAILED":
-                        result = "FAILED" # FAILED now
-                    elif combined_report["testcases"][classname][name]["result"] == "SKIPPED":
-                        # SKIPPED before
-                        if combined_report["testcases"][classname][name]["result"] == "PASSED":
-                            result = "PASSED"
-                        else:
-                            result = "SKIPPED"
-                    else:
-                        if combined_report["testcases"][classname][name]["result"] == "PASSED":
-                            result = "PASSED"
+                    previous_result = combined_report["testcases"][classname][name]["result"]
+                    actual_result = report_dict["testcases"][classname][name]["result"]
+                    result = get_result_based_on_previous(previous_result, actual_result)
 
                     if report_dict["testcases"][classname][name]["result"] != "PASSED":
                         message = "{} // PROTOCOL: {} - SLAVE: {} --> {} ({})".format(

--- a/tests/combine_reports.py
+++ b/tests/combine_reports.py
@@ -149,8 +149,11 @@ def update_report(report_dict, combined_report, classname, name, protocol, slave
         message = combined_report["testcases"][classname][name]["message"]
         output = combined_report["testcases"][classname][name]["output"]
 
-    time = combined_report["testcases"][classname][name]["time"] + report_dict["testcases"][classname][name]["time"]
-    
+    time = (
+        combined_report["testcases"][classname][name]["time"]
+        + report_dict["testcases"][classname][name]["time"]
+    )
+
     return result, message, output, time
 
 

--- a/tests/combine_reports.py
+++ b/tests/combine_reports.py
@@ -99,9 +99,6 @@ def combine_reports(test_reports):
             combined_report["timestamp"] = report_dict["timestamp"]
             combined_report["hostname"] = report_dict["hostname"]
         combined_report["time"] += report_dict["time"]
-        if combined_report["tests"] > 0:
-            if report_dict["tests"] != combined_report["tests"]:
-                raise AssertionError("The number of tests should be the same for every report")
         combined_report["tests"] = report_dict["tests"]
 
         for classname in report_dict["testcases"].keys():
@@ -136,7 +133,7 @@ def combine_reports(test_reports):
                         result = "FAILED" # FAILED before
                     elif report_dict["testcases"][classname][name]["result"] == "FAILED":
                         result = "FAILED" # FAILED now
-                    elif report_dict["testcases"][classname][name]["result"] == "SKIPPED":
+                    elif combined_report["testcases"][classname][name]["result"] == "SKIPPED":
                         # SKIPPED before
                         if combined_report["testcases"][classname][name]["result"] == "PASSED":
                             result = "PASSED"

--- a/tests/combine_reports.py
+++ b/tests/combine_reports.py
@@ -1,3 +1,5 @@
+import os
+import glob
 import argparse
 import xml.etree.ElementTree as ET
 from xml.dom import minidom
@@ -21,8 +23,8 @@ def load_reports(input_reports):
     test_reports = {}
     for input_path in input_reports:
         try: 
-            with open(input_path, 'r', encoding='utf-8') as xdf_file:
-                tree = ET.parse(xdf_file)
+            with open(input_path, 'r', encoding='utf-8') as xml_file:
+                tree = ET.parse(xml_file)
         except FileNotFoundError:
             raise FileNotFoundError(f"There is not any xml file in the path: {input_path}")
         root = tree.getroot()
@@ -230,10 +232,22 @@ def save_xml(combined_report, output_file):
 
 
 def main(args):
-    if len(args.input_reports) < 2:
+    input_reports = []
+    for input_report in  args.input_reports:
+        if os.path.isdir(input_report):
+            xml_files = glob.glob(os.path.join(input_report, "*.xml"))
+            if len(xml_files) == 0:
+                raise AttributeError(f"Folder {input_report} is empty")
+            input_reports.extend(xml_files)
+        elif input_report.endswith('.xml'):
+            input_reports.append(input_report)
+        else:
+            raise AttributeError(f"Incorrect extension: {input_report}")
+
+    if len(input_reports) < 2:
         raise AttributeError("At least two input reports are needed to be combined")
 
-    test_reports = load_reports(args.input_reports)
+    test_reports = load_reports(input_reports)
     combined_report = combine_reports(test_reports)
     save_xml(combined_report, args.output_file)        
 

--- a/tests/combine_reports.py
+++ b/tests/combine_reports.py
@@ -89,9 +89,7 @@ def get_result_based_on_previous(previous_result, actual_result):
         result = "FAILED"
     elif previous_result == "SKIPPED" and actual_result == "SKIPPED":
         result = "SKIPPED"
-    elif previous_result == "SKIPPED" and actual_result == "PASSED":
-        result = "PASSED"
-    elif previous_result == "PASSED" and actual_result == "PASSED":
+    elif previous_result in ["SKIPPED", "PASSED"] and actual_result == "PASSED":
         result = "PASSED"
 
     return result

--- a/tests/combine_reports.py
+++ b/tests/combine_reports.py
@@ -1,0 +1,233 @@
+import argparse
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+
+
+XML_ROOT = "."
+XML_TESTSUITE = f"{XML_ROOT}/testsuite"
+XML_TESTSUITE_PROPS = "properties/property"
+XML_TESTCASE = "testcase"
+SEPARATOR = "============================================="
+
+
+def setup_command():
+    parser = argparse.ArgumentParser(description='Combine xml pytest reports')
+    parser.add_argument('-i', '--input-reports', default=[], nargs='+', required=True)
+    parser.add_argument('-o', '--output-file', type=str, required=True)
+    return parser.parse_args()
+
+
+def load_reports(input_reports):
+    test_reports = {}
+    for input_path in input_reports:
+        try: 
+            with open(input_path, 'r', encoding='utf-8') as xdf_file:
+                tree = ET.parse(xdf_file)
+        except FileNotFoundError:
+            raise FileNotFoundError(f"There is not any xml file in the path: {input_path}")
+        root = tree.getroot()
+        testsuite = root.find(XML_TESTSUITE)
+        properties = testsuite.findall(XML_TESTSUITE_PROPS)
+        protocol = [prop.attrib["value"] for prop in properties if prop.attrib["name"] == "protocol"][0]
+        slave = [prop.attrib["value"] for prop in properties if prop.attrib["name"] == "slave"][0]
+        test_reports[input_path] = {
+            "errors": int(testsuite.attrib["errors"]),
+            "failures": int(testsuite.attrib["failures"]),
+            "skipped": int(testsuite.attrib["skipped"]),
+            "tests": int(testsuite.attrib["tests"]),
+            "time": float(testsuite.attrib["time"]),
+            "timestamp": testsuite.attrib["timestamp"],
+            "hostname": testsuite.attrib["hostname"],
+            "protocol": protocol,
+            "slave": slave,
+            "testcases": {}
+        } 
+        testcases = testsuite.findall(XML_TESTCASE)
+        
+        for testcase in testcases:
+            classname = testcase.attrib["classname"]
+            name = testcase.attrib["name"]
+            if classname not in test_reports[input_path]["testcases"]:
+                test_reports[input_path]["testcases"][classname] = {}
+            
+            failure = testcase.find("failure")
+            skipped = testcase.find("skipped")
+            error = testcase.find("error")
+            if failure is not None:
+                test_reports[input_path]["testcases"][classname][name] = {
+                    "result": "FAILED",
+                    "message": failure.attrib["message"],
+                    "output": failure.text
+                }
+            elif skipped is not None:
+                test_reports[input_path]["testcases"][classname][name] = {
+                    "result": "SKIPPED",
+                    "message": skipped.attrib["message"],
+                    "output": skipped.text
+                }
+            elif error is not None:
+                test_reports[input_path]["testcases"][classname][name] = {
+                    "result": "ERROR",
+                    "message": error.attrib["message"],
+                    "output": error.text
+                }
+            else:
+                test_reports[input_path]["testcases"][classname][name] = {
+                    "result": "PASSED",
+                    "message": "",
+                    "output": ""
+                }
+            test_reports[input_path]["testcases"][classname][name]["time"] = float(testcase.attrib["time"])
+        
+    return test_reports
+
+
+def combine_reports(test_reports):
+    combined_report = {
+        "time": 0,
+        "errors": 0,
+        "failures": 0,
+        "passed": 0,
+        "skipped": 0,
+        "tests": 0,
+        "testcases": {}
+    }
+    for report_path, report_dict in test_reports.items():
+        protocol = report_dict["protocol"]
+        slave = report_dict["slave"]
+        if "timestamp" not in combined_report:
+            combined_report["timestamp"] = report_dict["timestamp"]
+            combined_report["hostname"] = report_dict["hostname"]
+        combined_report["time"] += report_dict["time"]
+        if combined_report["tests"] > 0:
+            if report_dict["tests"] != combined_report["tests"]:
+                raise AssertionError("The number of tests should be the same for every report")
+        combined_report["tests"] = report_dict["tests"]
+
+        for classname in report_dict["testcases"].keys():
+            if classname not in combined_report["testcases"]:
+                combined_report["testcases"][classname] = {}
+            for name in report_dict["testcases"][classname].keys():
+                if name not in combined_report["testcases"][classname]:
+                    combined_report["testcases"][classname][name] = {
+                        "result": report_dict["testcases"][classname][name]["result"],
+                        "message": "\n PROTOCOL: {} - SLAVE: {} --> {} \n {} \n {}".format(
+                            str(protocol),
+                            str(slave),
+                            report_dict["testcases"][classname][name]["result"],
+                            SEPARATOR,
+                            report_dict["testcases"][classname][name]["message"]
+                        ),
+                        "output": "\n PROTOCOL: {} - SLAVE: {} --> {} \n {} \n {}".format(
+                            str(protocol),
+                            str(slave),
+                            report_dict["testcases"][classname][name]["result"],
+                            SEPARATOR,
+                            report_dict["testcases"][classname][name]["output"]
+                        ),
+                        "time": report_dict["testcases"][classname][name]["time"]
+                    }
+                else:
+                    if combined_report["testcases"][classname][name]["result"] == "ERROR":
+                        result = "ERROR" # ERROR before
+                    elif report_dict["testcases"][classname][name]["result"] == "ERROR":
+                        result = "ERROR" # ERROR now
+                    elif combined_report["testcases"][classname][name]["result"] == "FAILED":
+                        result = "FAILED" # FAILED before
+                    elif report_dict["testcases"][classname][name]["result"] == "FAILED":
+                        result = "FAILED" # FAILED now
+                    elif report_dict["testcases"][classname][name]["result"] == "SKIPPED":
+                        # SKIPPED before
+                        if combined_report["testcases"][classname][name]["result"] == "PASSED":
+                            result = "PASSED"
+                        else:
+                            result = "SKIPPED"
+                    else:
+                        if combined_report["testcases"][classname][name]["result"] == "PASSED":
+                            result = "PASSED"
+
+                    combined_report["testcases"][classname][name] = {
+                        "result": result,
+                        "message": "{} \n\n PROTOCOL: {} - SLAVE: {} --> {} \n {} \n {}".format(
+                            combined_report["testcases"][classname][name]["message"],
+                            str(protocol),
+                            str(slave),
+                            report_dict["testcases"][classname][name]["result"],
+                            SEPARATOR,
+                            report_dict["testcases"][classname][name]["message"]
+                        ),
+                        "output": "{} \n\n PROTOCOL: {} - SLAVE: {} --> {} \n {} \n {}".format(
+                            combined_report["testcases"][classname][name]["output"],
+                            str(protocol),
+                            str(slave),
+                            report_dict["testcases"][classname][name]["result"],
+                            SEPARATOR,
+                            report_dict["testcases"][classname][name]["output"]
+                        ),
+                        "time": combined_report["testcases"][classname][name]["time"] + report_dict["testcases"][classname][name]["time"]
+                    }
+
+    for classname in combined_report["testcases"].keys():
+        for name in combined_report["testcases"][classname].keys():
+            result = combined_report["testcases"][classname][name]["result"]
+            if result == "PASSED":
+                combined_report["passed"] += 1
+            elif result == "ERROR":
+                combined_report["errors"] += 1        
+            elif result == "FAILED":
+                combined_report["failures"] += 1    
+            else:
+                combined_report["skipped"] += 1    
+
+    return combined_report
+
+
+def save_xml(combined_report, output_file):
+    tree = ET.Element("testsuites")
+    testsuite = ET.SubElement(tree, "testsuite")
+    testsuite.set("name", "pytest")
+    testsuite.set("errors", str(combined_report["errors"]))
+    testsuite.set("failures", str(combined_report["failures"]))
+    testsuite.set("skipped", str(combined_report["skipped"]))
+    testsuite.set("tests", str(combined_report["tests"]))
+    testsuite.set("time", str(combined_report["time"]))
+    testsuite.set("timestamp", combined_report["timestamp"])
+    testsuite.set("hostname", combined_report["hostname"])
+
+    for classname in combined_report["testcases"].keys():
+        for name, testcase_dict in combined_report["testcases"][classname].items():
+            testcase = ET.SubElement(testsuite, "testcase")
+            testcase.set("time", str(testcase_dict["time"]))
+            testcase.set("classname", classname)
+            testcase.set("name", name)
+
+            if testcase_dict["result"] == "SKIPPED":
+                skip = ET.SubElement(testcase, "skipped")
+                skip.set("type", "pytest.skip") 
+                skip.set("message", testcase_dict["message"]) 
+                skip.text = testcase_dict["output"] 
+            elif testcase_dict["result"] == "ERROR":
+                skip = ET.SubElement(testcase, "error")
+                skip.set("message", testcase_dict["message"]) 
+                skip.text = testcase_dict["output"] 
+            elif testcase_dict["result"] == "FAILED":
+                skip = ET.SubElement(testcase, "failure")
+                skip.set("message", testcase_dict["message"]) 
+                skip.text = testcase_dict["output"] 
+
+    dom = minidom.parseString(ET.tostring(tree, encoding='utf-8'))
+    with open(output_file, "wb") as f:
+        f.write(dom.toprettyxml(indent='\t').encode())
+
+
+def main(args):
+    if len(args.input_reports) < 2:
+        raise AttributeError("At least two input reports are needed to be combined")
+
+    test_reports = load_reports(args.input_reports)
+    combined_report = combine_reports(test_reports)
+    save_xml(combined_report, args.output_file)        
+
+if __name__ == '__main__':
+    args = setup_command()
+    main(args)

--- a/tests/combine_reports.py
+++ b/tests/combine_reports.py
@@ -93,6 +93,8 @@ def get_result_based_on_previous(previous_result, actual_result):
         result = "SKIPPED"
     elif previous_result in ["SKIPPED", "PASSED"] and actual_result == "PASSED":
         result = "PASSED"
+    elif previous_result == "PASSED" and actual_result in "SKIPPED":
+        result = "PASSED"
 
     return result
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,3 +133,11 @@ def clean_and_restore_feedbacks(motion_controller):
     mc.configuration.set_velocity_feedback(vel, servo=alias)
     mc.configuration.set_position_feedback(pos, servo=alias)
     mc.configuration.set_auxiliar_feedback(aux, servo=alias)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def log_node_protocol(record_testsuite_property, pytestconfig):
+    protocol = pytestconfig.getoption("--protocol")
+    slave = pytestconfig.getoption("--slave")
+    record_testsuite_property("protocol", protocol)
+    record_testsuite_property("slave", slave)


### PR DESCRIPTION
## Combine test reports

### Description

This PR adds a script to combine XML reports from several runs of the tests. This is relevant to combine information from tests with different protocols/slaves. The script concatenates error/failure/skip messages, including a header with the protocol and slave information. The combined test result is defined as follows:

PASSED → If the test passed for all protocols and all slaves.
SKIPPED → If the test was skipped for all protocols and all slaves.
ERROR → If there is at least one error.
FAILED → If there is at least one failure if no error occurred.

Fixes # INGM-254

### Type of change

- [x] Add the `tests/combine_reports.py script`
- [x] Add a fixture to save the protocol and slave for each test session. 
- [x] Update Jenkinsfile to combine the reports before publishing them using JUnit.

### Tests
- [x] The script was verified using Jenkins (branch test-INGM-254).

[INGM-254]: https://ingeniamc.atlassian.net/browse/INGM-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INGM-254]: https://ingeniamc.atlassian.net/browse/INGM-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ