### PR TITLE
INGM-273 Downgrade sphinx_autodoc_typehints lib

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -2,7 +2,7 @@
 sphinx==3.5.4
 sphinx-rtd-theme==1.0.0
 sphinxcontrib-bibtex==2.4.1
-sphinx_autodoc_typehints==1.19.5
+sphinx_autodoc_typehints==1.12.0
 matplotlib==3.3.4
 nbsphinx==0.8.7
 rst2pdf==0.98


### PR DESCRIPTION
### Description

Fix compatibility issues between libraries.

Fixes # INGM-273

### Type of change

- Downgrade sphinx_autodoc_typehints to version 1.12.0