### PR TITLE
INGM-370 Fix ethercat connection for multiple slaves

### DIFF
--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -504,8 +504,9 @@ class Communication(metaclass=MCMetaClass):
         if not path.isfile(dict_path):
             raise FileNotFoundError(f"Dict file {dict_path} does not exist!")
 
-        self.mc.net[alias] = EthercatNetwork(interface_name)
-        net = self.mc.net[alias]
+        if interface_name not in self.mc.net:
+            self.mc.net[interface_name] = EthercatNetwork(interface_name)
+        net = self.mc.net[interface_name]
         servo = net.connect_to_slave(
             slave_id,
             dict_path,
@@ -514,7 +515,7 @@ class Communication(metaclass=MCMetaClass):
         )
 
         self.mc.servos[alias] = servo
-        self.mc.servo_net[alias] = alias
+        self.mc.servo_net[alias] = interface_name
 
     def connect_servo_ethercat_interface_index(
         self,

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -503,7 +503,6 @@ class Communication(metaclass=MCMetaClass):
 
         if not path.isfile(dict_path):
             raise FileNotFoundError(f"Dict file {dict_path} does not exist!")
-
         if interface_name not in self.mc.net:
             self.mc.net[interface_name] = EthercatNetwork(interface_name)
         net = self.mc.net[interface_name]
@@ -513,7 +512,6 @@ class Communication(metaclass=MCMetaClass):
             servo_status_listener=servo_status_listener,
             net_status_listener=net_status_listener,
         )
-
         self.mc.servos[alias] = servo
         self.mc.servo_net[alias] = interface_name
 


### PR DESCRIPTION
### Description

Use one network per interface name.

Fixes #INGM-370

### Tests
- Connect to two EtherCAT drives.
- Enable the motor on both drives without any error.
