### PR TITLE
INGM-261 Load configuration if a test fails

### DIFF
--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest==6.2.4
+pytest==7.0.1
 pytest-cov==2.12.1
 pytest-mock==3.6.1
 ping3==3.0.2

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     ],
     extras_require={
         "tests": [
-            "pytest==6.2.4",
+            "pytest==7.0.1",
             "pytest-cov==2.12.1",
             "pytest-mock==3.6.1",
             "ping3==3.0.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
 import json
 import pytest
+from typing import Dict
 
 from ingeniamotion.enums import CAN_BAUDRATE, CAN_DEVICE, SensorType
 from ingeniamotion import MotionController
 
 ALLOW_PROTOCOLS = ["eoe", "soem", "canopen"]
+
+test_report_key = pytest.StashKey[Dict[str, pytest.CollectReport]]()
 
 
 def pytest_addoption(parser):
@@ -133,3 +136,24 @@ def clean_and_restore_feedbacks(motion_controller):
     mc.configuration.set_velocity_feedback(vel, servo=alias)
     mc.configuration.set_position_feedback(pos, servo=alias)
     mc.configuration.set_auxiliar_feedback(aux, servo=alias)
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    # execute all other hooks to obtain the report object
+    outcome = yield
+    rep = outcome.get_result()
+
+    # store test results for each phase of a call, which can be "setup", "call", "teardown"
+    item.stash.setdefault(test_report_key, {})[rep.when] = rep
+
+
+@pytest.fixture(scope="function", autouse=True)
+def load_configuration_if_test_fails(request, motion_controller, read_config):
+    mc, alias = motion_controller
+    yield
+
+    report = request.node.stash[test_report_key]
+    if report["setup"].failed or ("call" not in report) or report["call"].failed:
+        mc.configuration.load_configuration(read_config["config_file"], servo=alias)
+        mc.motion.fault_reset(servo=alias)


### PR DESCRIPTION
##  Load configuration if a test fails

### Description

This PR adds a fixture to load configuration if a test fails. Based on [pytest docs](https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures).

Fixes # INGM-261

### Type of change

- [x] Add fixture.
- [x] Upgrade pytest to 7.0.1 (still compatible with py 3.6.0).

### Tests
- [x] It was verified that the fixture was called if a test fails during setup or calling.