### PR TITLE
INGM-292 Update FOE and eoe service functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 - connect_servo_eoe_service, connect_servo_eoe_service_interface_index and connect_servo_eoe_service_interface_ip functions.
 
+### Changed
+- Removed ``boot_in_app`` argument from load_firmware_ecat and load_firmware_ecat_interface_index functions. It is not necessary anymore.
+
 ### Removed
 - connect_servo_ecat, connect_servo_ecat_interface_index and connect_servo_ecat_interface_ip functions.
 - get_sdo_register, get_sdo_register_complete_access and set_sdo_register functions.

--- a/examples/load_fw_ecat.py
+++ b/examples/load_fw_ecat.py
@@ -10,5 +10,4 @@ print(mc.communication.get_interface_name_list())
 mc.communication.load_firmware_ecat_interface_index(
     2,  # ifname index
     "./cap-xcr-e_0.7.1.lfu",  # FW file
-    1,  # Slave index
-    boot_in_app=False)  # True if Everest, False if Capitan, else contact manufacturer
+    1)  # Slave index

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,11 +47,10 @@ def connect_eoe(mc, config, alias):
 
 
 def connect_soem(mc, config, alias):
-    mc.communication.connect_servo_ecat_interface_index(
+    mc.communication.connect_servo_eoe_service_interface_index(
         config["index"],
         config["dictionary"],
-        config["slave"],
-        eoe_comm=config["eoe_comm"],
+        slave=config["slave"],
         alias=alias,
     )
 

--- a/tests/load_FWs.py
+++ b/tests/load_FWs.py
@@ -110,9 +110,7 @@ def load_can(drive_conf, mc):
 
 def load_ecat(drive_conf, mc):
     if_name = mc.communication.get_ifname_from_interface_ip(drive_conf["ip"])
-    mc.communication.load_firmware_ecat(
-        if_name, drive_conf["fw_file"], drive_conf["slave"]
-    )
+    mc.communication.load_firmware_ecat(if_name, drive_conf["fw_file"], drive_conf["slave"])
     logger.info("FW updated. ifname: %s, slave: %d", if_name, drive_conf["slave"])
 
 

--- a/tests/load_FWs.py
+++ b/tests/load_FWs.py
@@ -111,7 +111,7 @@ def load_can(drive_conf, mc):
 def load_ecat(drive_conf, mc):
     if_name = mc.communication.get_ifname_from_interface_ip(drive_conf["ip"])
     mc.communication.load_firmware_ecat(
-        if_name, drive_conf["fw_file"], drive_conf["slave"], boot_in_app=drive_conf["boot_in_app"]
+        if_name, drive_conf["fw_file"], drive_conf["slave"]
     )
     logger.info("FW updated. ifname: %s, slave: %d", if_name, drive_conf["slave"])
 


### PR DESCRIPTION
### Description

Adapt to ingenialink 7.0.0

Fixes # INGM-292

### Type of change

- [x] Change ecat load fw arguments (remove boot_in_app, is not more necessary)
- [x] Adapt EoE service connect, now allows multidrive

### Tests
- [x] Modify test fixtures.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.