### PR TITLE
INGM-337: run only smoke test in pr jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Feedbacks functions to set/get feedback polarity
 - Add in configuration set_velocity_pid, set_position_pid and get_rated_current
 - Add functions to connect to and scan EtherCAT devices using CoE (SDOs).
+- Running Smoke and All tests stages for the Jenkins pipeline.
+- Option to choose running only smoke and no connection tests, or all tests.
 
 ### Fixed
 - check_motor_disabled decorator does not work with positional arguments
@@ -26,6 +28,7 @@
 ### Changed
 - Use ingenialink to get the drive's encoded image from the dictionary.
 - Update subscribe and unsubscribe to network status functions.
+- Smoke tests are defined as tests that need a setup but takes 1 second (approx.) as maximum.
 
 ## [0.6.3] - 2023-10-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@
 ### Changed
 - Use ingenialink to get the drive's encoded image from the dictionary.
 - Update subscribe and unsubscribe to network status functions.
-- Smoke tests are defined as tests that need a setup but takes 1 second (approx.) as maximum.
 
 ## [0.6.3] - 2023-10-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@
 - Feedbacks functions to set/get feedback polarity
 - Add in configuration set_velocity_pid, set_position_pid and get_rated_current
 - Add functions to connect to and scan EtherCAT devices using CoE (SDOs).
