### PR TITLE
INGM-322 Fix monitoring set_trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Changed
 - Remove EDS file path param from CANopen connection. It is no longer necessary.
 
+### Fixed
+- Fix monitoring V3. Remove rearm_monitoring from set_trigger function.
+
 ## [0.6.1] - 2023-04-03
 ### Added
 - connect_servo_eoe_service, connect_servo_eoe_service_interface_index and connect_servo_eoe_service_interface_ip functions.

--- a/ingeniamotion/monitoring/monitoring_v3.py
+++ b/ingeniamotion/monitoring/monitoring_v3.py
@@ -20,7 +20,6 @@ class MonitoringV3(Monitoring):
     def set_trigger(
         self, trigger_mode, edge_condition=None, trigger_signal=None, trigger_value=None
     ):
-        self.rearm_monitoring()
         self.mc.communication.set_register(
             self.MONITOR_START_CONDITION_TYPE_REGISTER, trigger_mode, servo=self.servo, axis=0
         )


### PR DESCRIPTION
### Description

Fix set_trigger in monitoring V3.

Fixes # INGM-322

### Type of change

- [x] Remove rearm_monitoring from set_trigger function

### Tests

- [x] Tested manually with ML3

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.