### PR TITLE
INGM-323 Set positioning mode to NO LIMITS

### DIFF
--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -46,6 +46,8 @@ class Feedbacks(BaseTest):
     RATED_CURRENT_REGISTER = "MOT_RATED_CURRENT"
     MAXIMUM_CONTINUOUS_CURRENT_DRIVE_PROTECTION = "DRV_PROT_MAN_MAX_CONT_CURRENT_VALUE"
     POSITIONING_OPTION_CODE_REGISTER = "PROF_POS_OPTION_CODE"
+    MAX_POSITION_RANGE_LIMIT_REGISTER = "CL_POS_REF_MAX_RANGE"
+    MIN_POSITION_RANGE_LIMIT_REGISTER = "CL_POS_REF_MIN_RANGE"
 
     BACKUP_REGISTERS = [
         "CL_POS_FBK_SENSOR",
@@ -75,6 +77,8 @@ class Feedbacks(BaseTest):
         "CL_VEL_FBK_FILTER1_TYPE",
         "CL_VEL_FBK_FILTER1_FREQ",
         POSITIONING_OPTION_CODE_REGISTER,
+        MAX_POSITION_RANGE_LIMIT_REGISTER,
+        MIN_POSITION_RANGE_LIMIT_REGISTER,
     ]
 
     FEEDBACK_POLARITY_REGISTER = None
@@ -202,6 +206,12 @@ class Feedbacks(BaseTest):
         # Set positioning mode to NO LIMITS
         self.mc.communication.set_register(
             self.POSITIONING_OPTION_CODE_REGISTER, 0, servo=self.servo, axis=self.axis
+        )
+        self.mc.communication.set_register(
+            self.MIN_POSITION_RANGE_LIMIT_REGISTER, 0, servo=self.servo, axis=self.axis
+        )
+        self.mc.communication.set_register(
+            self.MAX_POSITION_RANGE_LIMIT_REGISTER, 0, servo=self.servo, axis=self.axis
         )
         # Default resolution multiplier
         # Change multiplier using gear ratio if feedback to check is configured

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -45,6 +45,7 @@ class Feedbacks(BaseTest):
     VELOCITY_FEEDBACK_FILTER_1_FREQUENCY_REGISTER = "CL_VEL_FBK_FILTER1_FREQ"
     RATED_CURRENT_REGISTER = "MOT_RATED_CURRENT"
     MAXIMUM_CONTINUOUS_CURRENT_DRIVE_PROTECTION = "DRV_PROT_MAN_MAX_CONT_CURRENT_VALUE"
+    POSITIONING_OPTION_CODE_REGISTER = "PROF_POS_OPTION_CODE"
 
     BACKUP_REGISTERS = [
         "CL_POS_FBK_SENSOR",
@@ -73,6 +74,7 @@ class Feedbacks(BaseTest):
         "COMMU_ANGLE_REF_SENSOR",
         "CL_VEL_FBK_FILTER1_TYPE",
         "CL_VEL_FBK_FILTER1_FREQ",
+        POSITIONING_OPTION_CODE_REGISTER,
     ]
 
     FEEDBACK_POLARITY_REGISTER = None
@@ -196,6 +198,10 @@ class Feedbacks(BaseTest):
         # Set commutation modulation to sinusoidal
         self.mc.communication.set_register(
             self.COMMUTATION_MODULATION_REGISTER, 0, servo=self.servo, axis=self.axis
+        )
+        # Set positioning mode to NO LIMITS
+        self.mc.communication.set_register(
+            self.POSITIONING_OPTION_CODE_REGISTER, 0, servo=self.servo, axis=self.axis
         )
         # Default resolution multiplier
         # Change multiplier using gear ratio if feedback to check is configured


### PR DESCRIPTION
### Description

Set the positioning mode to NO LIMITS before starting the feedback tests, afterward restore it's initial value.

Fixes #INGM-323

### Type of change

- [x] Set the positioning mode to NO LIMITS
- [x] Restore initial value


### Tests
- Connect ML3 to a drive
- Go to the application/positioning mode wizard page
- Select a positioning mode different from No Limits
- Go to the feedback wizard page and launch the test
- Check that no error occurs



### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.