### PR TITLE
INGM-405: New example of using PDO poller

### DIFF
--- a/docs/examples/capture.rst
+++ b/docs/examples/capture.rst
@@ -15,3 +15,8 @@ Disturbance Example
 -------------------
 
 .. literalinclude:: ../../examples/disturbance_example.py
+
+Polling using PDOs Example
+--------------------------
+
+.. literalinclude:: ../../examples/pdo_poller_example.py

--- a/examples/pdo_poller_example.py
+++ b/examples/pdo_poller_example.py
@@ -5,33 +5,6 @@ from ingeniamotion.enums import SensorType
 from ingeniamotion.motion_controller import MotionController
 
 
-def establish_coe_connection(mc: MotionController) -> None:
-    """Establish an EtherCAT-CoE communication.
-
-    Find all available nodes, and perform a communication.
-
-    Args:
-        mc: The object where there are all functions to establish a communication.
-    """
-    # Modify these parameters to connect a drive
-    interface_index = 3
-    slave_id = 1
-    dictionary_path = "parent_directory/dictionary_file.xdf"
-
-    interface_selected = mc.communication.get_ifname_by_index(interface_index)
-    slave_id_list = mc.communication.scan_servos_ethercat(interface_selected)
-
-    if not slave_id_list:
-        interface_list = mc.communication.get_interface_name_list()
-        print(f"No slave detected on interface: {interface_list[interface_index]}")
-        return
-    else:
-        print(f"Found slaves: {slave_id_list}")
-
-    mc.communication.connect_servo_ethercat(interface_selected, slave_id, dictionary_path)
-    print("Drive is connected.")
-
-
 def set_feedback_sensors(mc: MotionController) -> None:
     """Set the type of position and velocity feedback sensors.
 
@@ -39,12 +12,12 @@ def set_feedback_sensors(mc: MotionController) -> None:
         mc: the controller to configure.
     """
     # Modify the SensorType.
-    mc.configuration.set_position_feedback(SensorType.HALLS)
-    mc.configuration.set_velocity_feedback(SensorType.HALLS)
+    mc.configuration.set_position_feedback(SensorType.QEI)
+    mc.configuration.set_velocity_feedback(SensorType.QEI)
 
 
-def perform_pdo_poller(mc: MotionController) -> None:
-    """Perform a PDO poller.
+def set_up_pdo_poller(mc: MotionController) -> None:
+    """Set-up a PDO poller.
 
     Read the Actual Position and the Actual Velocity registers using the PDO poller.
 
@@ -75,9 +48,15 @@ def perform_pdo_poller(mc: MotionController) -> None:
 
 def main() -> None:
     mc = MotionController()
-    establish_coe_connection(mc)
+    # Modify these parameters to connect a drive
+    interface_index = 3
+    slave_id = 1
+    dictionary_path = "parent_directory/dictionary_file.xdf"
+    mc.communication.connect_servo_ethercat_interface_index(
+        interface_index, slave_id, dictionary_path
+    )
     set_feedback_sensors(mc)
-    perform_pdo_poller(mc)
+    set_up_pdo_poller(mc)
     mc.communication.disconnect()
     print("The drive has been disconnected.")
 

--- a/examples/pdo_poller_example.py
+++ b/examples/pdo_poller_example.py
@@ -14,10 +14,10 @@ def establish_coe_connection(mc: MotionController) -> None:
         mc: The object where there are all functions to establish a communication.
     """
     # Modify these parameters to connect a drive
-    interface_index = 4
+    interface_index = 3
     slave_id = 1
     dictionary_path = (
-        "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+        "parent_directory/dictionary_file.xdf"
     )
 
     interface_selected = mc.communication.get_ifname_by_index(interface_index)
@@ -40,7 +40,7 @@ def set_feedback_sensors(mc: MotionController) -> None:
     Args:
         mc: the controller to configure.
     """
-    # Modify the SensorType if you are using another type.
+    # Modify the SensorType.
     mc.configuration.set_position_feedback(SensorType.HALLS)
     mc.configuration.set_velocity_feedback(SensorType.HALLS)
 

