### PR TITLE
INGM-245 Improve tests of the disturbance module

### DIFF
--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -15,8 +15,6 @@ def disturbance(motion_controller, skip_if_monitoring_not_available):
     return Disturbance(mc, alias)
 
 
-@pytest.mark.soem
-@pytest.mark.eoe
 @pytest.mark.smoke
 def test_disturbance_max_sample_size(motion_controller, disturbance):
     mc, alias = motion_controller
@@ -27,8 +25,6 @@ def test_disturbance_max_sample_size(motion_controller, disturbance):
     assert max_sample_size == value
 
 
-@pytest.mark.soem
-@pytest.mark.eoe
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
 def test_set_frequency_divider(motion_controller, disturbance, prescaler):
     mc, alias = motion_controller
@@ -39,16 +35,12 @@ def test_set_frequency_divider(motion_controller, disturbance, prescaler):
     assert value == prescaler
 
 
-@pytest.mark.soem
-@pytest.mark.eoe
 def test_set_frequency_divider_exception(disturbance):
     prescaler = -1
     with pytest.raises(ValueError):
         disturbance.set_frequency_divider(prescaler)
 
 
-@pytest.mark.soem
-@pytest.mark.eoe
 @pytest.mark.parametrize(
     "axis, name, expected_value",
     [
@@ -67,8 +59,6 @@ def test_disturbance_map_registers(motion_controller, disturbance, axis, name, e
     assert value == 1
 
 
-@pytest.mark.soem
-@pytest.mark.eoe
 @pytest.mark.parametrize("number_registers", list(range(1, 17)))
 def test_disturbance_number_map_registers(motion_controller, disturbance, number_registers):
     mc, alias = motion_controller
@@ -79,16 +69,12 @@ def test_disturbance_number_map_registers(motion_controller, disturbance, number
     assert value == number_registers
 
 
-@pytest.mark.soem
-@pytest.mark.eoe
 def test_disturbance_map_registers_sample_number(disturbance):
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]
     value = disturbance.map_registers(registers)
     assert value == disturbance.max_sample_number / 4
 
 
-@pytest.mark.soem
-@pytest.mark.eoe
 def test_disturbance_map_registers_exception(disturbance):
     registers = [{"axis": 0, "name": "DRV_AXIS_NUMBER"}]
     with pytest.raises(IMDisturbanceError):
@@ -96,8 +82,6 @@ def test_disturbance_map_registers_exception(disturbance):
 
 
 @pytest.mark.skip("Exception is not implemented yet")
-@pytest.mark.soem
-@pytest.mark.eoe
 def test_disturbance_map_registers_empty(disturbance):
     # TODO Add exception in function for this test case
     registers = []
@@ -105,8 +89,6 @@ def test_disturbance_map_registers_empty(disturbance):
         disturbance.map_registers(registers)
 
 
-@pytest.mark.soem
-@pytest.mark.eoe
 @pytest.mark.usefixtures("disturbance_map_registers")
 def test_write_disturbance_data_buffer_exception(disturbance):
     with pytest.raises(IMDisturbanceError):
@@ -114,16 +96,12 @@ def test_write_disturbance_data_buffer_exception(disturbance):
 
 
 @pytest.mark.skip("Exception is not implemented yet")
-@pytest.mark.soem
-@pytest.mark.eoe
 def test_write_disturbance_data_not_configured(disturbance):
     # TODO Add exception in function for this test case
     with pytest.raises(IMDisturbanceError):
         disturbance.write_disturbance_data([0] * 100)
 
 
-@pytest.mark.soem
-@pytest.mark.eoe
 def test_write_disturbance_data_enabled(
     motion_controller, disturbance, disable_monitoring_disturbance
 ):


### PR DESCRIPTION
##  Improve tests of the disturbance module

### Description

This PR improves the tests of the disturbance module.

Fixes # INGM-245

### Type of change

- [x] Run the tests in canopen as well if disturbance is available.

### Tests
- [x] Run tests and obtain similar coverage.