### PR TITLE
INGM-286 Change timeout from 5s to 1s

### DIFF
--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -69,7 +69,7 @@ class Communication(metaclass=MCMetaClass):
         dict_path: str,
         alias: str = DEFAULT_SERVO,
         port: int = 1061,
-        connection_timeout: int = 5,
+        connection_timeout: int = 1,
         servo_status_listener: bool = False,
         net_status_listener: bool = False,
     ) -> None:
@@ -81,7 +81,7 @@ class Communication(metaclass=MCMetaClass):
             alias : servo alias to reference it. ``default`` by default.
             port : servo port. ``1061`` by default.
             connection_timeout: Timeout in seconds for connection.
-                ``5`` seconds by default.
+                ``1`` seconds by default.
             servo_status_listener : Toggle the listener of the servo for
                 its status, errors, faults, etc.
             net_status_listener : Toggle the listener of the network
@@ -109,7 +109,7 @@ class Communication(metaclass=MCMetaClass):
         dict_path: str,
         alias: str,
         port: int = 1061,
-        connection_timeout: int = 5,
+        connection_timeout: int = 1,
         servo_status_listener: bool = False,
         net_status_listener: bool = False,
     ) -> None:


### PR DESCRIPTION
### Description

Change ethernet connections timeout

Fixes # INGM-286

### Type of change

- [x] Decrease timeout from 5s to 1s in ethernet connections

### Documentation

- [x] Build documentation locally to verify changes.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.