### PR TITLE
INGM-350 Run tests of ethercat in jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,10 +105,6 @@ pipeline {
             }
         }
         stage('EtherCAT tests') {
-            // Remove once EtherCAT tests are operational.
-            when {
-                expression { false }
-            }
             options {
                 lock(ECAT_NODE_LOCK)
             }
@@ -146,7 +142,6 @@ pipeline {
                     }
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests --protocol soem --slave 0 --junitxml=pytest_reports/pytest_ethercat_0_report.xml
                             venv\\Scripts\\python.exe -m pytest tests --protocol soem --slave 1 --junitxml=pytest_reports/pytest_ethercat_1_report.xml
                             move .coverage .coverage_ethercat
                             exit /b 0
@@ -163,7 +158,6 @@ pipeline {
                     }
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol soem --slave 0 --junitxml=pytest_reports/pytest_ethercat_0_report.xml
                             venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol soem --slave 1 --junitxml=pytest_reports/pytest_ethercat_1_report.xml
                             move .coverage .coverage_ethercat
                             exit /b 0
@@ -215,7 +209,7 @@ pipeline {
                         }
                     }
                     steps {
-                        //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
+                        unstash 'test_reports'
                         bat '''
                             venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
                             venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
@@ -233,7 +227,7 @@ pipeline {
                         }
                     }
                     steps {
-                        //unstash 'test_reports' Uncomment once EtherCAT tests are operational.
+                        unstash 'test_reports'
                         bat '''
                             venv\\Scripts\\python.exe -m pytest tests --protocol canopen --slave 0 --junitxml=pytest_reports/pytest_canopen_0_report.xml
                             venv\\Scripts\\python.exe -m pytest tests --protocol canopen --slave 1 --junitxml=pytest_reports/pytest_canopen_1_report.xml
@@ -279,12 +273,10 @@ pipeline {
                 }
                 stage('Save test results') {
                     steps {
-                        //unstash 'coverage_reports' Uncomment once EtherCAT tests are operational.
-                        // Add .coverage_ethercat to the combine command once EtherCAT tests are operational.
                         unstash 'coverage_reports'
                         unstash 'test_reports'
                         bat '''
-                            venv\\Scripts\\python.exe -m coverage combine .coverage_ethernet .coverage_canopen .coverage_virtual
+                            venv\\Scripts\\python.exe -m coverage combine .coverage_ethernet .coverage_canopen .coverage_virtual .coverage_ethercat
                             venv\\Scripts\\python.exe -m coverage xml --include=ingeniamotion/*
                         '''
                         publishCoverage adapters: [coberturaReportAdapter('coverage.xml')]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ingenialink==7.1.0
+ingenialink @ git+https://github.com/ingeniamc/ingenialink-python@INGK-729-handle-emcy-messages
 ingenialogger>=0.2.1
 ifaddr==0.1.7
 numpy==1.19.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,11 +54,11 @@ def connect_eoe(mc, config, alias):
 
 
 def connect_soem(mc, config, alias):
-    mc.communication.connect_servo_eoe_service_interface_index(
+    mc.communication.connect_servo_ethercat_interface_index(
         config["index"],
+        config["slave"],
         config["dictionary"],
-        slave=config["slave"],
-        alias=alias,
+        alias,
     )
 
 


### PR DESCRIPTION
### Description

Run the EtherCAT tests using the CoE protocol.

Fixes #INGM-350

### Type of change

- Enable the EtherCAT stage on the Jenkins pipeline
- Disable the slave 0 tests (It will be included once INGM-351 is fixed)
- Use the EtherCAT CoE protocol.