### PR TITLE
Bugfix/ingm 293 is_alive does not return a boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - connect_servo_ecat, connect_servo_ecat_interface_index and connect_servo_ecat_interface_ip functions.
 - get_sdo_register, get_sdo_register_complete_access and set_sdo_register functions.
 
+### Fixed
+- is_alive function in MotionController.
+
 ## [0.6.0] - 2023-01-23
 ### Added
 - Pull request template.

--- a/ingeniamotion/motion_controller.py
+++ b/ingeniamotion/motion_controller.py
@@ -49,7 +49,7 @@ class MotionController:
             ``True`` if the servo is alive, ``False`` otherwise.
 
         """
-        drive = self.mc._get_drive(servo)
+        drive = self._get_drive(servo)
         return drive.is_alive()
 
     def _get_network(self, servo: str) -> Network:

--- a/tests/test_motion_controller.py
+++ b/tests/test_motion_controller.py
@@ -47,3 +47,9 @@ def test_get_register_enum(motion_controller):
             checked_ops += 1
 
     assert checked_ops > 0
+
+
+@pytest.mark.smoke
+def test_is_alive(motion_controller):
+    mc, alias = motion_controller
+    assert mc.is_alive(alias)


### PR DESCRIPTION
Fixes # INGM-293

### Type of change

- [x] Fix is_alive function

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.