### PR TITLE
INGM-421 Study the receive process data timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - The get_subnodes method from the information module now returns a dictionary with the subnodes IDs as keys and their type as values.
+- Set the send_receive_processdata timeout in the ProcessDataThread according to the refresh rate.
 
 ### Removed
 - The comkit module. Now ingenialink methods are use to merge the COM-KIT and CORE dictionaries.

--- a/tests/test_pdo.py
+++ b/tests/test_pdo.py
@@ -183,11 +183,18 @@ def test_set_pdo_maps_to_slave_exception(motion_controller, rpdo_maps, tpdo_maps
         mc.capture.pdo.set_pdo_maps_to_slave(rx_maps, tx_maps, alias)
 
 
+@pytest.mark.parametrize(
+    "refresh_rate",
+    [
+        0.0001,
+        5,
+    ],
+)
 @pytest.mark.soem
-def test_pdos_refresh_rate(motion_controller):
+def test_pdos_refresh_rate(motion_controller, refresh_rate):
     mc, alias = motion_controller
     with pytest.raises(ValueError):
-        mc.capture.pdo.start_pdos(COMMUNICATION_TYPE.Ethercat, 5)
+        mc.capture.pdo.start_pdos(COMMUNICATION_TYPE.Ethercat, refresh_rate)
 
 
 @pytest.mark.soem
@@ -314,7 +321,7 @@ def test_subscribe_exceptions(motion_controller, mocker):
 
     error_msg = "Test error"
 
-    def send_receive_processdata(self):
+    def send_receive_processdata(self, *args):
         raise ILWrongWorkingCount(error_msg)
 
     mocker.patch("ingenialink.ethercat.network.EthercatNetwork.start_pdos")


### PR DESCRIPTION
### Description

Set the send_receive_processdata timeout in the ProcessDataThread according to the refresh rate.

Fixes #INGM-421

### Type of change

- Set the send_receive_processdata timeout in the ProcessDataThread according to the refresh rate.
- Add the MAXIMUM_PDO_REFRESH_TIME
- Fix the names of the default and minimum PDO refresh time.

### Tests
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.