### PR TITLE
INGM-356 Raise exception if monitoring/disturbance are not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - check_motor_disabled decorator does not work with positional arguments
 - Adapt get_encoded_image_from_dictionary for COM-KIT
 - Feedback test output when symmetry and resolution errors occurred simultaneously.
+- Raise exception if monitoring and disturbance features are not available.
 
 ### Changed
 - Use ingenialink to get the drive's encoded image from the dictionary.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,7 +170,9 @@ def clean_and_restore_feedbacks(motion_controller):
 @pytest.fixture()
 def skip_if_monitoring_not_available(motion_controller):
     mc, alias = motion_controller
-    if "MON_DIST_STATUS" not in mc.servos[alias].dictionary.registers(0):
+    try:
+        mc.capture._check_version(alias)
+    except NotImplementedError:
         pytest.skip("Monitoring is not available")
 
 


### PR DESCRIPTION
### Description

Raise an exception if monitoring and disturbance features are not available.

Fixes #INGM-356

### Type of change

- To determine if the monitoring version is V1, check if the monitoring status register exists.
- If the monitoring and disturbance features are not available raise an exception.


### Test 1
- Connect to an EVE-NET-C with CANopen communication
- Check that an exception is raised when [creating an empty monitoring](https://github.com/ingeniamc/ingeniamotion/blob/master/ingeniamotion/capture.py#L122).

### Test 2
- Connect to an EVE-NET-C with Ethernet communication
- Check that no exception is raised when [creating an empty monitoring](https://github.com/ingeniamc/ingeniamotion/blob/master/ingeniamotion/capture.py#L122).

### Test 3
- Connect to an EVE-NET-E with EtherCAT CoE communication
- Check that an exception is raised when [creating an empty monitoring](https://github.com/ingeniamc/ingeniamotion/blob/master/ingeniamotion/capture.py#L122).