--- a/examples/pdo_poller_example.py
+++ b/examples/pdo_poller_example.py
@@ -1,0 +1,88 @@
+import time
+from typing import Dict, List, Union
+
+from ingeniamotion.enums import SensorType
+from ingeniamotion.motion_controller import MotionController
+
+
+def establish_coe_connection(mc: MotionController) -> None:
+    """Establish an EtherCAT-CoE communication.
+
+    Find all available nodes, and perform a communication.
+
+    Args:
+        mc: The object where there are all functions to establish a communication.
+    """
+    # Modify these parameters to connect a drive
+    interface_index = 4
+    slave_id = 1
+    dictionary_path = (
+        "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+    )
+
+    interface_selected = mc.communication.get_ifname_by_index(interface_index)
+    slave_id_list = mc.communication.scan_servos_ethercat(interface_selected)
+
+    if not slave_id_list:
+        interface_list = mc.communication.get_interface_name_list()
+        print(f"No slave detected on interface: {interface_list[interface_index]}")
+        return
+    else:
+        print(f"Found slaves: {slave_id_list}")
+
+    mc.communication.connect_servo_ethercat(interface_selected, slave_id, dictionary_path)
+    print("Drive is connected.")
+
+
+def set_feedback_sensors(mc: MotionController) -> None:
+    """Set the type of position and velocity feedback sensors.
+
+    Args:
+        mc: the controller to configure.
+    """
+    # Modify the SensorType if you are using another type.
+    mc.configuration.set_position_feedback(SensorType.HALLS)
+    mc.configuration.set_velocity_feedback(SensorType.HALLS)
+
+
+def perform_pdo_poller(mc: MotionController) -> None:
+    """Perform a PDO poller.
+
+    Read the Actual Position and the Actual Velocity registers using the PDO poller.
+
+    Args:
+        mc: The controller where there are all functions to perform a PDO poller.
+    """
+    registers: List[Dict[str, Union[int, str]]] = [
+        {
+            "name": "CL_POS_FBK_VALUE",
+            "axis": 1,
+        },
+        {
+            "name": "CL_VEL_FBK_VALUE",
+            "axis": 1,
+        },
+    ]
+
+    poller = mc.capture.pdo.create_poller(registers)
+    # Waiting time for generating new samples
+    time.sleep(1)
+    time_stamps, data = poller.data
+    poller.stop()
+
+    print(f"Time: {time_stamps}")
+    print(f"Actual Position values: {data[0]}")
+    print(f"Actual Velocity values: {data[1]}")
+
+
+def main() -> None:
+    mc = MotionController()
+    establish_coe_connection(mc)
+    set_feedback_sensors(mc)
+    perform_pdo_poller(mc)
+    mc.communication.disconnect()
+    print("The drive has been disconnected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pdo_poller_example.py
+++ b/examples/pdo_poller_example.py
@@ -16,9 +16,7 @@ def establish_coe_connection(mc: MotionController) -> None:
     # Modify these parameters to connect a drive
     interface_index = 3
     slave_id = 1
-    dictionary_path = (
-        "parent_directory/dictionary_file.xdf"
-    )
+    dictionary_path = "parent_directory/dictionary_file.xdf"
 
     interface_selected = mc.communication.get_ifname_by_index(interface_index)
     slave_id_list = mc.communication.scan_servos_ethercat(interface_selected)

--- a/examples/pdo_poller_example.py
+++ b/examples/pdo_poller_example.py
@@ -5,17 +5,6 @@ from ingeniamotion.enums import SensorType
 from ingeniamotion.motion_controller import MotionController
 
 
-def set_feedback_sensors(mc: MotionController) -> None:
-    """Set the type of position and velocity feedback sensors.
-
-    Args:
-        mc: the controller to configure.
-    """
-    # Modify the SensorType.
-    mc.configuration.set_position_feedback(SensorType.QEI)
-    mc.configuration.set_velocity_feedback(SensorType.QEI)
-
-
 def set_up_pdo_poller(mc: MotionController) -> None:
     """Set-up a PDO poller.
 
@@ -49,13 +38,12 @@ def set_up_pdo_poller(mc: MotionController) -> None:
 def main() -> None:
     mc = MotionController()
     # Modify these parameters to connect a drive
-    interface_index = 3
+    interface_ip = "192.168.2.1"
     slave_id = 1
     dictionary_path = "parent_directory/dictionary_file.xdf"
-    mc.communication.connect_servo_ethercat_interface_index(
-        interface_index, slave_id, dictionary_path
+    mc.communication.connect_servo_ethercat_interface_ip(
+        interface_ip, slave_id, dictionary_path
     )
-    set_feedback_sensors(mc)
     set_up_pdo_poller(mc)
     mc.communication.disconnect()
     print("The drive has been disconnected.")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,6 +16,26 @@ from ingeniamotion.configuration import Configuration
 from ingeniamotion.enums import SeverityLevel
 from ingeniamotion.information import Information
 from ingeniamotion.pdo import PDONetworkManager, PDOPoller
+from tests.conftest import connect_canopen, connect_eoe, connect_soem
+
+
+@pytest.fixture
+def setup_for_test_examples(motion_controller):
+    mc, alias = motion_controller
+    mc.communication.disconnect(alias)
+
+
+@pytest.fixture
+def teardown_for_test_examples(motion_controller, read_config, pytestconfig):
+    yield
+    mc, alias = motion_controller
+    protocol = pytestconfig.getoption("--protocol")
+    if protocol == "soem":
+        connect_soem(mc, read_config, alias)
+    elif protocol == "canopen":
+        connect_canopen(mc, read_config, alias)
+    else:
+        connect_eoe(mc, read_config, alias)
 
 
 @pytest.mark.eoe

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,7 +2,7 @@ from collections import deque
 
 import pytest
 
-from examples.pdo_poller_example import main as perform_pdo_poller
+from examples.pdo_poller_example import main as set_up_pdo_poller
 from ingeniamotion import MotionController
 from ingeniamotion.communication import Communication
 from ingeniamotion.configuration import Configuration
@@ -222,11 +222,9 @@ def test_brake_config_example(read_config, script_runner, mocker, override):
 
 @pytest.mark.virtual
 def test_pdo_poller_success(mocker):
-    get_ifname_by_index = mocker.patch.object(Communication, "get_ifname_by_index")
-    scan_servos_ethercat = mocker.patch.object(
-        Communication, "scan_servos_ethercat", return_value=[32]
+    connect_servo_ethercat = mocker.patch.object(
+        Communication, "connect_servo_ethercat_interface_index"
     )
-    connect_servo_ethercat = mocker.patch.object(Communication, "connect_servo_ethercat")
     set_position_feedback = mocker.patch.object(Configuration, "set_position_feedback")
     set_velocity_feedback = mocker.patch.object(Configuration, "set_velocity_feedback")
     disconnect = mocker.patch.object(Communication, "disconnect")
@@ -240,10 +238,8 @@ def test_pdo_poller_success(mocker):
     )
     stop = mocker.patch.object(PDOPoller, "stop")
 
-    perform_pdo_poller()
+    set_up_pdo_poller()
 
-    get_ifname_by_index.assert_called_once()
-    scan_servos_ethercat.assert_called_once()
     connect_servo_ethercat.assert_called_once()
     set_position_feedback.assert_called_once()
     set_velocity_feedback.assert_called_once()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,7 +1,5 @@
-from typing import Dict
-
-import pytest
 from collections import deque
+from typing import Dict
 
 import pytest
 from ingenialink import CAN_BAUDRATE, CAN_DEVICE

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -532,11 +532,9 @@ def test_ecat_coe_connection_example_connection_error(mocker, capsys):
 
 @pytest.mark.virtual
 def test_pdo_poller_success(mocker):
-    connect_servo_ethercat = mocker.patch.object(
-        Communication, "connect_servo_ethercat_interface_index"
+    connect_servo_ethercat_interface_ip = mocker.patch.object(
+        Communication, "connect_servo_ethercat_interface_ip"
     )
-    set_position_feedback = mocker.patch.object(Configuration, "set_position_feedback")
-    set_velocity_feedback = mocker.patch.object(Configuration, "set_velocity_feedback")
     disconnect = mocker.patch.object(Communication, "disconnect")
     mock_pdo_poller = PDOPoller(MotionController(), "mock_alias", 0.1, 100)
     create_poller = mocker.patch.object(
@@ -550,9 +548,7 @@ def test_pdo_poller_success(mocker):
 
     set_up_pdo_poller()
 
-    connect_servo_ethercat.assert_called_once()
-    set_position_feedback.assert_called_once()
-    set_velocity_feedback.assert_called_once()
+    connect_servo_ethercat_interface_ip.assert_called_once()
     create_poller.assert_called_once()
     data.assert_called_once()
     stop.assert_called_once()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -220,23 +220,28 @@ def test_brake_config_example(read_config, script_runner, mocker, override):
     assert result.returncode == 0
 
 
-
 @pytest.mark.virtual
 def test_pdo_poller_success(mocker):
     get_ifname_by_index = mocker.patch.object(Communication, "get_ifname_by_index")
-    scan_servos_ethercat = mocker.patch.object(Communication, "scan_servos_ethercat", return_value=[32])
+    scan_servos_ethercat = mocker.patch.object(
+        Communication, "scan_servos_ethercat", return_value=[32]
+    )
     connect_servo_ethercat = mocker.patch.object(Communication, "connect_servo_ethercat")
     set_position_feedback = mocker.patch.object(Configuration, "set_position_feedback")
     set_velocity_feedback = mocker.patch.object(Configuration, "set_velocity_feedback")
     disconnect = mocker.patch.object(Communication, "disconnect")
     mock_pdo_poller = PDOPoller(MotionController(), "mock_alias", 0.1, 100)
-    create_poller = mocker.patch.object(PDONetworkManager, "create_poller", return_value=mock_pdo_poller)
+    create_poller = mocker.patch.object(
+        PDONetworkManager, "create_poller", return_value=mock_pdo_poller
+    )
     mock_poller_data = (deque([0.1, 0.2]), [deque([1, 2]), deque([0.0, 0.0])])
-    data = mocker.patch.object(PDOPoller, "data", new_callable=mocker.PropertyMock, return_value=mock_poller_data)
+    data = mocker.patch.object(
+        PDOPoller, "data", new_callable=mocker.PropertyMock, return_value=mock_poller_data
+    )
     stop = mocker.patch.object(PDOPoller, "stop")
-    
+
     perform_pdo_poller()
-    
+
     get_ifname_by_index.assert_called_once()
     scan_servos_ethercat.assert_called_once()
     connect_servo_ethercat.assert_called_once()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,7 +1,13 @@
+from collections import deque
+
 import pytest
 
+from examples.pdo_poller_example import main as perform_pdo_poller
 from ingeniamotion import MotionController
+from ingeniamotion.communication import Communication
+from ingeniamotion.configuration import Configuration
 from ingeniamotion.enums import SeverityLevel
+from ingeniamotion.pdo import PDONetworkManager, PDOPoller
 
 
 @pytest.mark.eoe
@@ -212,3 +218,31 @@ def test_brake_config_example(read_config, script_runner, mocker, override):
     mocker.patch.object(MotionController, "configuration", MockConfiguration)
     result = script_runner.run(script_path, override, dictionary, f"-ip={ip_address}")
     assert result.returncode == 0
+
+
+
+@pytest.mark.virtual
+def test_pdo_poller_success(mocker):
+    get_ifname_by_index = mocker.patch.object(Communication, "get_ifname_by_index")
+    scan_servos_ethercat = mocker.patch.object(Communication, "scan_servos_ethercat", return_value=[32])
+    connect_servo_ethercat = mocker.patch.object(Communication, "connect_servo_ethercat")
+    set_position_feedback = mocker.patch.object(Configuration, "set_position_feedback")
+    set_velocity_feedback = mocker.patch.object(Configuration, "set_velocity_feedback")
+    disconnect = mocker.patch.object(Communication, "disconnect")
+    mock_pdo_poller = PDOPoller(MotionController(), "mock_alias", 0.1, 100)
+    create_poller = mocker.patch.object(PDONetworkManager, "create_poller", return_value=mock_pdo_poller)
+    mock_poller_data = (deque([0.1, 0.2]), [deque([1, 2]), deque([0.0, 0.0])])
+    data = mocker.patch.object(PDOPoller, "data", new_callable=mocker.PropertyMock, return_value=mock_poller_data)
+    stop = mocker.patch.object(PDOPoller, "stop")
+    
+    perform_pdo_poller()
+    
+    get_ifname_by_index.assert_called_once()
+    scan_servos_ethercat.assert_called_once()
+    connect_servo_ethercat.assert_called_once()
+    set_position_feedback.assert_called_once()
+    set_velocity_feedback.assert_called_once()
+    create_poller.assert_called_once()
+    data.assert_called_once()
+    stop.assert_called_once()
+    disconnect.assert_called_once()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -536,7 +536,7 @@ def test_pdo_poller_success(mocker):
         Communication, "connect_servo_ethercat_interface_ip"
     )
     disconnect = mocker.patch.object(Communication, "disconnect")
-    mock_pdo_poller = PDOPoller(MotionController(), "mock_alias", 0.1, 100)
+    mock_pdo_poller = PDOPoller(MotionController(), "mock_alias", 0.1, None, 100)
     create_poller = mocker.patch.object(
         PDONetworkManager, "create_poller", return_value=mock_pdo_poller
     )


### PR DESCRIPTION
### Example using PDO poller

### Description

The example establish a CoE communication, set a type of sensor for position and velocity feedback sensors, and read them using a poller with PDO.

### Type of change

- [x] Example using PDO poller.

### Tests
- [x] Unit test that checks all functions are called.

Please describe the tests that you run to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.