### PR TITLE
INGM-339 Use ingenialink dictionary attribute to get drive image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 - check_motor_disabled decorator does not work with positional arguments
 - Adapt get_encoded_image_from_dictionary for COM-KIT
 
+### Changed
+- Use ingenialink to get the drive's encoded image from the dictionary.
+
 ## [0.6.3] - 2023-10-11
 ### Fixed
 - Remove disturbance data before including new data.

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -317,7 +317,6 @@ class Information(metaclass=MCMetaClass):
         drive = self.mc.servos[alias]
         return str(os.path.basename(drive.dictionary.path))
 
-    # TODO: INGM-333 - Once ingenialink has the encoded image
     def get_encoded_image_from_dictionary(self, alias: str, axis: int = 0) -> Optional[str]:
         """Get the encoded product image from a drive dictionary.
         This function reads a dictionary of a drive, and it parses whether the dictionary file has a
@@ -329,25 +328,9 @@ class Information(metaclass=MCMetaClass):
             The encoded image or NoneType object.
         """
         drive = self.mc.servos[alias]
-        # Read encoded image in XDF dictionary file
-        dictionary_path = drive.dictionary.path
-        try:
-            with open(dictionary_path, "r", encoding="utf-8") as xdf_file:
-                tree = ET.parse(xdf_file)
-        except FileNotFoundError:
-            raise FileNotFoundError(f"There is not any xdf file in the path: {dictionary_path}")
-        root = tree.getroot()
-        try:
-            images = root.findall("./DriveImage")
-            try:
-                image = images[axis]
-            except IndexError:
-                return None
-            if image.text is not None and image.text.strip():
-                return f"{image.text}"
-            else:
-                # If the content in DriveImage tag is empty
-                return None
-        except IndexError:
-            # If there is no DriveImage tag in dictionary file
-            return None
+        encoded_image: Optional[str] = None
+        if axis == 1:
+            encoded_image = drive.dictionary.moco_image
+        else:
+            encoded_image = drive.dictionary.image
+        return encoded_image


### PR DESCRIPTION
### Description

Get the drive's encoded image from a dictionary attribute.

Fixes #INGM-339

### Type of change

- Remove XML logic from get_encoded_image_from_dictionary
- Use the dictionary attributes to get the drive's encoded image.


### Tests
- Connect to a drive using a dictionary
- Check that the function get_encoded_image_from_dictionary returns the encoded image.