### PR TITLE
INGM-386 Use ingenialink to load the FW

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,9 @@ pipeline {
                 stage('Update drives FW') {
                     steps {
                         bat '''
-                            venv\\Scripts\\python.exe tests\\load_FWs.py soem
+                            py -3.9 -m venv venv_fw
+                            venv_fw\\Scripts\\python.exe -m pip install . 
+                            venv_fw\\Scripts\\python.exe tests\\load_FWs.py soem
                         '''
                     }
                 }

--- a/tests/load_FWs.py
+++ b/tests/load_FWs.py
@@ -1,17 +1,15 @@
-import sys
+import argparse
+import json
 import os
 import time
-import json
-import argparse
+from functools import partial
+
 import ingenialogger
-from ping3 import ping
-
-sys.path.append("./")
-
-from ingeniamotion import MotionController
-from ingeniamotion.exceptions import IMException
-from ingeniamotion.enums import CAN_BAUDRATE, CAN_DEVICE
+from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.ethercat.network import EthercatNetwork
+from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
+from ping3 import ping
 
 logger = ingenialogger.get_logger("load_FWs")
 ingenialogger.configure_logger(level=ingenialogger.LoggingLevel.INFO)
@@ -24,9 +22,19 @@ def setup_command():
     return parser.parse_args()
 
 
-def load_can(drive_conf, mc):
+def connect_can(drive_conf):
+    net = CanopenNetwork(
+        CAN_DEVICE(drive_conf["device"]),
+        drive_conf["channel"],
+        CAN_BAUDRATE(drive_conf["baudrate"]),
+    )
+    servo = net.connect_to_slave(drive_conf["node_id"], drive_conf["dictionary"])
+    return net, servo
+
+
+def load_can(drive_conf):
     # Number of reattempts for trying the CAN bootloader
-    BL_NUM_OF_REATTEMPTS = 2
+    BL_NUM_OF_REATTEMPTS = 4
 
     # Timings, in seconds
     SLEEP_TIME_AFTER_ATTEMP = 5.0
@@ -37,13 +45,7 @@ def load_can(drive_conf, mc):
     for attempt in range(BL_NUM_OF_REATTEMPTS):
         logger.info(f"CAN boot attempt {attempt + 1} of {BL_NUM_OF_REATTEMPTS}")
         try:
-            mc.communication.connect_servo_canopen(
-                CAN_DEVICE(drive_conf["device"]),
-                drive_conf["dictionary"],
-                drive_conf["node_id"],
-                CAN_BAUDRATE(drive_conf["baudrate"]),
-                channel=drive_conf["channel"],
-            )
+            net, servo = connect_can(drive_conf)
             logger.info(
                 "Drive connected. %s, node: %d, baudrate: %d, channel: %d",
                 drive_conf["device"],
@@ -55,9 +57,12 @@ def load_can(drive_conf, mc):
             logger.info(f"Couldn't connect to the drive: {e}")
             continue
 
+        status_callback = partial(logger.info, "Load firmware status: %s")
+        progress_callback = partial(logger.info, "Load firmware progress: %s")
         try:
-            mc.communication.load_firmware_canopen(drive_conf["fw_file"])
-
+            net.load_firmware(
+                servo.target, drive_conf["fw_file"], status_callback, progress_callback
+            )
             # Reaching this means that FW was correctly flashed
             break
 
@@ -67,7 +72,7 @@ def load_can(drive_conf, mc):
 
         finally:
             try:
-                mc.communication.disconnect()
+                net.disconnect_from_slave(servo)
             except Exception as e:
                 logger.error(f"Error when disconnection from drive: {e}")
 
@@ -87,36 +92,32 @@ def load_can(drive_conf, mc):
     ini_time = time.perf_counter()
     while (time.perf_counter() - ini_time) <= TIMEOUT_NEW_FW_DETECT and not detected:
         try:
-            mc.communication.connect_servo_canopen(
-                CAN_DEVICE(drive_conf["device"]),
-                drive_conf["dictionary"],
-                drive_conf["node_id"],
-                CAN_BAUDRATE(drive_conf["baudrate"]),
-                channel=drive_conf["channel"],
-            )
+            net, servo = connect_can(drive_conf)
             # Reaching this point means we are connected
             detected = True
-            logger.info("New FW detected after: {:.1f} s".format(time.perf_counter() - ini_time))
-            mc.communication.disconnect()
+            fw_version = servo.info["firmware_version"]
+            logger.info(
+                f"New FW detected ({fw_version}) after: {time.perf_counter() - ini_time:.1f} s"
+            )
+            net.disconnect_from_slave(servo)
         except Exception as e:
             # When cannot connect
             time.sleep(SLEEP_TIME_NEW_FW_DETECT)
 
     if not detected:
-        raise Exception("New FW not detected")
+        raise Exception("Could not connect to the drive. FW loading might have failed.")
 
 
-def load_ecat(drive_conf, mc):
-    if_name = mc.communication.get_ifname_from_interface_ip(drive_conf["ip"])
-    mc.communication.load_firmware_ecat(if_name, drive_conf["fw_file"], drive_conf["slave"])
-    logger.info("FW updated. ifname: %s, slave: %d", if_name, drive_conf["slave"])
+def load_ecat(drive_conf):
+    net = EthercatNetwork(drive_conf["ifname"])
+    net.load_firmware(drive_conf["fw_file"], drive_conf["slave"])
+    logger.info("FW updated. ifname: %s, slave: %d", drive_conf["ifname"], drive_conf["slave"])
 
 
-def ping_check(target_ip):
+def ping_check(target_ip, timeout=180):
     # TODO Stop use this function when issue INGM-104 will done
     time.sleep(5)
     initial_time = time.time()
-    timeout = 180
     success_num_pings = 3
     num_pings = 0
     detected = False
@@ -129,35 +130,65 @@ def ping_check(target_ip):
         time.sleep(1)
     if not detected:
         logger.error("drive ping not detected", drive=target_ip)
+    return detected
 
 
-def load_eth(drive_conf, mc):
+def connect_eth(drive_conf):
+    net = EthernetNetwork()
+    servo = net.connect_to_slave(drive_conf["ip"], drive_conf["dictionary"])
+    return net, servo
+
+
+def boot_mode(net, servo):
+    PASSWORD_FORCE_BOOT_COCO = 0x424F4F54
     try:
-        mc.communication.connect_servo_ethernet(drive_conf["ip"], drive_conf["dictionary"])
-        logger.info("Drive connected. IP: %s", drive_conf["ip"])
-        mc.communication.boot_mode_and_load_firmware_ethernet(drive_conf["fw_file"])
-    except ILError:
+        servo.write("DRV_BOOT_COCO_FORCE", PASSWORD_FORCE_BOOT_COCO, subnode=0)
+        ftp_ready = ping_check(servo.ip_address, timeout=5)
+    except ILError as e:
+        logger.debug("Could not enter in boot mode.")
+        raise e
+    finally:
+        logger.debug("Disconnecting from drive.")
+        net.disconnect_from_slave(servo)
+    if not ftp_ready:
+        logger.debug("FTP is not ready.")
+        raise ILError("FTP is not ready.")
+    else:
+        logger.debug("FTP is ready.")
+
+
+def load_eth(drive_conf):
+    net, servo = connect_eth(drive_conf)
+    logger.info("Drive connected. IP: %s", drive_conf["ip"])
+    try:
+        boot_mode(net, servo)
+    except ILError as e:
         logger.warning(
-            "Drive does not respond. It may already be in boot mode.", drive=drive_conf["ip"]
+            f"Drive does not respond ({e}). It may already be in boot mode.", drive=drive_conf["ip"]
         )
-        mc.communication.load_firmware_ethernet(drive_conf["ip"], drive_conf["fw_file"])
-    ping_check(drive_conf["ip"])
+    try:
+        net.load_firmware(drive_conf["fw_file"], drive_conf["ip"], "Ingenia", "Ingenia")
+    except ILError as e:
+        raise Exception(f"Could not load the firmware: {e}")
+    detected = ping_check(drive_conf["ip"])
+    if not detected:
+        logger.info("FW not updated. IP: %s", drive_conf["ip"])
+        raise Exception("Could not detect the drive.")
     logger.info("FW updated. IP: %s", drive_conf["ip"])
 
 
 def main(comm, config):
-    mc = MotionController()
     servo_list = config[comm]
     for index, servo_conf in enumerate(servo_list):
         logger.info("Upload FW comm %s, index: %d", comm, index)
         try:
             if comm == "canopen":
-                load_can(servo_conf, mc)
+                load_can(servo_conf)
             if comm == "soem":
-                load_ecat(servo_conf, mc)
+                load_ecat(servo_conf)
             if comm == "eoe":
-                load_eth(servo_conf, mc)
-        except (ILError, IMException) as e:
+                load_eth(servo_conf)
+        except ILError as e:
             logger.exception(e)
             logger.error("Error in FW update. comm %s, index: %d", comm, index)
 

--- a/tests/load_FWs.py
+++ b/tests/load_FWs.py
@@ -4,6 +4,7 @@ import os
 import time
 from functools import partial
 
+import ifaddr
 import ingenialogger
 from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
 from ingenialink.ethercat.network import EthercatNetwork
@@ -109,6 +110,14 @@ def load_can(drive_conf):
 
 
 def load_ecat(drive_conf):
+    ifname = None
+    for adapter in ifaddr.get_adapters():
+        for ip in adapter.ips:
+            if ip.is_IPv4 and ip.ip == drive_conf["ip"]:
+                ifname = bytes.decode(adapter.name)
+                break
+        if ifname is not None:
+            break
     net = EthercatNetwork(drive_conf["ifname"])
     net.load_firmware(drive_conf["fw_file"], drive_conf["slave"])
     logger.info("FW updated. ifname: %s, slave: %d", drive_conf["ifname"], drive_conf["slave"])

--- a/tests/load_FWs.py
+++ b/tests/load_FWs.py
@@ -114,11 +114,11 @@ def load_ecat(drive_conf):
     for adapter in ifaddr.get_adapters():
         for ip in adapter.ips:
             if ip.is_IPv4 and ip.ip == drive_conf["ip"]:
-                ifname = bytes.decode(adapter.name)
+                ifname = "\\Device\\NPF_{}".format(bytes.decode(adapter.name))
                 break
         if ifname is not None:
             break
-    net = EthercatNetwork(drive_conf["ifname"])
+    net = EthercatNetwork(ifname)
     net.load_firmware(drive_conf["fw_file"], drive_conf["slave"])
     logger.info("FW updated. ifname: %s, slave: %d", drive_conf["ifname"], drive_conf["slave"])
 

--- a/tests/load_FWs.py
+++ b/tests/load_FWs.py
@@ -123,7 +123,7 @@ def load_ecat(drive_conf):
         net.load_firmware(drive_conf["fw_file"], drive_conf["slave"])
     except ILError as e:
         raise Exception(f"Could not load the firmware: {e}")
-    logger.info("FW updated. ifname: %s, slave: %d", drive_conf["ifname"], drive_conf["slave"])
+    logger.info("FW updated. ifname: %s, slave: %d", ifname, drive_conf["slave"])
 
 
 def ping_check(target_ip, timeout=180):

--- a/tests/load_FWs.py
+++ b/tests/load_FWs.py
@@ -119,7 +119,10 @@ def load_ecat(drive_conf):
         if ifname is not None:
             break
     net = EthercatNetwork(ifname)
-    net.load_firmware(drive_conf["fw_file"], drive_conf["slave"])
+    try:
+        net.load_firmware(drive_conf["fw_file"], drive_conf["slave"])
+    except ILError as e:
+        raise Exception(f"Could not load the firmware: {e}")
     logger.info("FW updated. ifname: %s, slave: %d", drive_conf["ifname"], drive_conf["slave"])
 
 


### PR DESCRIPTION
## Use ingenialink to load the FW

### Description

This PR changes the load FW script to use ingenialink instead of ingeniamotion.

Fixes # INGM-386 

### Type of change

- [x] Use ingenialink instead of ingeniamotion to load the FW.

### Tests
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.