-- Running Smoke and All tests stages for the Jenkins pipeline.
-- Option to choose running only smoke and no connection tests, or all tests.
 
 ### Fixed
 - check_motor_disabled decorator does not work with positional arguments

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,8 @@ def CAN_NODE_LOCK = "test_execution_lock_can"
 pipeline {
     agent none
     parameters {
-        booleanParam(name: 'Run all tests', defaultValue: false, description: 'Run all tests.')
         choice(
-            choices: ['All', 'Smoke'], 
+            choices: ['Smoke', 'All'], 
             name: 'TESTS'
         )
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,13 +184,17 @@ pipeline {
                 }*/
                 stage('Run CANopen smoke tests') {
                     when {
-                        expression { params.TESTS == 'Smoke' }
+                        allOf{
+                            not{ branch 'master' };
+                            not{ branch 'INGM-337-Run-only-smoke-test-in-PR-jobs' };
+                            expression { params.TESTS == 'Smoke' }
+                        }
                     }
                     steps {
                         //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
                             move .coverage .coverage_canopen
                             exit /b 0
                         '''
@@ -207,8 +211,8 @@ pipeline {
                     steps {
                         //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
                             move .coverage .coverage_canopen
                             exit /b 0
                         '''
@@ -216,12 +220,16 @@ pipeline {
                 }
                 stage('Run Ethernet smoke tests') {
                     when {
-                        expression { params.TESTS == 'Smoke' }
+                        allOf{
+                            not{ branch 'master' };
+                            not{ branch 'INGM-337-Run-only-smoke-test-in-PR-jobs' };
+                            expression { params.TESTS == 'Smoke' }
+                        }
                     }
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
                             move .coverage .coverage_ethernet
                             exit /b 0
                         '''
@@ -237,8 +245,8 @@ pipeline {
                     }
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
                             move .coverage .coverage_ethernet
                             exit /b 0
                         '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -217,8 +217,8 @@ pipeline {
                     steps {
                         //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durantions-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durantions-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
                             move .coverage .coverage_canopen
                             exit /b 0
                         '''
@@ -253,8 +253,8 @@ pipeline {
                     }
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durantions-min=1.0 --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durantions-min=1.0 --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
                             move .coverage .coverage_ethernet
                             exit /b 0
                         '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,13 +175,13 @@ pipeline {
                         '''
                     }
                 }
-                stage('Update drives FW') {
+                /*stage('Update drives FW') {
                     steps {
                         bat '''
                             venv\\Scripts\\python.exe tests\\load_FWs.py canopen
                         '''
                     }
-                }
+                }*/
                 stage('Run CANopen smoke tests') {
                     when {
                         allOf{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -217,8 +217,8 @@ pipeline {
                     steps {
                         //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
                             move .coverage .coverage_canopen
                             exit /b 0
                         '''
@@ -235,8 +235,8 @@ pipeline {
                     steps {
                         //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
                             move .coverage .coverage_canopen
                             exit /b 0
                         '''
@@ -253,8 +253,8 @@ pipeline {
                     }
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
                             move .coverage .coverage_ethernet
                             exit /b 0
                         '''
@@ -270,8 +270,8 @@ pipeline {
                     }
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
                             move .coverage .coverage_ethernet
                             exit /b 0
                         '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ def CAN_NODE_LOCK = "test_execution_lock_can"
 pipeline {
     agent none
     parameters {
-        booleanParam(name: 'Run all tests', defaultValue: false, description: 'Run all tests.'),
+        booleanParam(name: 'Run all tests', defaultValue: false, description: 'Run all tests.')
         choice(
             choices: ['All', 'Smoke'], 
             name: 'TESTS',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,8 +133,8 @@ pipeline {
                 stage('Run EtherCAT tests') {
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests --protocol soem --slave 0 --junitxml=pytest_reports/pytest_ethercat_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests --protocol soem --slave 1 --junitxml=pytest_reports/pytest_ethercat_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol soem --slave 0 --junitxml=pytest_reports/pytest_ethercat_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol soem --slave 1 --junitxml=pytest_reports/pytest_ethercat_1_report.xml
                             move .coverage .coverage_ethercat
                             exit /b 0
                         '''
@@ -180,8 +180,8 @@ pipeline {
                     steps {
                         //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
                             move .coverage .coverage_canopen
                             exit /b 0
                         '''
@@ -190,8 +190,8 @@ pipeline {
                 stage('Run Ethernet tests') {
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
                             move .coverage .coverage_ethernet
                             exit /b 0
                         '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,13 +175,13 @@ pipeline {
                         '''
                     }
                 }
-                /*stage('Update drives FW') {
+                stage('Update drives FW') {
                     steps {
                         bat '''
                             venv\\Scripts\\python.exe tests\\load_FWs.py canopen
                         '''
                     }
-                }*/
+                }
                 stage('Run CANopen smoke tests') {
                     when {
                         allOf{
@@ -222,7 +222,7 @@ pipeline {
                     when {
                         allOf{
                             not{ branch 'master' };
-                            not{ branch 'INGM-337-Run-only-smoke-test-in-PR-jobs' };
+                            not{ branch 'develop' };
                             expression { params.TESTS == 'Smoke' }
                         }
                     }
@@ -239,7 +239,7 @@ pipeline {
                     when {
                         anyOf{
                             branch 'master';
-                            branch 'INGM-337-Run-only-smoke-test-in-PR-jobs';
+                            branch 'develop';
                             expression { params.TESTS == 'All' }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,7 @@ pipeline {
         booleanParam(name: 'Run all tests', defaultValue: false, description: 'Run all tests.')
         choice(
             choices: ['All', 'Smoke'], 
-            name: 'TESTS',
-            defaultValue: 'Smoke'
+            name: 'TESTS'
         )
     }
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,9 @@ def CAN_NODE_LOCK = "test_execution_lock_can"
 
 pipeline {
     agent none
+    parameters {
+        booleanParam(name: 'Run all tests', defaultValue: false, description: 'Run all tests.')
+    }
     stages {
         stage('Build wheels and documentation') {
             agent {
@@ -124,6 +127,9 @@ pipeline {
                     }
                 }
                 stage('Update drives FW') {
+                    when {
+                        expression { false }
+                    }
                     steps {
                         bat '''
                             venv\\Scripts\\python.exe tests\\load_FWs.py soem
@@ -180,8 +186,8 @@ pipeline {
                     steps {
                         //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
                             move .coverage .coverage_canopen
                             exit /b 0
                         '''
@@ -190,8 +196,8 @@ pipeline {
                 stage('Run Ethernet tests') {
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
                             move .coverage .coverage_ethernet
                             exit /b 0
                         '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,29 +197,49 @@ pipeline {
                         '''
                     }
                 }
-                /*stage('Run CANopen all tests') {
+                stage('Run CANopen all tests') {
+                    when {
+                        anyOf{
+                            branch 'master';
+                            branch 'develop';
+                            expression { params.TESTS == 'All' }
+                        }
+                    }
                     steps {
                         //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
-                        when {
-                            anyOf{
-                                branch 'master';
-                                branch 'develop';
-                                expression {params.TESTS == 'All'}
-                            }
-                        }
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
                             move .coverage .coverage_canopen
                             exit /b 0
                         '''
                     }
-                }*/
-                stage('Run Ethernet tests') {
+                }
+                stage('Run Ethernet smoke tests') {
+                    when {
+                        expression { params.TESTS == 'Smoke' }
+                    }
                     steps {
                         bat '''
                             venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
                             venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
+                            move .coverage .coverage_ethernet
+                            exit /b 0
+                        '''
+                    }
+                }
+                stage('Run Ethernet all tests') {
+                    when {
+                        anyOf{
+                            branch 'master';
+                            branch 'develop';
+                            expression { params.TESTS == 'All' }
+                        }
+                    }
+                    steps {
+                        bat '''
+                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
                             move .coverage .coverage_ethernet
                             exit /b 0
                         '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,18 +175,18 @@ pipeline {
                         '''
                     }
                 }
-                /*stage('Update drives FW') {
+                stage('Update drives FW') {
                     steps {
                         bat '''
                             venv\\Scripts\\python.exe tests\\load_FWs.py canopen
                         '''
                     }
-                }*/
+                }
                 stage('Run CANopen smoke tests') {
                     when {
                         allOf{
                             not{ branch 'master' };
-                            not{ branch 'INGM-337-Run-only-smoke-test-in-PR-jobs' };
+                            not{ branch 'develop' };
                             expression { params.TESTS == 'Smoke' }
                         }
                     }
@@ -222,7 +222,7 @@ pipeline {
                     when {
                         allOf{
                             not{ branch 'master' };
-                            not{ branch 'INGM-337-Run-only-smoke-test-in-PR-jobs' };
+                            not{ branch 'develop' };
                             expression { params.TESTS == 'Smoke' }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,11 +184,11 @@ pipeline {
                     }
                 }*/
                 stage('Run CANopen smoke tests') {
+                    when {
+                        expression { params.TESTS == 'Smoke' }
+                    }
                     steps {
                         //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
-                        when {
-                            expression {params.TESTS == 'Smoke'}
-                        }
                         bat '''
                             venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
                             venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durations-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,7 +222,7 @@ pipeline {
                     when {
                         allOf{
                             not{ branch 'master' };
-                            not{ branch 'develop' };
+                            not{ branch 'INGM-337-Run-only-smoke-test-in-PR-jobs' };
                             expression { params.TESTS == 'Smoke' }
                         }
                     }
@@ -239,7 +239,7 @@ pipeline {
                     when {
                         anyOf{
                             branch 'master';
-                            branch 'develop';
+                            branch 'INGM-337-Run-only-smoke-test-in-PR-jobs';
                             expression { params.TESTS == 'All' }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -235,8 +235,8 @@ pipeline {
                     steps {
                         //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
                             move .coverage .coverage_canopen
                             exit /b 0
                         '''
@@ -270,7 +270,8 @@ pipeline {
                     }
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --durations=0 --durations-min=1.0 --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
                             move .coverage .coverage_ethernet
                             exit /b 0
                         '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,31 @@ pipeline {
                         '''
                     }
                 }
-                stage('Run EtherCAT tests') {
+                stage('Run EtherCAT all tests') {
+                    when {
+                        anyOf{
+                            branch 'master';
+                            branch 'develop';
+                            expression { params.TESTS == 'All' }
+                        }
+                    }
+                    steps {
+                        bat '''
+                            venv\\Scripts\\python.exe -m pytest tests --protocol soem --slave 0 --junitxml=pytest_reports/pytest_ethercat_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests --protocol soem --slave 1 --junitxml=pytest_reports/pytest_ethercat_1_report.xml
+                            move .coverage .coverage_ethercat
+                            exit /b 0
+                        '''
+                    }
+                }
+                stage('Run EtherCAT smoke tests') {
+                    when {
+                        allOf{
+                            not{ branch 'master' };
+                            not{ branch 'develop' };
+                            expression { params.TESTS == 'Smoke' }
+                        }
+                    }
                     steps {
                         bat '''
                             venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol soem --slave 0 --junitxml=pytest_reports/pytest_ethercat_0_report.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -217,8 +217,8 @@ pipeline {
                     steps {
                         //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durantions-min=1.0 --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durantions-min=1.0 --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
                             move .coverage .coverage_canopen
                             exit /b 0
                         '''
@@ -253,8 +253,8 @@ pipeline {
                     }
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durantions-min=1.0 --protocol eoe --slave 0 --junitxml=pytest_reports/pytest_ethernet_0_report.xml
+                            venv\\Scripts\\python.exe -m pytest tests -m smoke --durations=0 --durantions-min=1.0 --protocol eoe --slave 1 --junitxml=pytest_reports/pytest_ethernet_1_report.xml
                             move .coverage .coverage_ethernet
                             exit /b 0
                         '''

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -265,6 +265,7 @@ def test_monitoring_max_sample_size(skip_if_monitoring_not_available, motion_con
     assert max_sample_size == value
 
 
+@pytest.mark.smoke
 def test_get_frequency(
     skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
 ):

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -6,7 +6,7 @@ from ingenialink.exceptions import ILError
 
 from ingeniamotion import MotionController
 from ingeniamotion.exceptions import IMRegisterNotExist, IMRegisterWrongAccess
-from ingeniamotion.enums import CAN_BAUDRATE, CAN_DEVICE, REG_DTYPE
+from ingeniamotion.enums import CAN_BAUDRATE, CAN_DEVICE
 
 
 @pytest.mark.smoke

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -219,6 +219,7 @@ def dummy_callback(status, _, axis):
     pass
 
 
+@pytest.mark.smoke
 def test_subscribe_servo_status(mocker, motion_controller):
     mc, alias = motion_controller
     axis = 1

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from ingenialink.canopen.network import CAN_BAUDRATE
@@ -72,6 +73,7 @@ def remove_file_if_exist():
         os.remove(file_path)
 
 
+@pytest.mark.smoke
 @pytest.mark.usefixtures("remove_file_if_exist")
 def test_save_configuration_and_load_configuration(motion_controller):
     file_path = "test_file.xcf"
@@ -89,6 +91,7 @@ def test_save_configuration_and_load_configuration(motion_controller):
 @pytest.mark.usefixtures("remove_file_if_exist")
 @pytest.mark.canopen
 @pytest.mark.eoe
+@pytest.mark.smoke
 def test_save_configuration_and_load_configuration_nvm_none(motion_controller):
     file_path = "test_file.xcf"
     mc, alias = motion_controller
@@ -242,6 +245,7 @@ def test_get_status_word(motion_controller):
     assert test_value == reg_value
 
 
+@pytest.mark.smoke
 def test_is_motor_enabled_1(motion_controller):
     mc, alias = motion_controller
     mc.motion.motor_disable(alias)
@@ -296,6 +300,7 @@ def test_is_commutation_feedback_aligned(
     assert test_value == expected_result
 
 
+@pytest.mark.smoke
 def test_set_phasing_mode(motion_controller):
     input_value = 0
     mc, alias = motion_controller
@@ -449,6 +454,7 @@ def test_is_sto_abnormal_latched(mocker, motion_controller, sto_status_value, ex
     assert value == expected_result
 
 
+@pytest.mark.smoke
 def test_store_configuration(motion_controller):
     mc, alias = motion_controller
     mc.configuration.store_configuration(servo=alias)
@@ -551,7 +557,7 @@ def test_change_node_id_exception(motion_controller):
         mc.configuration.change_node_id(32, alias)
 
 
-@pytest.mark.develop
+@pytest.mark.smoke
 def test_set_velocity_pid(motion_controller_teardown):
     mc, alias = motion_controller_teardown
     kp_test = 1
@@ -566,7 +572,7 @@ def test_set_velocity_pid(motion_controller_teardown):
     assert kd_test == kd_reg
 
 
-@pytest.mark.develop
+@pytest.mark.smoke
 def test_set_position_pid(motion_controller_teardown):
     mc, alias = motion_controller_teardown
     kp_test = 1
@@ -581,7 +587,7 @@ def test_set_position_pid(motion_controller_teardown):
     assert kd_test == kd_reg
 
 
-@pytest.mark.develop
+@pytest.mark.smoke
 def test_get_set_rated_current(motion_controller):
     mc, alias = motion_controller
     initial_rated_current = mc.communication.get_register(RATED_CURRENT_REGISTER, servo=alias)
@@ -595,7 +601,7 @@ def test_get_set_rated_current(motion_controller):
     mc.communication.set_register(RATED_CURRENT_REGISTER, initial_rated_current, servo=alias)
 
 
-@pytest.mark.develop
+@pytest.mark.smoke
 def test_get_max_current(motion_controller):
     mc, alias = motion_controller
     real_max_current = mc.communication.get_register(MAX_CURRENT_REGISTER, servo=alias)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -582,7 +582,6 @@ def test_set_position_pid(motion_controller_teardown):
 
 
 @pytest.mark.develop
-@pytest.mark.smoke
 def test_get_set_rated_current(motion_controller):
     mc, alias = motion_controller
     initial_rated_current = mc.communication.get_register(RATED_CURRENT_REGISTER, servo=alias)
@@ -597,7 +596,6 @@ def test_get_set_rated_current(motion_controller):
 
 
 @pytest.mark.develop
-@pytest.mark.smoke
 def test_get_max_current(motion_controller):
     mc, alias = motion_controller
     real_max_current = mc.communication.get_register(MAX_CURRENT_REGISTER, servo=alias)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -105,6 +105,7 @@ def test_save_configuration_and_load_configuration_nvm_none(motion_controller):
     mc.communication.set_register(POSITION_SET_POINT_REGISTER, old_value, servo=alias)
 
 
+@pytest.mark.smoke
 def test_set_profiler_exception(motion_controller):
     mc, alias = motion_controller
 
@@ -326,6 +327,7 @@ def test_set_generator_mode(motion_controller):
     assert pytest.approx(input_value) == output_value
 
 
+@pytest.mark.smoke
 def test_set_motor_pair_poles(motion_controller_teardown):
     input_value = 0
     mc, alias = motion_controller_teardown
@@ -460,6 +462,7 @@ def test_store_configuration(motion_controller):
     mc.configuration.store_configuration(servo=alias)
 
 
+@pytest.mark.smoke
 def test_restore_configuration(motion_controller):
     mc, alias = motion_controller
     mc.configuration.restore_configuration(servo=alias)

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -25,6 +25,7 @@ def test_disturbance_max_sample_size(motion_controller, disturbance):
     assert max_sample_size == value
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
 def test_set_frequency_divider(motion_controller, disturbance, prescaler):
     mc, alias = motion_controller
@@ -35,12 +36,14 @@ def test_set_frequency_divider(motion_controller, disturbance, prescaler):
     assert value == prescaler
 
 
+@pytest.mark.smoke
 def test_set_frequency_divider_exception(disturbance):
     prescaler = -1
     with pytest.raises(ValueError):
         disturbance.set_frequency_divider(prescaler)
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize(
     "axis, name, expected_value",
     [
@@ -59,6 +62,7 @@ def test_disturbance_map_registers(motion_controller, disturbance, axis, name, e
     assert value == 1
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize("number_registers", list(range(1, 17)))
 def test_disturbance_number_map_registers(motion_controller, disturbance, number_registers):
     mc, alias = motion_controller
@@ -69,35 +73,41 @@ def test_disturbance_number_map_registers(motion_controller, disturbance, number
     assert value == number_registers
 
 
+@pytest.mark.smoke
 def test_disturbance_map_registers_sample_number(disturbance):
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]
     value = disturbance.map_registers(registers)
     assert value == disturbance.max_sample_number / 4
 
 
+@pytest.mark.smoke
 def test_disturbance_map_registers_exception(disturbance):
     registers = [{"axis": 0, "name": "DRV_AXIS_NUMBER"}]
     with pytest.raises(IMDisturbanceError):
         disturbance.map_registers(registers)
 
 
+@pytest.mark.smoke
 def test_disturbance_map_registers_empty(disturbance):
     registers = []
     with pytest.raises(IMDisturbanceError):
         disturbance.map_registers(registers)
 
 
+@pytest.mark.smoke
 @pytest.mark.usefixtures("disturbance_map_registers")
 def test_write_disturbance_data_buffer_exception(disturbance):
     with pytest.raises(IMDisturbanceError):
         disturbance.write_disturbance_data([0] * disturbance.max_sample_number)
 
 
+@pytest.mark.smoke
 def test_write_disturbance_data_not_configured(disturbance):
     with pytest.raises(IMDisturbanceError):
         disturbance.write_disturbance_data([0] * 100)
 
 
+@pytest.mark.smoke
 def test_write_disturbance_data_enabled(
     motion_controller, disturbance, disable_monitoring_disturbance
 ):

--- a/tests/test_drive_tests.py
+++ b/tests/test_drive_tests.py
@@ -18,7 +18,7 @@ from ingeniamotion.wizard_tests.feedbacks_tests.digital_incremental2_test import
 from ingeniamotion.wizard_tests.feedbacks_tests.secondary_ssi_test import SecondarySSITest
 from ingeniamotion.wizard_tests.phase_calibration import Phasing
 from ingeniamotion.wizard_tests.phasing_check import PhasingCheck
-from ingeniamotion.wizard_tests.base_test import BaseTest, TestError
+from ingeniamotion.wizard_tests.base_test import TestError
 
 CURRENT_QUADRATURE_SET_POINT_REGISTER = "CL_CUR_Q_SET_POINT"
 RATED_CURRENT_REGISTER = "MOT_RATED_CURRENT"
@@ -124,6 +124,7 @@ def test_commutation(motion_controller):
     assert results["result_severity"] == SeverityLevel.SUCCESS
 
 
+pytest.mark.smoke
 def test_commutation_error(motion_controller, force_fault):
     mc, alias = motion_controller
     with pytest.raises(force_fault):
@@ -136,6 +137,7 @@ def test_phasing_check(motion_controller):
     assert results["result_severity"] == SeverityLevel.SUCCESS
 
 
+pytest.mark.smoke
 def test_phasing_check_error(motion_controller, force_fault):
     mc, alias = motion_controller
     with pytest.raises(force_fault):

--- a/tests/test_drive_tests.py
+++ b/tests/test_drive_tests.py
@@ -124,7 +124,7 @@ def test_commutation(motion_controller):
     assert results["result_severity"] == SeverityLevel.SUCCESS
 
 
-pytest.mark.smoke
+@pytest.mark.smoke
 def test_commutation_error(motion_controller, force_fault):
     mc, alias = motion_controller
     with pytest.raises(force_fault):
@@ -137,7 +137,7 @@ def test_phasing_check(motion_controller):
     assert results["result_severity"] == SeverityLevel.SUCCESS
 
 
-pytest.mark.smoke
+@pytest.mark.smoke
 def test_phasing_check_error(motion_controller, force_fault):
     mc, alias = motion_controller
     with pytest.raises(force_fault):

--- a/tests/test_feedbacks.py
+++ b/tests/test_feedbacks.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ingeniamotion.enums import SensorType, SensorCategory
+from ingeniamotion.enums import SensorCategory, SensorType
 
 COMMUTATION_FEEDBACK_REGISTER = "COMMU_ANGLE_SENSOR"
 REFERENCE_FEEDBACK_REGISTER = "COMMU_ANGLE_REF_SENSOR"
@@ -398,9 +398,7 @@ def test_instance_sensor_type(motion_controller):
     assert isinstance(test_feedback, SensorType)
 
 
-@pytest.mark.develop
 @pytest.mark.smoke
-@pytest.mark.no_connection
 @pytest.mark.parametrize(
     "sensor, register",
     [

--- a/tests/test_homing.py
+++ b/tests/test_homing.py
@@ -61,7 +61,6 @@ def test_set_homing_timeout(motion_controller, homing_timeout):
     assert test_homing_timeout == homing_timeout
 
 
-@pytest.mark.smoke
 @pytest.mark.parametrize("homing_offset", [0, 1000])
 @pytest.mark.usefixtures("initial_position")
 def test_homing_on_current_position(motion_controller, homing_offset):
@@ -74,7 +73,6 @@ def test_homing_on_current_position(motion_controller, homing_offset):
     ) == mc.motion.get_actual_position(servo=alias)
 
 
-@pytest.mark.smoke
 @pytest.mark.usefixtures("initial_position")
 @pytest.mark.parametrize("direction", [1, 0])
 def test_homing_on_switch_limit(motion_controller, direction):
@@ -212,7 +210,6 @@ def test_homing_on_index_pulse(motion_controller, feedback_list, direction):
         )
 
 
-@pytest.mark.smoke
 @pytest.mark.usefixtures("initial_position")
 @pytest.mark.parametrize("direction", [1, 0])
 def test_homing_on_switch_limit_and_index_pulse(motion_controller, direction):

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -101,7 +101,6 @@ def test_raise_forced_trigger_fail(motion_controller, monitoring, disable_monito
         monitoring.raise_forced_trigger()
 
 
-@pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.parametrize(
@@ -353,6 +352,7 @@ def run_read_monitoring_data_and_stop(monitoring, timeout):
     return test_thread.join()
 
 
+@pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 def test_stop_reading_data(motion_controller, monitoring, disable_monitoring_disturbance):

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -58,7 +58,6 @@ def test_get_trigger_type(motion_controller, monitoring, trigger_type):
     assert test_trigger == trigger_type
 
 
-@pytest.mark.smoke
 @pytest.mark.parametrize(
     "block, timeout, sample_t, wait, result",
     [
@@ -102,6 +101,7 @@ def test_raise_forced_trigger_fail(motion_controller, monitoring, disable_monito
         monitoring.raise_forced_trigger()
 
 
+@pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.parametrize(
@@ -125,6 +125,7 @@ def test_read_monitoring_data_forced_trigger(
         assert len(test_output[0]) == 0
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
 def test_set_monitoring_frequency(motion_controller, monitoring, prescaler):
     mc, alias = motion_controller
@@ -135,12 +136,14 @@ def test_set_monitoring_frequency(motion_controller, monitoring, prescaler):
     assert value == prescaler
 
 
+@pytest.mark.smoke
 def test_set_monitoring_frequency_exception(monitoring):
     prescaler = 0.5
     with pytest.raises(ValueError):
         monitoring.set_frequency(prescaler)
 
 
+@pytest.mark.smoke
 def test_monitoring_map_registers_size_exception(monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     monitoring.samples_number = monitoring.max_sample_number
@@ -148,12 +151,14 @@ def test_monitoring_map_registers_size_exception(monitoring):
         monitoring.map_registers(registers)
 
 
+@pytest.mark.smoke
 def test_monitoring_map_registers_fail(monitoring):
     registers = []
     with pytest.raises(IMMonitoringError):
         monitoring.map_registers(registers)
 
 
+@pytest.mark.smoke
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.parametrize(
     "trigger_type, edge_condition, trigger_signal, trigger_value",
@@ -179,6 +184,7 @@ def test_monitoring_set_trigger(
     assert value == trigger_type
 
 
+@pytest.mark.smoke
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.parametrize(
     "trigger_type, edge_condition, trigger_signal, trigger_value",
@@ -205,6 +211,7 @@ def test_monitoring_set_trigger_exceptions(
         monitoring.set_trigger(trigger_type, edge_condition, trigger_signal, trigger_value)
 
 
+@pytest.mark.smoke
 def test_configure_number_samples(motion_controller, monitoring):
     mc, alias = motion_controller
     total_num_samples = 500
@@ -220,12 +227,14 @@ def test_configure_number_samples(motion_controller, monitoring):
     assert value == trigger_delay_samples
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize("total_num_samples, trigger_delay_samples", [(500, 510), (510, -500)])
 def test_configure_number_samples_exceptions(monitoring, total_num_samples, trigger_delay_samples):
     with pytest.raises(ValueError):
         monitoring.configure_number_samples(total_num_samples, trigger_delay_samples)
 
 
+@pytest.mark.smoke
 def test_configure_sample_time(motion_controller, monitoring):
     mc, alias = motion_controller
     total_time = 5
@@ -245,6 +254,7 @@ def test_configure_sample_time(motion_controller, monitoring):
     assert value == trigger_delay_samples
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize("total_time, sign", [(5, 1), (5, -1)])
 def test_configure_sample_time_exception(monitoring, total_time, sign):
     trigger_delay = sign * ((total_time // 2) + 1)
@@ -265,6 +275,7 @@ def test_read_monitoring_data_not_configured(motion_controller, monitoring):
     assert len(test_output[0]) == 0
 
 
+@pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 def test_read_monitoring_data_disabled(monitoring):
@@ -289,7 +300,6 @@ def test_read_monitoring_data_timeout(
     assert len(test_output[0]) == 0
 
 
-@pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 def test_read_monitoring_data_no_rearm(
@@ -314,7 +324,6 @@ def test_read_monitoring_data_no_rearm(
     assert len(test_output[0]) == 0
 
 
-@pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 def test_rearm_monitoring(motion_controller, monitoring, disable_monitoring_disturbance):
@@ -344,7 +353,6 @@ def run_read_monitoring_data_and_stop(monitoring, timeout):
     return test_thread.join()
 
 
-@pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 def test_stop_reading_data(motion_controller, monitoring, disable_monitoring_disturbance):

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -1,13 +1,13 @@
 import time
-import pytest
-import numpy as np
-from ingenialink import exceptions
-import logging
 
-from .conftest import mean_actual_velocity_position
+import numpy as np
+import pytest
+from ingenialink import exceptions
+
 from ingeniamotion.enums import OperationMode
-from ingeniamotion.motion import Motion
 from ingeniamotion.exceptions import IMTimeoutError
+from ingeniamotion.motion import Motion
+from tests.conftest import mean_actual_velocity_position
 
 POS_PID_KP_VALUE = 0.1
 POSITION_PERCENTAGE_ERROR_ALLOWED = 5
@@ -68,6 +68,7 @@ def test_motor_enable(motion_controller):
     assert mc.configuration.is_motor_enabled(servo=alias)
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize(
     "uid, value, exception_type, message",
     [
@@ -89,6 +90,7 @@ def test_motor_enable_error(motion_controller_teardown, uid, value, exception_ty
     assert str(excinfo.value) == "An error occurred enabling motor. Reason: {}".format(message)
 
 
+@pytest.mark.smoke
 def test_motor_enable_with_fault(motion_controller_teardown):
     uid = "DRV_PROT_USER_UNDER_VOLT"
     value = 100
@@ -114,6 +116,7 @@ def test_motor_disable(motion_controller, enable_motor):
     assert not mc.configuration.is_motor_enabled(servo=alias)
 
 
+@pytest.mark.smoke
 def test_motor_disable_with_fault(motion_controller_teardown):
     uid = "DRV_PROT_USER_UNDER_VOLT"
     value = 100
@@ -126,6 +129,7 @@ def test_motor_disable_with_fault(motion_controller_teardown):
     assert not mc.configuration.is_motor_enabled(servo=alias)
 
 
+@pytest.mark.smoke
 def test_fault_reset(motion_controller_teardown):
     mc, alias = motion_controller_teardown
     uid = "DRV_PROT_USER_UNDER_VOLT"
@@ -160,7 +164,6 @@ def test_move_position(motion_controller, position_value):
     assert pytest.approx(position_value, abs=pos_tolerance) == test_position
 
 
-@pytest.mark.smoke
 @pytest.mark.parametrize("velocity_value", [0.5, 1, 0, -0.5])
 def test_set_velocity(motion_controller, velocity_value):
     mc, alias = motion_controller
@@ -292,7 +295,6 @@ def test_get_actual_current_quadrature(mocker, motion_controller):
     )
 
 
-@pytest.mark.smoke
 def test_wait_for_position_timeout(motion_controller):
     timeout_value = 2
     mc, alias = motion_controller
@@ -303,7 +305,6 @@ def test_wait_for_position_timeout(motion_controller):
     assert pytest.approx(timeout_value, abs=0.1) == final_time - init_time
 
 
-@pytest.mark.smoke
 def test_wait_for_velocity_timeout(motion_controller):
     timeout_value = 2
     mc, alias = motion_controller
@@ -314,6 +315,7 @@ def test_wait_for_velocity_timeout(motion_controller):
     assert pytest.approx(timeout_value, abs=0.1) == final_time - init_time
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize("op_mode", [OperationMode.VOLTAGE, OperationMode.CURRENT])
 def test_set_internal_generator_configuration(motion_controller_teardown, op_mode):
     mc, alias = motion_controller_teardown

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -26,13 +26,6 @@ VOLTAGE_QUADRATURE_SET_POINT_REGISTER = "CL_VOL_Q_SET_POINT"
 VOLTAGE_DIRECT_SET_POINT_REGISTER = "CL_VOL_D_SET_POINT"
 
 
-@pytest.mark.smoke
-def test_aaaa(motion_controller):
-    mc, alias = motion_controller
-    assert True
-
-
-@pytest.mark.smoke
 def test_target_latch(motion_controller):
     mc, alias = motion_controller
     mc.communication.set_register(PROFILER_LATCHING_MODE_REGISTER, 0x40, servo=alias)
@@ -269,7 +262,6 @@ def test_get_actual_position(motion_controller, position_value):
     assert np.abs(np.mean(test_position) - np.mean(reg_value)) < 0.5
 
 
-@pytest.mark.smoke
 @pytest.mark.parametrize("velocity_value", [1, 0, -1])
 def test_get_actual_velocity(motion_controller, velocity_value):
     mc, alias = motion_controller
@@ -306,7 +298,6 @@ def test_get_actual_current_quadrature(mocker, motion_controller):
     )
 
 
-@pytest.mark.smoke
 def test_wait_for_position_timeout(motion_controller):
     timeout_value = 2
     mc, alias = motion_controller
@@ -317,7 +308,6 @@ def test_wait_for_position_timeout(motion_controller):
     assert pytest.approx(timeout_value, abs=0.1) == final_time - init_time
 
 
-@pytest.mark.smoke
 def test_wait_for_velocity_timeout(motion_controller):
     timeout_value = 2
     mc, alias = motion_controller

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -26,6 +26,13 @@ VOLTAGE_QUADRATURE_SET_POINT_REGISTER = "CL_VOL_Q_SET_POINT"
 VOLTAGE_DIRECT_SET_POINT_REGISTER = "CL_VOL_D_SET_POINT"
 
 
+@pytest.mark.smoke
+def test_aaaa(motion_controller):
+    mc, alias = motion_controller
+    assert True
+
+
+@pytest.mark.smoke
 def test_target_latch(motion_controller):
     mc, alias = motion_controller
     mc.communication.set_register(PROFILER_LATCHING_MODE_REGISTER, 0x40, servo=alias)
@@ -152,6 +159,7 @@ def test_set_position(motion_controller, position_value):
     assert test_position == position_value
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize("position_value", [1000, 0, -1000, 4000])
 def test_move_position(motion_controller, position_value):
     mc, alias = motion_controller
@@ -164,6 +172,7 @@ def test_move_position(motion_controller, position_value):
     assert pytest.approx(position_value, abs=pos_tolerance) == test_position
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize("velocity_value", [0.5, 1, 0, -0.5])
 def test_set_velocity(motion_controller, velocity_value):
     mc, alias = motion_controller
@@ -172,6 +181,7 @@ def test_set_velocity(motion_controller, velocity_value):
     assert test_vel == velocity_value
 
 
+@pytest.mark.smoke
 # TODO Update approx error. Well tuned motor is needed.
 @pytest.mark.parametrize("velocity_value", [0.5, 1, 0, -0.5])
 def test_set_velocity_blocking(motion_controller, velocity_value):
@@ -243,6 +253,7 @@ def test_ramp_generator(mocker, init_v, final_v, total_t, t, result):
         assert pytest.approx(result_v) == test_result
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize("position_value", [-4000, -1000, 1000, 4000])
 def test_get_actual_position(motion_controller, position_value):
     mc, alias = motion_controller
@@ -258,6 +269,7 @@ def test_get_actual_position(motion_controller, position_value):
     assert np.abs(np.mean(test_position) - np.mean(reg_value)) < 0.5
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize("velocity_value", [1, 0, -1])
 def test_get_actual_velocity(motion_controller, velocity_value):
     mc, alias = motion_controller
@@ -294,6 +306,7 @@ def test_get_actual_current_quadrature(mocker, motion_controller):
     )
 
 
+@pytest.mark.smoke
 def test_wait_for_position_timeout(motion_controller):
     timeout_value = 2
     mc, alias = motion_controller
@@ -304,6 +317,7 @@ def test_wait_for_position_timeout(motion_controller):
     assert pytest.approx(timeout_value, abs=0.1) == final_time - init_time
 
 
+@pytest.mark.smoke
 def test_wait_for_velocity_timeout(motion_controller):
     timeout_value = 2
     mc, alias = motion_controller


### PR DESCRIPTION
### Smoke tests

### Description

Issues documentation.

Fixes # (issue)

### Type of change

- [x] Tests that need a setup and takes 1 second (approx.) as maximum are selected as smoke tests.
- [x] Having the option to run only smoke or all tests.
- [x] Running only smoke tests for develop or master branches is not allowed.
- [x] Running all implemented tests for develop or master branches is mandatory.

### Documentation

Please update the documentation.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.