### PR TITLE
INGM-396 Add functions to scan drives with information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add in configuration set_velocity_pid, set_position_pid and get_rated_current
 - Add functions to connect to and scan EtherCAT devices using CoE (SDOs).
 - Optional backup registers for Wizard tests.
+- New methods to scan the network and obtained drive info (product code and revision number).
 
 ### Fixed
 - check_motor_disabled decorator does not work with positional arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Add in configuration set_velocity_pid, set_position_pid and get_rated_current
 - Add functions to connect to and scan EtherCAT devices using CoE (SDOs).
 - Optional backup registers for Wizard tests.
-- New methods to scan the network and obtained drive info (product code and revision number).
+- New methods to scan the network and obtain drive info (product code and revision number).
 
 ### Fixed
 - check_motor_disabled decorator does not work with positional arguments

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -1,8 +1,10 @@
 import time
+from collections import OrderedDict
 
 import pytest
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.exceptions import ILError
+from ingenialink.network import SlaveInfo
 from ingenialink.servo import SERVO_STATE
 
 from ingeniamotion import MotionController
@@ -278,3 +280,45 @@ def test_connect_servo_virtual_custom_dictionary(read_config):
     assert mc.communication._Communication__virtual_drive is not None
     mc.communication.disconnect()
     assert mc.communication._Communication__virtual_drive is None
+
+
+@pytest.mark.virtual
+def test_scan_servos_canopen_with_info(mocker):
+    mc = MotionController()
+    detected_slaves = OrderedDict({31: SlaveInfo(1234, 123), 32: SlaveInfo(1234, 123)})
+    mocker.patch(
+        "ingenialink.canopen.network.CanopenNetwork.scan_slaves_info", return_value=detected_slaves
+    )
+    assert mc.communication.scan_servos_canopen_with_info(CAN_DEVICE.KVASER) == detected_slaves
+
+
+@pytest.mark.virtual
+def test_scan_servos_canopen(mocker):
+    mc = MotionController()
+    detected_slaves = OrderedDict({31: SlaveInfo(1234, 123), 32: SlaveInfo(1234, 123)})
+    mocker.patch(
+        "ingenialink.canopen.network.CanopenNetwork.scan_slaves_info", return_value=detected_slaves
+    )
+    assert mc.communication.scan_servos_canopen(CAN_DEVICE.KVASER) == [31, 32]
+
+
+@pytest.mark.virtual
+def test_scan_servos_ethercat_with_info(mocker):
+    mc = MotionController()
+    detected_slaves = OrderedDict({1: SlaveInfo(1234, 123), 2: SlaveInfo(1234, 123)})
+    mocker.patch(
+        "ingenialink.ethercat.network.EthercatNetwork.scan_slaves_info",
+        return_value=detected_slaves,
+    )
+    assert mc.communication.scan_servos_ethercat_with_info("") == detected_slaves
+
+
+@pytest.mark.virtual
+def test_scan_servos_ethercat(mocker):
+    mc = MotionController()
+    detected_slaves = OrderedDict({1: SlaveInfo(1234, 123), 2: SlaveInfo(1234, 123)})
+    mocker.patch(
+        "ingenialink.ethercat.network.EthercatNetwork.scan_slaves_info",
+        return_value=detected_slaves,
+    )
+    assert mc.communication.scan_servos_ethercat("") == [1, 2]

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -295,11 +295,11 @@ def test_scan_servos_canopen_with_info(mocker):
 @pytest.mark.virtual
 def test_scan_servos_canopen(mocker):
     mc = MotionController()
-    detected_slaves = OrderedDict({31: SlaveInfo(1234, 123), 32: SlaveInfo(1234, 123)})
+    detected_slaves = [31, 32]
     mocker.patch(
-        "ingenialink.canopen.network.CanopenNetwork.scan_slaves_info", return_value=detected_slaves
+        "ingenialink.canopen.network.CanopenNetwork.scan_slaves", return_value=detected_slaves
     )
-    assert mc.communication.scan_servos_canopen(CAN_DEVICE.KVASER) == [31, 32]
+    assert mc.communication.scan_servos_canopen(CAN_DEVICE.KVASER) == detected_slaves
 
 
 @pytest.mark.virtual
@@ -316,9 +316,9 @@ def test_scan_servos_ethercat_with_info(mocker):
 @pytest.mark.virtual
 def test_scan_servos_ethercat(mocker):
     mc = MotionController()
-    detected_slaves = OrderedDict({1: SlaveInfo(1234, 123), 2: SlaveInfo(1234, 123)})
+    detected_slaves = [1, 2]
     mocker.patch(
-        "ingenialink.ethercat.network.EthercatNetwork.scan_slaves_info",
+        "ingenialink.ethercat.network.EthercatNetwork.scan_slaves",
         return_value=detected_slaves,
     )
-    assert mc.communication.scan_servos_ethercat("") == [1, 2]
+    assert mc.communication.scan_servos_ethercat("") == detected_slaves

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    deps = git+https://github.com/ingeniamc/ingenialink-python@develop
+    deps = git+https://github.com/ingeniamc/ingenialink-python@INGK-823-add-function-to-scan-drives-and-return-infos
 
 [testenv]
 description = run unit tests

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    deps = git+https://github.com/ingeniamc/ingenialink-python@INGK-823-add-function-to-scan-drives-and-return-infos
+    deps = git+https://github.com/ingeniamc/ingenialink-python@develop
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
## Add functions to scan drives with information

### Description

This PR adds methods to scan drives in ethercat and canopen including drive information (product code and revision number)

Fixes # INGM-396

### Type of change

Please add a description and delete options that are not relevant.

- [x] Add `scan_servos_ethercat_with_info`
- [x] Add `scan_servos_canopen_with_info`

### Tests
- [x] Add new unit tests if it applies.
- [ ] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.