### PR TITLE
INGM-355 Deprecate Python 3.6 and 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 - Use ingenialink to get the drive's encoded image from the dictionary.
 - Update subscribe and unsubscribe to network status functions.
 
+### Deprecated 
+- Support to Python 3.6 and 3.7.
+
 ## [0.6.3] - 2023-10-11
 ### Fixed
 - Remove disturbance data before including new data.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Ingeniamotion is a library that works over ingenialink and aims to simplify the 
 Requirements
 ------------
 
-* Python 3.6, 3.7, 3.8 or 3.9
+* Python 3.8 or 3.9
 * [WinPcap](https://www.winpcap.org/install/) 4.1.3
 
 Installation


### PR DESCRIPTION
## Deprecate Python 3.6 and 3.7

### Description

This PR deprecates Python 3.6 and 3.7.

Fixes #INGM-335

### Type of change

- [x] Update README
- [x] Update CHANGELOG

### Documentation

Please update the documentation.

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).