### PR TITLE
Bugfix/ingm 325 remove disturbance data before load the new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- Remove disturbance data before including new data.
+
 ## [0.6.2] - 2023-09-06
 ### Changed
 - Remove EDS file path param from CANopen connection. It is no longer necessary.

--- a/ingeniamotion/disturbance.py
+++ b/ingeniamotion/disturbance.py
@@ -188,6 +188,8 @@ class Disturbance:
         self.__check_buffer_size_is_enough(registers_data)
         idx_list = list(range(len(registers_data)))
         dtype_list = [REG_DTYPE(x["dtype"]) for x in self.mapped_registers]
+        if self._version >= MonitoringVersion.MONITORING_V3:
+            drive.disturbance_remove_data()
         drive.disturbance_write_data(idx_list, dtype_list, registers_data)
 
     def map_registers_and_write_data(self, registers: Union[dict, List[dict]]) -> None:


### PR DESCRIPTION
### Pull request name 

Try to have a descriptive title. Also, set the `draft tag` in case the PR is work in progress.

Fixes # INGM-325

### Type of change

- [x] Add disturbance remove data in disturbance write_disturbance_data

### Tests
- [ ] Add new unit tests if it applies.
- [ ] Run tests.

Manual test:

1. Connect drive
2. Create disturbance but not enable disturbance
3. Create another disturbance

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.