### PR TITLE
INGM-414 Subscribe to exceptions in the PDO poller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Callbacks to notify exceptions in the ProcessDataThread.
+- A method in the PDOPoller to subscribe to exceptions in the ProcessDataThread.
 
 ### Changed
 - The get_subnodes method from the information module now returns a dictionary with the subnodes IDs as keys and their type as values.


### PR DESCRIPTION
### Description

Subscribe to the PDO thread exceptions from the PDO poller.

Fixes # INGM-414

### Type of change

- Add a method in the PDOPoller to subscribe to exceptions in the ProcessDataThread.


### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.