### PR TITLE
INGM-324 Create force boot and load firmware functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Functions needed to load firmware to a Motion Core (MoCo).
+
 ## [0.6.2] - 2023-09-06
 ### Changed
 - Remove EDS file path param from CANopen connection. It is no longer necessary.

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -20,7 +20,13 @@ from .metaclass import MCMetaClass, DEFAULT_AXIS, DEFAULT_SERVO
 class Communication(metaclass=MCMetaClass):
     """Communication."""
 
-    FORCE_SYSTEM_BOOT_CODE_REGISTER = "DRV_BOOT_COCO_FORCE"
+    FORCE_SYSTEM_BOOT_COCO_REGISTER = "DRV_BOOT_COCO_FORCE"
+    FORCE_SYSTEM_BOOT_MOCO_REGISTER = "DRV_BOOT_MOCO_MODE"
+    SYSTEM_RESET_MOCO_REGISTER = "DRV_BOOT_RESET"
+
+    PASSWORD_FORCE_BOOT_COCO = 0x424F4F54
+    PASSWORD_FORCE_BOOT_MOCO = 0x426F6F74
+    PASSWORD_SYSTEM_RESET = 0x72657365
 
     def __init__(self, motion_controller):
         self.mc = motion_controller
@@ -721,15 +727,74 @@ class Communication(metaclass=MCMetaClass):
             servo : servo alias to reference it. ``default`` by default.
 
         """
-        PASSWORD_FORCE_BOOT_COCO = 0x424F4F54
         net = self.mc._get_network(servo)
         drive = self.mc._get_drive(servo)
         net.stop_status_listener()
         drive.stop_status_listener()
         try:
             self.mc.communication.set_register(
-                self.FORCE_SYSTEM_BOOT_CODE_REGISTER, PASSWORD_FORCE_BOOT_COCO, servo=servo, axis=0
+                self.FORCE_SYSTEM_BOOT_COCO_REGISTER,
+                self.PASSWORD_FORCE_BOOT_COCO,
+                servo=servo,
+                axis=0,
             )
         except ILError:
             pass
         self.disconnect(servo)
+
+    def load_firmware_moco(
+        self,
+        fw_file: str,
+        servo: str = DEFAULT_SERVO,
+    ) -> None:
+        """Load firmware to the Motion Core.
+
+        .. warning::
+            After functions ends, the servo will take a moment to load firmware.
+            During the process, the servo will be not operative.
+
+        Args:
+            fw_file : Firmware file path.
+            servo : servo alias to reference it. ``default`` by default.
+
+        Raises:
+            ValueError: If servo is not connected via Ethernet.
+
+        """
+        default_node = 10
+        default_subnode = 1
+        default_port = 1061
+        net = self.mc._get_network(servo)
+        drive = self.mc._get_drive(servo)
+        ip = drive.target
+        if not isinstance(net, EthernetNetwork):
+            raise ValueError("Target servo is not connected via Ethernet")
+        net.load_firmware_moco(default_node, default_subnode, ip, default_port, fw_file)
+
+    def boot_mode_moco(self, servo: str = DEFAULT_SERVO) -> None:
+        """Set the Motion Core to boot mode.
+
+        Args:
+            servo : servo alias to reference it. ``default`` by default.
+
+        """
+        net = self.mc._get_network(servo)
+        drive = self.mc._get_drive(servo)
+        net.stop_status_listener()
+        drive.stop_status_listener()
+        try:
+            self.mc.communication.set_register(
+                self.FORCE_SYSTEM_BOOT_MOCO_REGISTER,
+                self.PASSWORD_FORCE_BOOT_MOCO,
+                servo=servo,
+            )
+        except ILError as e:
+            self.logger.debug(e)
+        try:
+            self.mc.communication.set_register(
+                self.SYSTEM_RESET_MOCO_REGISTER,
+                self.PASSWORD_FORCE_BOOT_MOCO,
+                servo=servo,
+            )
+        except ILError as e:
+            self.logger.debug(e)


### PR DESCRIPTION
### Description

Add the necessary functions to load firmware to a Motion Core (MoCo).

Fixes #INGM-324

### Type of change

- [x] Add function to force boot mode
- [x] Add function to load firmware


### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.