### PR TITLE
INGM-242 Improve tests of the capture module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,3 +133,10 @@ def clean_and_restore_feedbacks(motion_controller):
     mc.configuration.set_velocity_feedback(vel, servo=alias)
     mc.configuration.set_position_feedback(pos, servo=alias)
     mc.configuration.set_auxiliar_feedback(aux, servo=alias)
+
+
+@pytest.fixture()
+def skip_if_monitoring_not_available(motion_controller):
+    mc, alias = motion_controller
+    if "MON_DIST_STATUS" not in mc.servos[alias].dictionary.registers(0):
+        pytest.skip('Monitoring is not available')

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -20,7 +20,7 @@ def __compare_signals(expected_signal, received_signal, length_tol=None, fft_tol
     fft_received = np.abs(np.fft.fft(received_signal))
     fft_expected = np.abs(np.fft.fft(expected_signal))
 
-    # L1 normalization
+    # Normalization
     fft_received = fft_received / np.amax(fft_received)
     fft_expected = fft_expected / np.amax(fft_expected)
         
@@ -215,6 +215,7 @@ def test_monitoring_max_sample_size(skip_if_monitoring_not_available, motion_con
     drive = mc.servos[alias]
     value = drive.read(target_register, subnode=axis)
     assert max_sample_size == value
+
 
 def test_get_frequency(
     skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -191,7 +191,7 @@ def test_mcb_synchronization_fail(motion_controller):
 
 
 @pytest.mark.smoke
-def test_disturbance_max_sample_size(motion_controller):
+def test_disturbance_max_sample_size(skip_if_monitoring_not_available, motion_controller):
     mc, alias = motion_controller
     target_register = mc.capture.DISTURBANCE_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -39,7 +39,7 @@ def test_create_poller(motion_controller):
         time.sleep(1)
         mc.motion.set_current_quadrature(0.2 * (i + 1), servo=alias)
         expected_signal.extend([0.2 * (i + 1)] * int(period / sampling_time))
-    time.sleep(2 * period)
+    time.sleep(3 * period)
     timestamp, test_data, _ = poller.data
     poller.stop()
     assert np.allclose(np.diff(timestamp), sampling_time, rtol=0.5, atol=0)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -28,21 +28,20 @@ def __compare_signals(expected_signal, received_signal, length_tol=None, fft_tol
 
 def test_create_poller(motion_controller):
     registers = [{"name": "CL_CUR_Q_SET_POINT", "axis": 1}]
-    sampling_time = 0.05
+    sampling_time = 0.125
     mc, alias = motion_controller
     mc.motion.set_current_quadrature(-0.2, servo=alias)
     poller = mc.capture.create_poller(registers, alias, sampling_time, buffer_size=120)
     mc.motion.set_current_quadrature(0, servo=alias)
     period = 1
     expected_signal = [0] * int(period / sampling_time)
-    for i in range(5):
+    for i in range(7):
         time.sleep(1)
         mc.motion.set_current_quadrature(0.2 * (i + 1), servo=alias)
         expected_signal.extend([0.2 * (i + 1)] * int(period / sampling_time))
     time.sleep(period)
     timestamp, test_data, _ = poller.data
     poller.stop()
-
     assert np.allclose(np.diff(timestamp), sampling_time, rtol=0.5, atol=0)
 
     received_signal = test_data[0]

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -15,6 +15,8 @@ def __compare_signals(expected_signal, received_signal, length_tol=None, fft_tol
         if len(received_signal) < len():
             expected_signal = expected_signal[:len(received_signal)]
 
+    assert len(received_signal) == len(expected_signal)
+
     fft_received = np.abs(np.fft.fft(received_signal))
     fft_expected = np.abs(np.fft.fft(expected_signal))
 

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -51,8 +51,9 @@ def test_create_poller(motion_controller):
     __compare_signals(expected_signal, received_signal)
 
 
-def test_create_monitoring_no_trigger(motion_controller,
-                                      disable_monitoring_disturbance):
+def test_create_monitoring_no_trigger(
+    skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
+):
     registers = [{
         "name": "CL_POS_REF_VALUE",
         "axis": 1
@@ -90,8 +91,14 @@ def test_create_monitoring_no_trigger(motion_controller,
      MonitoringSoCConfig.TRIGGER_CONFIG_FALLING,
      [0.75, 0.5, 0.25, 0]),
 ])
-def test_create_monitoring_edge_trigger(motion_controller, trigger_mode, trigger_config,
-                                        values_list, disable_monitoring_disturbance):
+def test_create_monitoring_edge_trigger(
+    skip_if_monitoring_not_available,
+    motion_controller,
+    trigger_mode,
+    trigger_config, 
+    values_list, 
+    disable_monitoring_disturbance
+):
     register = {
         "name": "CL_POS_REF_VALUE",
         "axis": 1
@@ -133,8 +140,9 @@ def test_create_monitoring_edge_trigger(motion_controller, trigger_mode, trigger
     __compare_signals(expected_signal, data[0])
 
 
-def test_create_disturbance(motion_controller,
-                            disable_monitoring_disturbance):
+def test_create_disturbance(
+    skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
+):
     mc, alias = motion_controller
     target_register = "CL_POS_SET_POINT_VALUE"
     max_frequency = mc.configuration.get_position_and_velocity_loop_rate(alias)
@@ -194,7 +202,7 @@ def test_disturbance_max_sample_size(motion_controller):
 
 
 @pytest.mark.smoke
-def test_monitoring_max_sample_size(motion_controller):
+def test_monitoring_max_sample_size(skip_if_monitoring_not_available, motion_controller):
     mc, alias = motion_controller
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -203,7 +211,9 @@ def test_monitoring_max_sample_size(motion_controller):
     value = drive.read(target_register, subnode=axis)
     assert max_sample_size == value
 
-def test_get_frequency(motion_controller, disable_monitoring_disturbance):
+def test_get_frequency(
+    skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
+):
     mc, alias = motion_controller
     registers = [{
         "name": "CL_POS_REF_VALUE",

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -74,6 +74,9 @@ def test_create_monitoring_no_trigger(
     monitoring = mc.capture.create_monitoring(registers, divider,
                                               total_time, servo=alias)
     mc.capture.enable_monitoring_disturbance(servo=alias)
+    # Dummy reading
+    monitoring.read_monitoring_data()
+    monitoring.rearm_monitoring()
     init = time.time()
     expected_signal = [0]*quarter_num_samples
     for i in range(1, 4):

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -7,7 +7,7 @@ from ingeniamotion.exceptions import IMStatusWordError
 from ingeniamotion.enums import OperationMode, MonitoringSoCType, MonitoringSoCConfig
 
 
-def __compare_signals(expected_signal, received_signal, length_tol=None, fft_tol=0.05, plot=False):
+def __compare_signals(expected_signal, received_signal, length_tol=None, fft_tol=0.05):
     if length_tol is not None:
         assert pytest.approx(len(received_signal), length_tol) == len(expected_signal)
 
@@ -22,13 +22,6 @@ def __compare_signals(expected_signal, received_signal, length_tol=None, fft_tol
     # Normalization
     fft_received = fft_received / np.amax(fft_received)
     fft_expected = fft_expected / np.amax(fft_expected)
-
-    if plot:
-        import matplotlib.pyplot as plt
-
-        plt.plot(received_signal)
-        plt.plot(expected_signal)
-        plt.show()
 
     assert np.allclose(fft_received, fft_expected, rtol=0, atol=fft_tol)
 
@@ -202,7 +195,7 @@ def test_create_monitoring_trigger_delay(
     else:
         expected_signal[-trigger_delay_samples:] = value
     data = monitoring.read_monitoring_data()
-    __compare_signals(expected_signal, data[0], plot=True)
+    __compare_signals(expected_signal, data[0])
 
 
 def test_create_disturbance(

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -7,15 +7,7 @@ from ingeniamotion.exceptions import IMStatusWordError
 from ingeniamotion.enums import OperationMode, MonitoringSoCType, MonitoringSoCConfig
 
 
-def __compare_signals(expected_signal, received_signal, length_tol=None, fft_tol=0.05):
-    if length_tol is not None:
-        assert pytest.approx(len(received_signal), length_tol) == len(expected_signal)
-
-        if len(received_signal) < len(expected_signal):
-            expected_signal = expected_signal[: len(received_signal)]
-
-    assert len(received_signal) == len(expected_signal)
-
+def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
     fft_received = np.abs(np.fft.fft(received_signal))
     fft_expected = np.abs(np.fft.fft(expected_signal))
 
@@ -23,7 +15,7 @@ def __compare_signals(expected_signal, received_signal, length_tol=None, fft_tol
     fft_received = fft_received / np.amax(fft_received)
     fft_expected = fft_expected / np.amax(fft_expected)
 
-    assert np.allclose(fft_received, fft_expected, rtol=0, atol=fft_tol)
+    return np.allclose(fft_received, fft_expected, rtol=0, atol=fft_tol)
 
 
 def test_create_poller(motion_controller):
@@ -45,7 +37,8 @@ def test_create_poller(motion_controller):
     assert np.allclose(np.diff(timestamp), sampling_time, rtol=0.5, atol=0)
 
     received_signal = test_data[0]
-    __compare_signals(expected_signal, received_signal)
+    assert len(received_signal) == len(expected_signal)
+    assert __compare_signals(expected_signal, received_signal)
 
 
 def test_create_monitoring_no_trigger(
@@ -76,7 +69,8 @@ def test_create_monitoring_no_trigger(
         mc.motion.move_to_position(quarter_num_samples * i, alias)
         expected_signal.extend([i * quarter_num_samples] * quarter_num_samples)
     data = monitoring.read_monitoring_data()
-    __compare_signals(expected_signal, data[0])
+    assert len(data[0]) == len(expected_signal)
+    assert __compare_signals(expected_signal, data[0])
 
 
 @pytest.mark.parametrize(
@@ -139,7 +133,8 @@ def test_create_monitoring_edge_trigger(
         expected_signal[i * quarter_num_samples : (i + 1) * quarter_num_samples] = value
 
     data = monitoring.read_monitoring_data()
-    __compare_signals(expected_signal, data[0])
+    assert len(data[0]) == len(expected_signal)
+    assert __compare_signals(expected_signal, data[0])
 
 
 @pytest.mark.parametrize("trigger_delay_rate", [-1 / 4, 1 / 4])
@@ -195,7 +190,8 @@ def test_create_monitoring_trigger_delay(
     else:
         expected_signal[-trigger_delay_samples:] = value
     data = monitoring.read_monitoring_data()
-    __compare_signals(expected_signal, data[0])
+    assert len(data[0]) == len(expected_signal)
+    assert __compare_signals(expected_signal, data[0])
 
 
 def test_create_disturbance(
@@ -225,7 +221,8 @@ def test_create_disturbance(
         time.sleep(period)
 
     read_data = np.interp(dist_timestamp, read_timestamp, read_data)
-    __compare_signals(data, read_data)
+    assert len(data) == len(read_data)
+    assert __compare_signals(data, read_data)
 
 
 @pytest.mark.smoke

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -28,7 +28,7 @@ def __compare_signals(expected_signal, received_signal, length_tol=None, fft_tol
 
 def test_create_poller(motion_controller):
     registers = [{"name": "CL_CUR_Q_SET_POINT", "axis": 1}]
-    sampling_time = 0.125
+    sampling_time = 0.25
     mc, alias = motion_controller
     mc.motion.set_current_quadrature(-0.2, servo=alias)
     poller = mc.capture.create_poller(registers, alias, sampling_time, buffer_size=120)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -45,7 +45,7 @@ def test_create_poller(motion_controller):
     timestamp, test_data, _ = poller.data
     poller.stop()
 
-    assert np.allclose(np.diff(timestamp), sampling_time, rtol=0.1, atol=0)
+    assert np.allclose(np.diff(timestamp), sampling_time, rtol=0.5, atol=0)
 
     received_signal = test_data[0]
     __compare_signals(expected_signal, received_signal)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -11,7 +11,7 @@ def __compare_signals(expected_signal, received_signal, length_tol=None, fft_tol
     if length_tol is not None:
         assert pytest.approx(len(received_signal), length_tol) == len(expected_signal)
 
-        if len(received_signal) < len():
+        if len(received_signal) < len(expected_signal):
             expected_signal = expected_signal[: len(received_signal)]
 
     assert len(received_signal) == len(expected_signal)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -28,10 +28,10 @@ def __compare_signals(expected_signal, received_signal, length_tol=None, fft_tol
 
 def test_create_poller(motion_controller):
     registers = [{"name": "CL_CUR_Q_SET_POINT", "axis": 1}]
-    sampling_time = 0.25
+    sampling_time = 0.0625
     mc, alias = motion_controller
     mc.motion.set_current_quadrature(-0.2, servo=alias)
-    poller = mc.capture.create_poller(registers, alias, sampling_time, buffer_size=120)
+    poller = mc.capture.create_poller(registers, alias, sampling_time, buffer_size=128)
     mc.motion.set_current_quadrature(0, servo=alias)
     period = 1
     expected_signal = [0] * int(period / sampling_time)
@@ -39,7 +39,7 @@ def test_create_poller(motion_controller):
         time.sleep(1)
         mc.motion.set_current_quadrature(0.2 * (i + 1), servo=alias)
         expected_signal.extend([0.2 * (i + 1)] * int(period / sampling_time))
-    time.sleep(period)
+    time.sleep(2 * period)
     timestamp, test_data, _ = poller.data
     poller.stop()
     assert np.allclose(np.diff(timestamp), sampling_time, rtol=0.5, atol=0)

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -124,7 +124,9 @@ def test_write_disturbance_data_not_configured(disturbance):
 
 @pytest.mark.soem
 @pytest.mark.eoe
-def test_write_disturbance_data_enabled(motion_controller, disturbance, disable_monitoring_disturbance):
+def test_write_disturbance_data_enabled(
+    motion_controller, disturbance, disable_monitoring_disturbance
+):
     mc, alias = motion_controller
     mc.capture.enable_monitoring_disturbance(alias)
     with pytest.raises(IMDisturbanceError):

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -5,12 +5,12 @@ from ingeniamotion.exceptions import IMDisturbanceError
 
 
 @pytest.fixture
-def disturbance_map_registers(disturbance):
+def disturbance_map_registers(disturbance, skip_if_monitoring_not_available):
     disturbance.map_registers([{"axis": 1, "name": "CL_TOR_SET_POINT_VALUE"}])
 
 
 @pytest.fixture
-def disturbance(motion_controller):
+def disturbance(motion_controller, skip_if_monitoring_not_available):
     mc, alias = motion_controller
     return Disturbance(mc, alias)
 
@@ -141,8 +141,7 @@ def test_write_disturbance_data_not_configured(disturbance):
 
 @pytest.mark.soem
 @pytest.mark.eoe
-@pytest.mark.usefixtures("disable_monitoring_disturbance")
-def test_write_disturbance_data_enabled(motion_controller, disturbance):
+def test_write_disturbance_data_enabled(motion_controller, disturbance, disable_monitoring_disturbance):
     mc, alias = motion_controller
     mc.capture.enable_monitoring_disturbance(alias)
     with pytest.raises(IMDisturbanceError):

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -27,7 +27,7 @@ class ThreadWithReturnValue(Thread):
 @pytest.mark.soem
 @pytest.mark.eoe
 @pytest.fixture
-def monitoring(motion_controller):
+def monitoring(skip_if_monitoring_not_available, motion_controller):
     mc, alias = motion_controller
     return mc.capture.create_empty_monitoring(alias)
 
@@ -35,14 +35,14 @@ def monitoring(motion_controller):
 @pytest.mark.soem
 @pytest.mark.eoe
 @pytest.fixture
-def mon_set_freq(monitoring):
+def mon_set_freq(skip_if_monitoring_not_available, monitoring):
     monitoring.set_frequency(10)
 
 
 @pytest.mark.soem
 @pytest.mark.eoe
 @pytest.fixture
-def mon_map_registers(monitoring):
+def mon_map_registers(skip_if_monitoring_not_available, monitoring):
     monitoring.map_registers([{"axis": 1, "name": "CL_POS_FBK_VALUE"}])
 
 
@@ -67,7 +67,6 @@ def test_get_trigger_type(motion_controller, monitoring, trigger_type):
 @pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
-@pytest.mark.usefixtures("disable_monitoring_disturbance")
 @pytest.mark.parametrize("block, timeout, sample_t, wait, result", [
     (False, 5, 0.8, 2, True),
     (True, 6, 0.8, 0, True),
@@ -75,7 +74,7 @@ def test_get_trigger_type(motion_controller, monitoring, trigger_type):
     (True, 0.3, 0.8, 0, False),
 ])
 def test_raise_forced_trigger(motion_controller, monitoring, block,
-                              timeout, sample_t, wait, result):
+                              timeout, sample_t, wait, result, disable_monitoring_disturbance):
     mc, alias = motion_controller
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_FORCED)
     monitoring.configure_sample_time(sample_t, 0)
@@ -90,8 +89,7 @@ def test_raise_forced_trigger(motion_controller, monitoring, block,
 @pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
-@pytest.mark.usefixtures("disable_monitoring_disturbance")
-def test_raise_forced_trigger_fail(motion_controller, monitoring):
+def test_raise_forced_trigger_fail(motion_controller, monitoring, disable_monitoring_disturbance):
     mc, alias = motion_controller
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_AUTO)
     monitoring.configure_sample_time(0.8, 0)
@@ -104,13 +102,12 @@ def test_raise_forced_trigger_fail(motion_controller, monitoring):
 @pytest.mark.eoe
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
-@pytest.mark.usefixtures("disable_monitoring_disturbance")
 @pytest.mark.parametrize("timeout, sample_t, result", [
     (5, 0.8, True),
     (0.3, 0.8, False),
 ])
 def test_read_monitoring_data_forced_trigger(motion_controller, monitoring,
-                                             timeout, sample_t, result):
+                                             timeout, sample_t, result, disable_monitoring_disturbance):
     mc, alias = motion_controller
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_FORCED)
     monitoring.configure_sample_time(sample_t, 0)
@@ -304,8 +301,7 @@ def test_read_monitoring_data_disabled(monitoring):
 @pytest.mark.eoe
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
-@pytest.mark.usefixtures("disable_monitoring_disturbance")
-def test_read_monitoring_data_timeout(motion_controller, monitoring):
+def test_read_monitoring_data_timeout(motion_controller, monitoring, disable_monitoring_disturbance):
     timeout = 2
     sample_t = 0.8
     mc, alias = motion_controller
@@ -321,8 +317,7 @@ def test_read_monitoring_data_timeout(motion_controller, monitoring):
 @pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
-@pytest.mark.usefixtures("disable_monitoring_disturbance")
-def test_read_monitoring_data_no_rearm(motion_controller, monitoring):
+def test_read_monitoring_data_no_rearm(motion_controller, monitoring, disable_monitoring_disturbance):
     sample_t = 0.8
     timeout = 2
     block = True
@@ -347,8 +342,7 @@ def test_read_monitoring_data_no_rearm(motion_controller, monitoring):
 @pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
-@pytest.mark.usefixtures("disable_monitoring_disturbance")
-def test_rearm_monitoring(motion_controller, monitoring):
+def test_rearm_monitoring(motion_controller, monitoring, disable_monitoring_disturbance):
     sample_t = 0.8
     timeout = 2
     block = True
@@ -380,8 +374,7 @@ def run_read_monitoring_data_and_stop(monitoring, timeout):
 @pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
-@pytest.mark.usefixtures("disable_monitoring_disturbance")
-def test_stop_reading_data(motion_controller, monitoring):
+def test_stop_reading_data(motion_controller, monitoring, disable_monitoring_disturbance):
     sample_t = 0.8
     timeout = 10
     mc, alias = motion_controller
@@ -395,7 +388,7 @@ def test_stop_reading_data(motion_controller, monitoring):
 
 
 @pytest.mark.smoke
-def test_monitoring_max_sample_size(motion_controller):
+def test_monitoring_max_sample_size(motion_controller, skip_if_monitoring_not_available):
     mc, alias = motion_controller
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0


### PR DESCRIPTION
##   Improve tests of the capture module

### Description

This PR improves the tests of the capture module. These changes improve the tests' robustness.  

Fixes # INGM-242

### Type of change

- [x] Compare signals using the FFT.
- [x] Add a fixture to skip if monitoring is not available.
- [x] Add `test_create_monitoring_trigger_delay` 

### Tests
- [x] Run tests and obtain similar coverage.

[INGM-242]: https://ingeniamc.atlassian.net/browse/INGM-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