### PR TITLE
INGM-338 Raise exception if disturbance data cannot be written

### DIFF
--- a/ingeniamotion/disturbance.py
+++ b/ingeniamotion/disturbance.py
@@ -3,6 +3,7 @@ from numpy import ndarray
 from functools import wraps
 from typing import Callable, Dict, List, Union, TYPE_CHECKING, Optional
 from ingenialink.enums.register import REG_DTYPE
+from ingenialink.exceptions import ILValueError
 
 from ingeniamotion.enums import MonitoringVersion
 from ingeniamotion.metaclass import DEFAULT_SERVO, DEFAULT_AXIS
@@ -229,7 +230,10 @@ class Disturbance:
         dtype_list = [REG_DTYPE(x["dtype"]) for x in self.mapped_registers]
         if self._version >= MonitoringVersion.MONITORING_V3:
             drive.disturbance_remove_data()
-        drive.disturbance_write_data(idx_list, dtype_list, registers_data)
+        try:
+            drive.disturbance_write_data(idx_list, dtype_list, registers_data)
+        except ILValueError as e:
+            raise IMDisturbanceError(e)
 
     def map_registers_and_write_data(
         self, registers: Union[TYPE_MAPPED_REGISTERS_ALL, List[TYPE_MAPPED_REGISTERS_ALL]]


### PR DESCRIPTION
### Description

Raise IMDisturbanceError when the disturbance data does not fit in a register.

Fixes #INGM-338

### Type of change

- Raise IMDisturbanceError when the disturbance data does not fit in a register.


### Tests
- Create a disturbance signal that cannot fit in the register dtype (for example the signal contains negative values and the register dtype is unsigned).
- Try to write the disturbance data.
- Check that the IMDisturbanceError exception is raised.