### PR TITLE
Adapt get_encoded_image_from_dictionary for COM-KIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Function to get the vendor ID
 - Function to change the node ID of a CANopen device
 
+### Fixed
+- Adapt get_encoded_image_from_dictionary for COM-KIT
+
 ## [0.6.2] - 2023-09-06
 ### Changed
 - Remove EDS file path param from CANopen connection. It is no longer necessary.

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -318,12 +318,13 @@ class Information(metaclass=MCMetaClass):
         return str(os.path.basename(drive.dictionary.path))
 
     # TODO: INGM-333 - Once ingenialink has the encoded image
-    def get_encoded_image_from_dictionary(self, alias: str) -> Optional[str]:
+    def get_encoded_image_from_dictionary(self, alias: str, axis: int = 0) -> Optional[str]:
         """Get the encoded product image from a drive dictionary.
         This function reads a dictionary of a drive, and it parses whether the dictionary file has a
         DriveImage tag and its content.
         Args:
             alias: Alias of the drive.
+            axis: Drive axis. Used when using  COM-KIT.
         Returns:
             The encoded image or NoneType object.
         """
@@ -337,9 +338,13 @@ class Information(metaclass=MCMetaClass):
             raise FileNotFoundError(f"There is not any xdf file in the path: {dictionary_path}")
         root = tree.getroot()
         try:
-            image_element = root.findall(f"./DriveImage")
-            if image_element[0].text is not None and image_element[0].text.strip():
-                return f"{image_element[0].text}"
+            images = root.findall("./DriveImage")
+            try:
+                image = images[axis]
+            except IndexError:
+                return None
+            if image.text is not None and image.text.strip():
+                return f"{image.text}"
             else:
                 # If the content in DriveImage tag is empty
                 return None


### PR DESCRIPTION
## Description

Fixes #INGM-334

### Type of change

- [x] Add axis parameter for when connecting to a COM-KIT

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.