### PR TITLE
INGM-335 Fix generate output function in feedbacks class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixed
 - check_motor_disabled decorator does not work with positional arguments
 - Adapt get_encoded_image_from_dictionary for COM-KIT
+- Feedback test output when symmetry and resolution errors occurred simultaneously.
 
 ## [0.6.3] - 2023-10-11
 ### Fixed

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -418,13 +418,7 @@ class Feedbacks(BaseTest):
         return self.ResultType.SUCCESS
 
     def get_result_msg(self, output: ResultType) -> str:
-        if output == self.ResultType.SUCCESS:
-            return self.result_description[output]
-        if output < 0:
-            text = [self.result_description[x] for x in self.result_description if -output & -x > 0]
-            return ".".join(text)
-        else:
-            raise NotImplementedError("This ResultType is not implemented")
+        return self.result_description[output]
 
     def get_result_severity(self, output: ResultType) -> SeverityLevel:
         if output < self.ResultType.SUCCESS:

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -407,14 +407,12 @@ class Feedbacks(BaseTest):
     def generate_output(
         self, position_displacement: float, negative_displacement: float
     ) -> ResultType:
-        if (
-            output := self.check_symmetry(position_displacement, negative_displacement)
-        ) != self.ResultType.SUCCESS.value:
-            return self.ResultType(output)
-        if (
-            output := self.check_resolution(position_displacement)
-        ) != self.ResultType.SUCCESS.value:
-            return self.ResultType(output)
+        symmetry_check_result = self.check_symmetry(position_displacement, negative_displacement)
+        if symmetry_check_result != self.ResultType.SUCCESS.value:
+            return self.ResultType.SYMMETRY_ERROR
+        resolution_check_result = self.check_resolution(position_displacement)
+        if resolution_check_result != self.ResultType.SUCCESS.value:
+            return self.ResultType.RESOLUTION_ERROR
         polarity = self.check_polarity(position_displacement)
         self.suggest_polarity(polarity)
         return self.ResultType.SUCCESS

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -407,14 +407,17 @@ class Feedbacks(BaseTest):
     def generate_output(
         self, position_displacement: float, negative_displacement: float
     ) -> ResultType:
-        test_output = 0
-
-        test_output += self.check_symmetry(position_displacement, negative_displacement)
-        test_output += self.check_resolution(position_displacement)
-        test_output = self.ResultType.SUCCESS if test_output == 0 else test_output
+        if (
+            output := self.check_symmetry(position_displacement, negative_displacement)
+        ) != self.ResultType.SUCCESS.value:
+            return self.ResultType(output)
+        if (
+            output := self.check_resolution(position_displacement)
+        ) != self.ResultType.SUCCESS.value:
+            return self.ResultType(output)
         polarity = self.check_polarity(position_displacement)
         self.suggest_polarity(polarity)
-        return self.ResultType(test_output)
+        return self.ResultType.SUCCESS
 
     def get_result_msg(self, output: ResultType) -> str:
         if output == self.ResultType.SUCCESS:


### PR DESCRIPTION
### Description

Fix feedback test output when symmetry and resolution errors occur simultaneously.

Fixes #INGM-335

### Type of change

- Return check result on the first failure.


### Tests
- Connect to a drive.
- Run a feedback test .
- Force a symmetry and resolution error.
- Check that the test output is a valid [ResultType](https://github.com/ingeniamc/ingeniamotion/blob/master/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py#L15).