### PR TITLE
INGM-358 Study which test could have their no connection version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,6 +105,7 @@ pipeline {
             }
         }
         stage('EtherCAT tests') {
+            // Add tests of slave 0 after fixing INGM-376
             options {
                 lock(ECAT_NODE_LOCK)
             }
@@ -142,7 +143,6 @@ pipeline {
                     }
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests --protocol soem --slave 0 --junitxml=pytest_reports/pytest_ethercat_0_report.xml
                             venv\\Scripts\\python.exe -m pytest tests --protocol soem --slave 1 --junitxml=pytest_reports/pytest_ethercat_1_report.xml
                             move .coverage .coverage_ethercat
                             exit /b 0
@@ -159,7 +159,6 @@ pipeline {
                     }
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol soem --slave 0 --junitxml=pytest_reports/pytest_ethercat_0_report.xml
                             venv\\Scripts\\python.exe -m pytest tests -m smoke --protocol soem --slave 1 --junitxml=pytest_reports/pytest_ethercat_1_report.xml
                             move .coverage .coverage_ethercat
                             exit /b 0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ingenialink @ git+https://github.com/ingeniamc/ingenialink-python@develop
+ingenialink @ git+https://github.com/ingeniamc/ingenialink-python@INGK-740-add-default-values-to-virtual-drive
 ingenialogger>=0.2.1
 ifaddr==0.1.7
 numpy==1.19.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ingenialink @ git+https://github.com/ingeniamc/ingenialink-python@INGK-740-add-default-values-to-virtual-drive
+ingenialink @ git+https://github.com/ingeniamc/ingenialink-python@develop
 ingenialogger>=0.2.1
 ifaddr==0.1.7
 numpy==1.19.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,13 +142,6 @@ def feedback_list(motion_controller):
 
 
 @pytest.fixture
-def commutation_teardown(motion_controller):
-    yield
-    mc, alias = motion_controller
-    mc.tests.commutation(servo=alias)
-
-
-@pytest.fixture
 def clean_and_restore_feedbacks(motion_controller):
     mc, alias = motion_controller
     comm = mc.configuration.get_commutation_feedback(servo=alias)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,12 +197,15 @@ def pytest_runtest_makereport(item, call):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def load_configuration_if_test_fails(request, motion_controller, read_config):
+def load_configuration_if_test_fails(pytestconfig, request, motion_controller, read_config):
     mc, alias = motion_controller
     yield
 
     report = request.node.stash[test_report_key]
-    if report["setup"].failed or ("call" not in report) or report["call"].failed:
+    protocol = pytestconfig.getoption("--protocol")
+    if protocol != "virtual" and (
+        report["setup"].failed or ("call" not in report) or report["call"].failed
+    ):
         mc.configuration.load_configuration(read_config["config_file"], servo=alias)
         mc.motion.fault_reset(servo=alias)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,9 @@ def disable_motor_fixture(pytestconfig, motion_controller):
 @pytest.fixture
 def motion_controller_teardown(motion_controller, pytestconfig, read_config):
     yield motion_controller
+    protocol = pytestconfig.getoption("--protocol")
+    if protocol == "virtual":
+        return
     mc, alias = motion_controller
     mc.motion.motor_disable(servo=alias)
     mc.configuration.load_configuration(read_config["config_file"], servo=alias)

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -156,6 +156,7 @@ def test_sto_test(motion_controller):
     assert results["result_severity"] == SeverityLevel.SUCCESS
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_value, message",
@@ -224,7 +225,7 @@ def test_feedback_stop(motion_controller, feedback_class):
         assert reg_values[reg] == mc.communication.get_register(reg, servo=alias)
 
 
-@pytest.mark.usefixtures("commutation_teardown")
+@pytest.mark.virtual
 def test_commutation_stop(motion_controller):
     mc, alias = motion_controller
     test = Phasing(mc, alias, 1)
@@ -234,7 +235,7 @@ def test_commutation_stop(motion_controller):
         assert reg_values[reg] == mc.communication.get_register(reg, servo=alias)
 
 
-@pytest.mark.usefixtures("commutation_teardown")
+@pytest.mark.virtual
 def test_phasing_check_stop(motion_controller):
     mc, alias = motion_controller
     test = PhasingCheck(mc, alias, 1)
@@ -244,6 +245,7 @@ def test_phasing_check_stop(motion_controller):
         assert reg_values[reg] == mc.communication.get_register(reg, servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.parametrize("test_currents", ["Rated current", "Drive current", "Same value"])
 @pytest.mark.parametrize(
     "test_sensor",

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -18,6 +18,7 @@ def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
     return np.allclose(fft_received, fft_expected, rtol=0, atol=fft_tol)
 
 
+@pytest.mark.virtual
 def test_create_poller(motion_controller):
     registers = [{"name": "CL_CUR_Q_SET_POINT", "axis": 1}]
     sampling_time = 0.0625
@@ -225,6 +226,7 @@ def test_create_disturbance(
     assert __compare_signals(data, read_data)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_mcb_synchronization(mocker, motion_controller):
     mc, alias = motion_controller
@@ -243,6 +245,7 @@ def test_mcb_synchronization_fail(motion_controller):
         mc.capture.mcb_synchronization(servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_disturbance_max_sample_size(skip_if_monitoring_not_available, motion_controller):
     mc, alias = motion_controller
@@ -254,6 +257,7 @@ def test_disturbance_max_sample_size(skip_if_monitoring_not_available, motion_co
     assert max_sample_size == value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_monitoring_max_sample_size(skip_if_monitoring_not_available, motion_controller):
     mc, alias = motion_controller

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -18,28 +18,26 @@ def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
     return np.allclose(fft_received, fft_expected, rtol=0, atol=fft_tol)
 
 
-@pytest.mark.virtual
 def test_create_poller(motion_controller):
     registers = [{"name": "CL_CUR_Q_SET_POINT", "axis": 1}]
-    sampling_time = 0.2
+    sampling_time = 0.0625
     mc, alias = motion_controller
-    poller = mc.capture.create_poller(registers, alias, sampling_time, start=False)
+    mc.motion.set_current_quadrature(-0.2, servo=alias)
+    poller = mc.capture.create_poller(registers, alias, sampling_time, buffer_size=128)
+    mc.motion.set_current_quadrature(0, servo=alias)
     period = 1
-    total_time = 5
-    expected_signal = np.concatenate(
-        [([i] * int(period / sampling_time)) for i in [0.2 * (i + 1) for i in range(total_time)]],
-        axis=0,
-    )
-    poller.start()
-    for i in range(total_time):
+    expected_signal = [0] * int(period / sampling_time)
+    for i in range(7):
+        time.sleep(1)
         mc.motion.set_current_quadrature(0.2 * (i + 1), servo=alias)
-        time.sleep(period)
-    poller.stop()
+        expected_signal.extend([0.2 * (i + 1)] * int(period / sampling_time))
+    time.sleep(3 * period)
     timestamp, test_data, _ = poller.data
+    poller.stop()
     assert np.allclose(np.diff(timestamp), sampling_time, rtol=0.5, atol=0)
+
     received_signal = test_data[0]
-    # The poller doesn't return the expected number of samples
-    expected_signal = expected_signal[: len(received_signal)]
+    assert len(received_signal) == len(expected_signal)
     assert __compare_signals(expected_signal, received_signal)
 
 

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -18,7 +18,6 @@ def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
     return np.allclose(fft_received, fft_expected, rtol=0, atol=fft_tol)
 
 
-@pytest.mark.virtual
 def test_create_poller(motion_controller):
     registers = [{"name": "CL_CUR_Q_SET_POINT", "axis": 1}]
     sampling_time = 0.0625

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -18,9 +18,10 @@ def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
     return np.allclose(fft_received, fft_expected, rtol=0, atol=fft_tol)
 
 
+@pytest.mark.virtual
 def test_create_poller(motion_controller):
     registers = [{"name": "CL_CUR_Q_SET_POINT", "axis": 1}]
-    sampling_time = 0.0625
+    sampling_time = 0.1
     mc, alias = motion_controller
     mc.motion.set_current_quadrature(-0.2, servo=alias)
     poller = mc.capture.create_poller(registers, alias, sampling_time, buffer_size=128)

--- a/tests/test_comkit.py
+++ b/tests/test_comkit.py
@@ -1,13 +1,12 @@
-from os import path
 import xml.etree.ElementTree as ET
 from xml.dom import minidom
 
 import pytest
 
-from ingeniamotion import MotionController
 from ingeniamotion.comkit import create_comkit_dictionary, get_tree_root
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_create_comkit_dictionary():
     coco_path = "./tests/resources/com-kit.xdf"
@@ -25,6 +24,7 @@ def test_create_comkit_dictionary():
     assert comkit_xml_str == reference_xml_str
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_create_comkit_dictionary_wrong_file_extension():
     coco_path = "./tests/resources/com-kit.xdf"

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -10,7 +10,7 @@ from ingeniamotion.enums import CAN_BAUDRATE, CAN_DEVICE
 
 
 @pytest.mark.smoke
-@pytest.mark.eoe
+@pytest.mark.virtual
 def test_connect_servo_eoe(read_config):
     mc = MotionController()
     assert "eoe_test" not in mc.servos
@@ -23,7 +23,7 @@ def test_connect_servo_eoe(read_config):
 
 
 @pytest.mark.smoke
-@pytest.mark.eoe
+@pytest.mark.virtual
 def test_connect_servo_eoe_no_dictionary_error(read_config):
     mc = MotionController()
     with pytest.raises(FileNotFoundError):
@@ -31,7 +31,7 @@ def test_connect_servo_eoe_no_dictionary_error(read_config):
 
 
 @pytest.mark.smoke
-@pytest.mark.eoe
+@pytest.mark.virtual
 def test_connect_servo_ethernet(read_config):
     mc = MotionController()
     assert "eoe_test" not in mc.servos
@@ -44,7 +44,7 @@ def test_connect_servo_ethernet(read_config):
 
 
 @pytest.mark.smoke
-@pytest.mark.eoe
+@pytest.mark.virtual
 def test_connect_servo_ethernet_no_dictionary_error(read_config):
     mc = MotionController()
     with pytest.raises(FileNotFoundError):
@@ -134,6 +134,7 @@ def test_connect_servo_canopen_busy_drive_error(motion_controller, read_config):
         )
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "uid, value",
@@ -151,6 +152,7 @@ def test_get_register(motion_controller, uid, value):
     assert pytest.approx(test_value) == value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_register_wrong_uid(motion_controller):
     mc, alias = motion_controller
@@ -158,6 +160,7 @@ def test_get_register_wrong_uid(motion_controller):
         mc.communication.get_register("WRONG_UID", servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "uid, value",
@@ -175,6 +178,7 @@ def test_set_register(motion_controller, uid, value):
     assert pytest.approx(test_value) == value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_set_register_wrong_uid(motion_controller):
     mc, alias = motion_controller
@@ -182,6 +186,7 @@ def test_set_register_wrong_uid(motion_controller):
         mc.communication.set_register("WRONG_UID", 2, servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "uid, value, fail",
@@ -206,6 +211,7 @@ def test_set_register_wrong_value_type(motion_controller, uid, value, fail):
         mc.communication.set_register(uid, value, servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_set_register_wrong_access(motion_controller):
     mc, alias = motion_controller

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -216,6 +216,7 @@ def test_get_current_loop_rate(motion_controller):
     assert test_value == reg_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_power_stage_frequency(motion_controller):
     mc, alias = motion_controller

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -43,6 +43,7 @@ def teardown_brake_override(motion_controller):
     mc.configuration.default_brake(servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_release_brake(motion_controller, teardown_brake_override):
     mc, alias = motion_controller
@@ -53,6 +54,7 @@ def test_release_brake(motion_controller, teardown_brake_override):
     )
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_enable_brake(motion_controller, teardown_brake_override):
     mc, alias = motion_controller
@@ -63,6 +65,7 @@ def test_enable_brake(motion_controller, teardown_brake_override):
     )
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_disable_brake_override(motion_controller, teardown_brake_override):
     mc, alias = motion_controller
@@ -113,6 +116,7 @@ def test_save_configuration_and_load_configuration_nvm_none(motion_controller):
     mc.communication.set_register(POSITION_SET_POINT_REGISTER, old_value, servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_set_profiler_exception(motion_controller):
     mc, alias = motion_controller
@@ -121,6 +125,7 @@ def test_set_profiler_exception(motion_controller):
         mc.configuration.set_profiler(None, None, None, servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "acceleration, deceleration, velocity",
@@ -143,6 +148,7 @@ def test_set_profiler(motion_controller, acceleration, deceleration, velocity):
         assert pytest.approx(expected_values[key]) == actual_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("acceleration", [0, 10, 25])
 def test_set_max_acceleration(motion_controller, acceleration):
@@ -152,6 +158,7 @@ def test_set_max_acceleration(motion_controller, acceleration):
     assert pytest.approx(acceleration) == output_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("acceleration", [0, 10, 25])
 def test_set_max_profile_acceleration(motion_controller, acceleration):
@@ -161,6 +168,7 @@ def test_set_max_profile_acceleration(motion_controller, acceleration):
     assert pytest.approx(acceleration) == output_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("deceleration", [0, 10, 25])
 def test_set_max_deceleration(motion_controller, deceleration):
@@ -170,6 +178,7 @@ def test_set_max_deceleration(motion_controller, deceleration):
     assert pytest.approx(output_value) == deceleration
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("velocity", [0, 10, 25])
 def test_set_max_velocity(motion_controller, velocity):
@@ -179,6 +188,7 @@ def test_set_max_velocity(motion_controller, velocity):
     assert pytest.approx(velocity) == output_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("velocity", [0, 10, 25])
 def test_set_max_profile_velocity(motion_controller, velocity):
@@ -188,6 +198,7 @@ def test_set_max_profile_velocity(motion_controller, velocity):
     assert pytest.approx(velocity) == output_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_position_and_velocity_loop_rate(motion_controller):
     mc, alias = motion_controller
@@ -196,6 +207,7 @@ def test_get_position_and_velocity_loop_rate(motion_controller):
     assert test_value == reg_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_current_loop_rate(motion_controller):
     mc, alias = motion_controller
@@ -210,6 +222,7 @@ def test_get_power_stage_frequency(motion_controller):
     mc.configuration.get_power_stage_frequency(servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_power_stage_frequency_raw(motion_controller):
     mc, alias = motion_controller
@@ -220,12 +233,14 @@ def test_get_power_stage_frequency_raw(motion_controller):
     assert test_value == pow_stg_freq
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_power_stage_frequency_enum(motion_controller):
     mc, alias = motion_controller
     mc.configuration.get_power_stage_frequency_enum(servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("input_value", [0, 1, 2, 3])
 def test_set_power_stage_frequency(motion_controller_teardown, input_value):
@@ -238,6 +253,7 @@ def test_set_power_stage_frequency(motion_controller_teardown, input_value):
     assert pytest.approx(input_value) == output_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_power_stage_frequency_exception(mocker, motion_controller):
     mc, alias = motion_controller
@@ -246,6 +262,7 @@ def test_get_power_stage_frequency_exception(mocker, motion_controller):
         mc.configuration.get_power_stage_frequency(servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_status_word(motion_controller):
     mc, alias = motion_controller
@@ -265,6 +282,7 @@ def test_is_motor_enabled_1(motion_controller):
     assert not mc.configuration.is_motor_enabled(servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "status_word_value, expected_result",
@@ -286,6 +304,7 @@ def test_is_motor_enabled_2(mocker, motion_controller, status_word_value, expect
     assert test_value == expected_result
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "status_word_value, expected_result",
@@ -309,6 +328,7 @@ def test_is_commutation_feedback_aligned(
     assert test_value == expected_result
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_set_phasing_mode(motion_controller):
     input_value = 0
@@ -318,6 +338,7 @@ def test_set_phasing_mode(motion_controller):
     assert pytest.approx(input_value) == output_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_phasing_mode(motion_controller):
     mc, alias = motion_controller
@@ -326,6 +347,7 @@ def test_get_phasing_mode(motion_controller):
     assert test_value == reg_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_set_generator_mode(motion_controller):
     input_value = 0
@@ -335,6 +357,7 @@ def test_set_generator_mode(motion_controller):
     assert pytest.approx(input_value) == output_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_set_motor_pair_poles(motion_controller_teardown):
     input_value = 0
@@ -344,6 +367,7 @@ def test_set_motor_pair_poles(motion_controller_teardown):
     assert pytest.approx(input_value) == output_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_motor_pair_poles(motion_controller):
     mc, alias = motion_controller
@@ -352,6 +376,7 @@ def test_get_motor_pair_poles(motion_controller):
     assert test_value == reg_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_sto_status(motion_controller):
     mc, alias = motion_controller
@@ -364,6 +389,7 @@ def patch_get_sto_status(mocker, value):
     mocker.patch("ingeniamotion.configuration.Configuration.get_sto_status", return_value=value)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value, expected_result",
@@ -383,6 +409,7 @@ def test_is_sto1_active(mocker, motion_controller, sto_status_value, expected_re
     assert value == expected_result
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value, expected_result",
@@ -395,6 +422,7 @@ def test_is_sto2_active(mocker, motion_controller, sto_status_value, expected_re
     assert value == expected_result
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value, expected_result",
@@ -419,6 +447,7 @@ def test_check_sto_abnormal_fault(mocker, motion_controller, sto_status_value, e
     assert value == expected_result
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value, expected_result",
@@ -431,6 +460,7 @@ def test_get_sto_report_bit(mocker, motion_controller, sto_status_value, expecte
     assert value == expected_result
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value, expected_result", [(0x13A0, False), (0x7648, False), (0x4, True)]
@@ -442,6 +472,7 @@ def test_is_sto_active(mocker, motion_controller, sto_status_value, expected_res
     assert value == expected_result
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value, expected_result", [(0xC18A, False), (0x742C, False), (0x17, True)]
@@ -453,6 +484,7 @@ def test_is_sto_inactive(mocker, motion_controller, sto_status_value, expected_r
     assert value == expected_result
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value, expected_result", [(0x1BF3, False), (0x6B7, False), (0x1F, True)]
@@ -571,6 +603,7 @@ def test_change_node_id_exception(motion_controller):
         mc.configuration.change_node_id(32, alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_set_velocity_pid(motion_controller_teardown):
     mc, alias = motion_controller_teardown
@@ -586,6 +619,7 @@ def test_set_velocity_pid(motion_controller_teardown):
     assert kd_test == kd_reg
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_set_position_pid(motion_controller_teardown):
     mc, alias = motion_controller_teardown
@@ -601,6 +635,7 @@ def test_set_position_pid(motion_controller_teardown):
     assert kd_test == kd_reg
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_set_rated_current(motion_controller):
     mc, alias = motion_controller
@@ -615,6 +650,7 @@ def test_get_set_rated_current(motion_controller):
     mc.communication.set_register(RATED_CURRENT_REGISTER, initial_rated_current, servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_max_current(motion_controller):
     mc, alias = motion_controller

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -15,6 +15,7 @@ def disturbance(motion_controller, skip_if_monitoring_not_available):
     return Disturbance(mc, alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_disturbance_max_sample_size(motion_controller, disturbance):
     mc, alias = motion_controller
@@ -80,6 +81,7 @@ def test_disturbance_map_registers_sample_number(disturbance):
     assert value == disturbance.max_sample_number / 4
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_disturbance_map_registers_exception(disturbance):
     registers = [{"axis": 0, "name": "DRV_AXIS_NUMBER"}]
@@ -87,6 +89,7 @@ def test_disturbance_map_registers_exception(disturbance):
         disturbance.map_registers(registers)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_disturbance_map_registers_empty(disturbance):
     registers = []
@@ -101,6 +104,7 @@ def test_write_disturbance_data_buffer_exception(disturbance):
         disturbance.write_disturbance_data([0] * disturbance.max_sample_number)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_write_disturbance_data_not_configured(disturbance):
     with pytest.raises(IMDisturbanceError):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -111,6 +111,7 @@ class TestErrors:
         mc.communication.set_register(USER_UNDER_VOLTAGE_LEVEL_REGISTER, 10, servo=alias)
         assert not mc.errors.is_warning_active(servo=alias)
 
+    @pytest.mark.virtual
     @pytest.mark.smoke
     @pytest.mark.parametrize(
         "error_code, affected_module, error_type, error_msg",

--- a/tests/test_feedbacks.py
+++ b/tests/test_feedbacks.py
@@ -60,6 +60,7 @@ def skip_if_qei2_is_not_available(mc, alias, sensor=SensorType.QEI2):
         pytest.skip("Incremental encoder 2 is not available")
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -70,6 +71,7 @@ def test_get_commutation_feedback(motion_controller, sensor):
     assert sensor == test_feedback
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -80,6 +82,7 @@ def test_set_commutation_feedback(motion_controller, sensor):
     assert sensor == register_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor, category", SENSOR_TYPE_AND_CATEGORY)
@@ -90,6 +93,7 @@ def test_get_commutation_feedback_category(motion_controller, sensor, category):
     assert test_category == category
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -106,6 +110,7 @@ def test_get_commutation_feedback_resolution(motion_controller, sensor):
         assert test_res_1 == test_res_2
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -116,6 +121,7 @@ def test_get_reference_feedback(motion_controller, sensor):
     assert sensor == test_feedback
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -126,6 +132,7 @@ def test_set_reference_feedback(motion_controller, sensor):
     assert sensor == register_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor, category", SENSOR_TYPE_AND_CATEGORY)
@@ -136,6 +143,7 @@ def test_get_reference_feedback_category(motion_controller, sensor, category):
     assert test_category == category
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -152,6 +160,7 @@ def test_get_reference_feedback_resolution(motion_controller, sensor):
         assert test_res_1 == test_res_2
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -162,6 +171,7 @@ def test_get_velocity_feedback(motion_controller, sensor):
     assert sensor == test_feedback
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -172,6 +182,7 @@ def test_set_velocity_feedback(motion_controller, sensor):
     assert sensor == register_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor, category", SENSOR_TYPE_AND_CATEGORY)
@@ -182,6 +193,7 @@ def test_get_velocity_feedback_category(motion_controller, sensor, category):
     assert test_category == category
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -198,6 +210,7 @@ def test_get_velocity_feedback_resolution(motion_controller, sensor):
         assert test_res_1 == test_res_2
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -208,6 +221,7 @@ def test_get_position_feedback(motion_controller, sensor):
     assert sensor == test_feedback
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -218,6 +232,7 @@ def test_set_position_feedback(motion_controller, sensor):
     assert sensor == register_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor, category", SENSOR_TYPE_AND_CATEGORY)
@@ -228,6 +243,7 @@ def test_get_position_feedback_category(motion_controller, sensor, category):
     assert test_category == category
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize("sensor", list(SensorType))
@@ -244,6 +260,7 @@ def test_get_position_feedback_resolution(motion_controller, sensor):
         assert test_res_1 == test_res_2
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize(
@@ -264,6 +281,7 @@ def test_get_auxiliar_feedback(motion_controller, sensor):
     assert sensor == test_feedback
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize(
@@ -284,6 +302,7 @@ def test_set_auxiliar_feedback(motion_controller, sensor):
     assert sensor == register_value
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize(
@@ -304,6 +323,7 @@ def test_get_auxiliar_feedback_category(motion_controller, sensor, category):
     assert test_category == category
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("clean_and_restore_feedbacks")
 @pytest.mark.parametrize(
@@ -330,6 +350,7 @@ def test_get_auxiliar_feedback_resolution(motion_controller, sensor):
         assert test_res_1 == test_res_2
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("restore_resolution_registers")
 @pytest.mark.parametrize("single_turn, resolution", ABSOLUTE_ENCODER_RESOLUTION_TEST_VALUES)
@@ -340,6 +361,7 @@ def test_get_absolute_encoder_1_resolution(motion_controller, single_turn, resol
     assert resolution == test_res
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("restore_resolution_registers")
 @pytest.mark.parametrize("resolution", INCREMENTAL_ENCODER_RESOLUTION_TEST_VALUES)
@@ -350,6 +372,7 @@ def test_get_incremental_encoder_1_resolution(motion_controller, resolution):
     assert resolution == test_res
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("restore_resolution_registers")
 @pytest.mark.parametrize("pair_poles, resolution", [(1, 6), (10, 60), (4, 24)])
@@ -360,6 +383,7 @@ def test_get_digital_halls_resolution(motion_controller, pair_poles, resolution)
     assert resolution == test_res
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("restore_resolution_registers")
 @pytest.mark.parametrize("single_turn, resolution", ABSOLUTE_ENCODER_RESOLUTION_TEST_VALUES)
@@ -370,6 +394,7 @@ def test_get_secondary_ssi_resolution(motion_controller, single_turn, resolution
     assert resolution == test_res
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("restore_resolution_registers")
 @pytest.mark.parametrize("single_turn, resolution", ABSOLUTE_ENCODER_RESOLUTION_TEST_VALUES)
@@ -380,6 +405,7 @@ def test_get_absolute_encoder_2_resolution(motion_controller, single_turn, resol
     assert resolution == test_res
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.usefixtures("restore_resolution_registers")
 @pytest.mark.parametrize("resolution", INCREMENTAL_ENCODER_RESOLUTION_TEST_VALUES)
@@ -391,6 +417,7 @@ def test_get_incremental_encoder_2_resolution(motion_controller, resolution):
     assert resolution == test_res
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_instance_sensor_type(motion_controller):
     mc, alias = motion_controller
@@ -398,6 +425,7 @@ def test_instance_sensor_type(motion_controller):
     assert isinstance(test_feedback, SensorType)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sensor, register",

--- a/tests/test_homing.py
+++ b/tests/test_homing.py
@@ -34,6 +34,7 @@ def initial_position(motion_controller):
     return position
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("homing_mode", list(HomingMode))
 def test_set_homing_mode(motion_controller, homing_mode):
@@ -43,6 +44,7 @@ def test_set_homing_mode(motion_controller, homing_mode):
     assert test_homing_mode == homing_mode
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("homing_offset", [0, 10, 500, -12, -100, 1000])
 def test_set_homing_offset(motion_controller, homing_offset):
@@ -52,6 +54,7 @@ def test_set_homing_offset(motion_controller, homing_offset):
     assert test_homing_offset == homing_offset
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("homing_timeout", [0, 10, 500, 1000, 5000, 10000])
 def test_set_homing_timeout(motion_controller, homing_timeout):

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -40,6 +40,7 @@ def mon_map_registers(skip_if_monitoring_not_available, monitoring):
     monitoring.map_registers([{"axis": 1, "name": "CL_POS_FBK_VALUE"}])
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "trigger_type",
@@ -142,6 +143,7 @@ def test_set_monitoring_frequency_exception(monitoring):
         monitoring.set_frequency(prescaler)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_monitoring_map_registers_size_exception(monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
@@ -150,6 +152,7 @@ def test_monitoring_map_registers_size_exception(monitoring):
         monitoring.map_registers(registers)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_monitoring_map_registers_fail(monitoring):
     registers = []
@@ -368,6 +371,7 @@ def test_stop_reading_data(motion_controller, monitoring, disable_monitoring_dis
     assert (time.time() - init_time) < timeout
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_monitoring_max_sample_size(motion_controller, skip_if_monitoring_not_available):
     mc, alias = motion_controller

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -43,6 +43,7 @@ def test_target_latch(motion_controller):
     assert pytest.approx(init_pos + pos_res, rel_tolerance) == test_act_pos
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("operation_mode", list(OperationMode))
 def test_set_operation_mode(motion_controller, operation_mode):
@@ -143,6 +144,7 @@ def test_fault_reset(motion_controller_teardown):
     assert not mc.errors.is_fault_active(servo=alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("position_value", [1000, 0, -1000, 4000])
 def test_set_position(motion_controller, position_value):
@@ -165,6 +167,7 @@ def test_move_position(motion_controller, position_value):
     assert pytest.approx(position_value, abs=pos_tolerance) == test_position
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("velocity_value", [0.5, 1, 0, -0.5])
 def test_set_velocity(motion_controller, velocity_value):
@@ -187,6 +190,7 @@ def test_set_velocity_blocking(motion_controller, velocity_value):
     assert pytest.approx(velocity_value, abs=0.1) == test_vel
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("current_value", [0.5, 1, 0, -0.5])
 def test_set_current_quadrature(motion_controller, current_value):
@@ -196,6 +200,7 @@ def test_set_current_quadrature(motion_controller, current_value):
     assert pytest.approx(current_value) == test_current
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("current_value", [0.5, 1, 0, -0.5])
 def test_set_current_direct(motion_controller, current_value):
@@ -205,6 +210,7 @@ def test_set_current_direct(motion_controller, current_value):
     assert pytest.approx(current_value) == test_current
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("voltage_value", [0.5, 1, 0, -0.5])
 def test_set_voltage_quadrature(motion_controller, voltage_value):
@@ -214,6 +220,7 @@ def test_set_voltage_quadrature(motion_controller, voltage_value):
     assert pytest.approx(voltage_value) == test_voltage
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("voltage_value", [0.5, 1, 0, -0.5])
 def test_set_voltage_direct(motion_controller, voltage_value):
@@ -223,6 +230,7 @@ def test_set_voltage_direct(motion_controller, voltage_value):
     assert pytest.approx(voltage_value) == test_voltage
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "init_v, final_v, total_t, t, result",
@@ -278,6 +286,7 @@ def test_get_actual_velocity(motion_controller, velocity_value):
     assert np.abs(np.mean(test_velocity) - np.mean(reg_value)) < 0.1
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_actual_current_direct(mocker, motion_controller):
     mc, alias = motion_controller
@@ -287,6 +296,7 @@ def test_get_actual_current_direct(mocker, motion_controller):
     patch_get_register.assert_called_once_with(ACTUAL_DIRECT_CURRENT_REGISTER, servo=alias, axis=1)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_actual_current_quadrature(mocker, motion_controller):
     mc, alias = motion_controller
@@ -298,6 +308,7 @@ def test_get_actual_current_quadrature(mocker, motion_controller):
     )
 
 
+@pytest.mark.virtual
 def test_wait_for_position_timeout(motion_controller):
     timeout_value = 2
     mc, alias = motion_controller
@@ -308,6 +319,7 @@ def test_wait_for_position_timeout(motion_controller):
     assert pytest.approx(timeout_value, abs=0.1) == final_time - init_time
 
 
+@pytest.mark.virtual
 def test_wait_for_velocity_timeout(motion_controller):
     timeout_value = 2
     mc, alias = motion_controller

--- a/tests/test_motion_controller.py
+++ b/tests/test_motion_controller.py
@@ -13,6 +13,7 @@ from ingeniamotion.information import Information
 from ingeniamotion.metaclass import MCMetaClass
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_motion_controller():
     mc = MotionController()
@@ -25,6 +26,7 @@ def test_motion_controller():
     assert isinstance(mc.info, Information)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_servo_name(motion_controller):
     mc, alias = motion_controller
@@ -34,6 +36,7 @@ def test_servo_name(motion_controller):
     assert name == "{} ({})".format(prod_code, alias)
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_register_enum(motion_controller):
     mc, alias = motion_controller
@@ -51,6 +54,7 @@ def test_get_register_enum(motion_controller):
     assert checked_ops > 0
 
 
+@pytest.mark.virtual
 @pytest.mark.smoke
 def test_is_alive(motion_controller):
     mc, alias = motion_controller


### PR DESCRIPTION
### Description

Run the tests that don't require a physical drive with a virtual drive.

Fixes #INGM-358

### Type of change

- [Update test_all_drive_tests.py](https://github.com/ingeniamc/ingeniamotion/commit/e320df76280b1d3c5a9448344ad15f71b8eeb8cb)
- [Update test_capture.py](https://github.com/ingeniamc/ingeniamotion/commit/c95ea172a5e1293ee239f41d49b8bc9a9bec0bad)
- [Update test_comkit.py](https://github.com/ingeniamc/ingeniamotion/commit/21bf40d301e06c9bbdd2346d1f04f8eb7f58492a)
-  [Update test_communication.py](https://github.com/ingeniamc/ingeniamotion/commit/9c9920cce5d5517341bd09256277a991ab2f1ea8)
- [Update test_configuration.py](https://github.com/ingeniamc/ingeniamotion/commit/798f5e1897952a749427b0c75d58d26092e6b48e)
- [Update test_disturbance.py](https://github.com/ingeniamc/ingeniamotion/commit/4e827ac6e58007a1b13c1c815a0a67a00a53f9f5)
- [Update test_errors.py](https://github.com/ingeniamc/ingeniamotion/commit/1e187ab516098b65c6d81239304653dcab67cfcc)
- [Update test_feedback.py](https://github.com/ingeniamc/ingeniamotion/commit/45befcd9afd0b8b2900cd6b82b4b2afdb9e9ad1d)
- [Update test_homing.py](https://github.com/ingeniamc/ingeniamotion/commit/bab5b3847d9bd14bcb032e3c6526bb46d1797766)
- [Update test_monitoring.py](https://github.com/ingeniamc/ingeniamotion/commit/e1c59dbf39b9fd196fc7d53c475d365e562b8e15)
- [Update test_motion.py](https://github.com/ingeniamc/ingeniamotion/commit/9aa0b1df51ce505e7d1cd0da7dbabaa024923b83)
- [Update test_motion_controller.py](https://github.com/ingeniamc/ingeniamotion/commit/5a9426d530b82ba16800aa4eeb21b625bf77ed2b)