### PR TITLE
INGM-294 Fix subscribe_net_status and unsubscribe_net_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - connect_servo_ecat, connect_servo_ecat_interface_index and connect_servo_ecat_interface_ip functions.
 - get_sdo_register, get_sdo_register_complete_access and set_sdo_register functions.
 
+### Fixed
+- subscribe_net_status and unsubscribe_net_status works for Ethernet based communication.
+
 ## [0.6.0] - 2023-01-23
 ### Added
 - Pull request template.

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -526,7 +526,11 @@ class Communication(metaclass=MCMetaClass):
 
         """
         network = self.mc._get_network(servo)
-        network.subscribe_to_status(callback)
+        if isinstance(network, EthernetNetwork):
+            drive = self.mc._get_drive(servo)
+            network.subscribe_to_status(drive.target, callback)
+        else:
+            network.subscribe_to_status(callback)
 
     def unsubscribe_net_status(self, callback: Callable, servo: str = DEFAULT_SERVO) -> None:
         """Remove net status change event callback.
@@ -537,7 +541,11 @@ class Communication(metaclass=MCMetaClass):
 
         """
         network = self.mc._get_network(servo)
-        network.unsubscribe_from_status(callback)
+        if isinstance(network, EthernetNetwork):
+            drive = self.mc._get_drive(servo)
+            network.unsubscribe_from_status(drive.target, callback)
+        else:
+            network.unsubscribe_from_status(callback)
 
     def subscribe_servo_status(self, callback: Callable, servo: str = DEFAULT_SERVO) -> None:
         """Add a callback to servo status change event.


### PR DESCRIPTION
Fixes # INGM-294

### Type of change

- [x] Fix subscribe_net_status and unsubscribe_net_status

### Documentation

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.