### PR TITLE
INGM-352 Fix the phasing check test

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ingenialink @ git+https://github.com/ingeniamc/ingenialink-python@INGK-729-handle-emcy-messages
+ingenialink==7.1.0
 ingenialogger>=0.2.1
 ifaddr==0.1.7
 numpy==1.19.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ingenialink==7.1.0
+ingenialink @ git+https://github.com/ingeniamc/ingenialink-python@develop
 ingenialogger>=0.2.1
 ifaddr==0.1.7
 numpy==1.19.5

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -135,8 +135,6 @@ def test_commutation_error(motion_controller, force_fault):
         mc.tests.commutation(servo=alias)
 
 
-# TODO: Remove skip mark after fixing INGM-352
-@pytest.mark.skip
 def test_phasing_check(motion_controller):
     mc, alias = motion_controller
     results = mc.tests.phasing_check(servo=alias)

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -137,6 +137,7 @@ def test_commutation_error(motion_controller, force_fault):
 
 def test_phasing_check(motion_controller):
     mc, alias = motion_controller
+    mc.tests.commutation(servo=alias)
     results = mc.tests.phasing_check(servo=alias)
     assert results["result_severity"] == SeverityLevel.SUCCESS
 


### PR DESCRIPTION
### Description

Fix the test_phasing_check tests.

Fixes #INGM-352 

### Type of change

- Perform a commutation test before the phasing check test.
- Re-include the phasing check test into the test suite.

### Test
- Run all the tests using the EVE-XCR-C ten times in a row without failure. (check out the Jenkins job for the test-INGM-352 branch). To achieve this, I  used [pytest-repeat](https://pypi.org/project/pytest-repeat/) with the flags --count 10 --repeat-scope session -x .