### PR TITLE
INGM-425 Use perf_counter to measure loop duration

### DIFF
--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -166,6 +166,7 @@ class PDONetworkManager:
         ETHERCAT_PDO_WATCHDOG = "processdata"
         PDO_WATCHDOG_INCREMENT_FACTOR = 1.5
         SECONDS_TO_MS_CONVERSION_FACTOR = 1000
+        TIME_SLEEP_PRECISION = 0.016
 
         def __init__(
             self,
@@ -235,9 +236,14 @@ class PDONetworkManager:
                 else:
                     if self._notify_receive_process_data is not None:
                         self._notify_receive_process_data()
-                    remaining_loop_time = self._refresh_rate - (time.perf_counter() - time_start)
-                    if remaining_loop_time > 0:
-                        self.high_precision_sleep(remaining_loop_time)
+                    while (
+                        remaining_loop_time := self._refresh_rate
+                        - (time.perf_counter() - time_start)
+                    ) > 0:
+                        if remaining_loop_time > self.TIME_SLEEP_PRECISION:
+                            time.sleep(self.TIME_SLEEP_PRECISION)
+                        else:
+                            self.high_precision_sleep(remaining_loop_time)
                     iteration_duration = time.perf_counter() - time_start
 
         def stop(self) -> None:

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -248,6 +248,8 @@ class PDONetworkManager:
 
         @staticmethod
         def high_precision_sleep(duration: float) -> None:
+            """Replaces the time.sleep() method in order to obtain
+            more precise sleeping times."""
             start_time = time.perf_counter()
             while duration - (time.perf_counter() - start_time) > 0:
                 pass

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -166,7 +166,9 @@ class PDONetworkManager:
         ETHERCAT_PDO_WATCHDOG = "processdata"
         PDO_WATCHDOG_INCREMENT_FACTOR = 1.5
         SECONDS_TO_MS_CONVERSION_FACTOR = 1000
-        TIME_SLEEP_PRECISION = 0.016
+        # The time.sleep precision is 13 ms for Windows OS
+        # https://stackoverflow.com/questions/1133857/how-accurate-is-pythons-time-sleep
+        WINDOWS_TIME_SLEEP_PRECISION = 0.013
 
         def __init__(
             self,
@@ -240,8 +242,8 @@ class PDONetworkManager:
                         remaining_loop_time := self._refresh_rate
                         - (time.perf_counter() - time_start)
                     ) > 0:
-                        if remaining_loop_time > self.TIME_SLEEP_PRECISION:
-                            time.sleep(self.TIME_SLEEP_PRECISION)
+                        if remaining_loop_time > self.WINDOWS_TIME_SLEEP_PRECISION:
+                            time.sleep(self.WINDOWS_TIME_SLEEP_PRECISION)
                         else:
                             self.high_precision_sleep(remaining_loop_time)
                     iteration_duration = time.perf_counter() - time_start


### PR DESCRIPTION
### Description

Optimize the PDO thread timing.

Fixes # INGM-425

### Type of change

- Use the perf_counter method to measure the elapsed time.
- Add a high_precision_sleep method for a more efficient sleeping mechanism.


### Tests
- [x] Run tests.

Test:

- Create a PDO thread with a refresh rate of 0.01 seconds.
- Check the time elapsed between each loop iteration

Old implementation:
![pdo_refresh_rate_0 01](https://github.com/ingeniamc/ingeniamotion/assets/6689833/fbe9b334-11fb-46c2-81f9-98fd22c4aec8)

New implementation:
![pdo_refresh_rate_0 01](https://github.com/ingeniamc/ingeniamotion/assets/6689833/382085dc-1218-4b2d-84e3-be20b99e0813)


### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.