### PR TITLE
INGM-408: make new example about save and load config

### DIFF
--- a/docs/examples/configuration.rst
+++ b/docs/examples/configuration.rst
@@ -10,3 +10,8 @@ Load and Save configuration example
 -----------------------------------
 
 .. literalinclude:: ../../examples/load_save_configuration.py
+
+Load and Save configuration with register changes example
+---------------------------------------------------------
+
+.. literalinclude:: ../../examples/load_save_config_register_changes.py

--- a/docs/examples/configuration.rst
+++ b/docs/examples/configuration.rst
@@ -5,3 +5,8 @@ Brake configuration example
 ---------------------------
 
 .. literalinclude:: ../../examples/brake_config.py
+
+Load and Save configuration example
+-----------------------------------
+
+.. literalinclude:: ../../examples/load_save_configuration.py

--- a/examples/load_save_config_register_changes.py
+++ b/examples/load_save_config_register_changes.py
@@ -6,9 +6,7 @@ def main() -> None:
     # Modify these parameters to connect a drive
     interface_index = 3
     slave_id = 1
-    dictionary_path = (
-        "parent_directory/dictionary_file.xdf"
-    )
+    dictionary_path = "parent_directory/dictionary_file.xdf"
     mc.communication.connect_servo_ethercat_interface_index(
         interface_index, slave_id, dictionary_path
     )

--- a/examples/load_save_config_register_changes.py
+++ b/examples/load_save_config_register_changes.py
@@ -1,0 +1,48 @@
+from ingeniamotion import MotionController
+
+
+def main() -> None:
+    mc = MotionController()
+    # Modify these parameters to connect a drive
+    interface_index = 3
+    slave_id = 1
+    dictionary_path = (
+        "parent_directory/dictionary_file.xdf"
+    )
+    mc.communication.connect_servo_ethercat_interface_index(
+        interface_index, slave_id, dictionary_path
+    )
+    # Save the initial configuration of your drive in a file
+    initial_config_path = "initial_configuration.xcf"
+    mc.configuration.save_configuration(initial_config_path)
+    print("The initial configuration is saved.")
+
+    # Get the initial max. velocity and set it with a new value
+    new_max_velocity = 20.0
+    initial_max_velocity = mc.configuration.get_max_velocity()
+    if new_max_velocity == initial_max_velocity:
+        print("This max. velocity value is already set.")
+        mc.communication.disconnect()
+        return
+    mc.configuration.set_max_velocity(new_max_velocity)
+
+    # Save the configuration with changes in a file
+    modified_config_path = "configuration_example.xcf"
+    mc.configuration.save_configuration(modified_config_path)
+    print("The configuration file is saved with the modification.")
+
+    # Load the initial configuration and check the max. velocity register has its initial value
+    mc.configuration.load_configuration(initial_config_path)
+    if mc.configuration.get_max_velocity() == initial_max_velocity:
+        print("Max. velocity register has the initial value.")
+
+    # Load the modified configuration and check the max. velocity value is changed again
+    mc.configuration.load_configuration(modified_config_path)
+    if mc.configuration.get_max_velocity() == new_max_velocity:
+        print("Max. velocity register has the new value.")
+
+    mc.communication.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/load_save_config_register_changes.py
+++ b/examples/load_save_config_register_changes.py
@@ -31,13 +31,17 @@ def main() -> None:
 
     # Load the initial configuration and check the max. velocity register has its initial value
     mc.configuration.load_configuration(initial_config_path)
-    if mc.configuration.get_max_velocity() == initial_max_velocity:
-        print("Max. velocity register has the initial value.")
+    print(
+        f"Max. velocity register should be set to its initial value ({initial_max_velocity}). "
+        f"Current value: {mc.configuration.get_max_velocity()}"
+    )
 
     # Load the modified configuration and check the max. velocity value is changed again
     mc.configuration.load_configuration(modified_config_path)
-    if mc.configuration.get_max_velocity() == new_max_velocity:
-        print("Max. velocity register has the new value.")
+    print(
+        f"Max. velocity register should now be set to the new value ({new_max_velocity}). "
+        f"Current value: {mc.configuration.get_max_velocity()}"
+    )
 
     mc.communication.disconnect()
 

--- a/examples/load_save_configuration.py
+++ b/examples/load_save_configuration.py
@@ -1,0 +1,45 @@
+from ingeniamotion import MotionController
+
+def main() -> None:
+    mc = MotionController()
+    # Modify these parameters to connect a drive
+    interface_index = 3
+    slave_id = 1
+    dictionary_path = "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+    mc.communication.connect_servo_ethercat_interface_index(
+        interface_index, slave_id, dictionary_path
+    )
+    # Save the initial configuration of your drive in a file
+    initial_config_path = "initial_configuration.xcf"
+    mc.configuration.save_configuration(initial_config_path)
+    
+    # Get the initial max. velocity and set it with a new value
+    new_max_velocity = 20.0
+    initial_max_velocity = mc.configuration.get_max_velocity()
+    if new_max_velocity == initial_max_velocity:
+        print("This max. velocity value is already set.")
+        mc.communication.disconnect()
+        return
+    mc.configuration.set_max_velocity(new_max_velocity)
+   
+    # Save the configuration with changes in a file
+    modified_config_path = "configuration_example.xcf"
+    mc.configuration.save_configuration(modified_config_path)
+    print("The configuration file is saved.")
+    
+    # Load the initial configuration and check the max. velocity register has its initial value
+    mc.configuration.load_configuration(initial_config_path)
+    if mc.configuration.get_max_velocity() == initial_max_velocity:
+        print("Max. velocity register has the initial value.")
+    
+    # Load the modified configuration and check the max. velocity value is changed again
+    mc.configuration.load_configuration(modified_config_path)
+    if mc.configuration.get_max_velocity() == new_max_velocity:
+        print("Max. velocity register has the new value.")
+
+    mc.communication.disconnect()
+    print("The drive has been disconnected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/load_save_configuration.py
+++ b/examples/load_save_configuration.py
@@ -6,9 +6,7 @@ def main() -> None:
     # Modify these parameters to connect a drive
     interface_index = 3
     slave_id = 1
-    dictionary_path = (
-        "parent_directory/dictionary_file.xdf"
-    )
+    dictionary_path = "parent_directory/dictionary_file.xdf"
     mc.communication.connect_servo_ethercat_interface_index(
         interface_index, slave_id, dictionary_path
     )

--- a/examples/load_save_configuration.py
+++ b/examples/load_save_configuration.py
@@ -12,6 +12,7 @@ def main() -> None:
     # Save the initial configuration of your drive in a file
     initial_config_path = "initial_configuration.xcf"
     mc.configuration.save_configuration(initial_config_path)
+    print("The initial configuration is saved.")
     
     # Get the initial max. velocity and set it with a new value
     new_max_velocity = 20.0
@@ -25,7 +26,7 @@ def main() -> None:
     # Save the configuration with changes in a file
     modified_config_path = "configuration_example.xcf"
     mc.configuration.save_configuration(modified_config_path)
-    print("The configuration file is saved.")
+    print("The configuration file is saved with the modification.")
     
     # Load the initial configuration and check the max. velocity register has its initial value
     mc.configuration.load_configuration(initial_config_path)
@@ -38,7 +39,6 @@ def main() -> None:
         print("Max. velocity register has the new value.")
 
     mc.communication.disconnect()
-    print("The drive has been disconnected.")
 
 
 if __name__ == "__main__":

--- a/examples/load_save_configuration.py
+++ b/examples/load_save_configuration.py
@@ -1,11 +1,14 @@
 from ingeniamotion import MotionController
 
+
 def main() -> None:
     mc = MotionController()
     # Modify these parameters to connect a drive
     interface_index = 3
     slave_id = 1
-    dictionary_path = "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+    dictionary_path = (
+        "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+    )
     mc.communication.connect_servo_ethercat_interface_index(
         interface_index, slave_id, dictionary_path
     )
@@ -13,7 +16,7 @@ def main() -> None:
     initial_config_path = "initial_configuration.xcf"
     mc.configuration.save_configuration(initial_config_path)
     print("The initial configuration is saved.")
-    
+
     # Get the initial max. velocity and set it with a new value
     new_max_velocity = 20.0
     initial_max_velocity = mc.configuration.get_max_velocity()
@@ -22,17 +25,17 @@ def main() -> None:
         mc.communication.disconnect()
         return
     mc.configuration.set_max_velocity(new_max_velocity)
-   
+
     # Save the configuration with changes in a file
     modified_config_path = "configuration_example.xcf"
     mc.configuration.save_configuration(modified_config_path)
     print("The configuration file is saved with the modification.")
-    
+
     # Load the initial configuration and check the max. velocity register has its initial value
     mc.configuration.load_configuration(initial_config_path)
     if mc.configuration.get_max_velocity() == initial_max_velocity:
         print("Max. velocity register has the initial value.")
-    
+
     # Load the modified configuration and check the max. velocity value is changed again
     mc.configuration.load_configuration(modified_config_path)
     if mc.configuration.get_max_velocity() == new_max_velocity:

--- a/examples/load_save_configuration.py
+++ b/examples/load_save_configuration.py
@@ -7,39 +7,18 @@ def main() -> None:
     interface_index = 3
     slave_id = 1
     dictionary_path = (
-        "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+        "parent_directory/dictionary_file.xdf"
     )
     mc.communication.connect_servo_ethercat_interface_index(
         interface_index, slave_id, dictionary_path
     )
-    # Save the initial configuration of your drive in a file
-    initial_config_path = "initial_configuration.xcf"
-    mc.configuration.save_configuration(initial_config_path)
-    print("The initial configuration is saved.")
+    # Save the configuration of your drive in a file
+    config_path = "configuration.xcf"
+    mc.configuration.save_configuration(config_path)
+    print("The configuration is saved.")
 
-    # Get the initial max. velocity and set it with a new value
-    new_max_velocity = 20.0
-    initial_max_velocity = mc.configuration.get_max_velocity()
-    if new_max_velocity == initial_max_velocity:
-        print("This max. velocity value is already set.")
-        mc.communication.disconnect()
-        return
-    mc.configuration.set_max_velocity(new_max_velocity)
-
-    # Save the configuration with changes in a file
-    modified_config_path = "configuration_example.xcf"
-    mc.configuration.save_configuration(modified_config_path)
-    print("The configuration file is saved with the modification.")
-
-    # Load the initial configuration and check the max. velocity register has its initial value
-    mc.configuration.load_configuration(initial_config_path)
-    if mc.configuration.get_max_velocity() == initial_max_velocity:
-        print("Max. velocity register has the initial value.")
-
-    # Load the modified configuration and check the max. velocity value is changed again
-    mc.configuration.load_configuration(modified_config_path)
-    if mc.configuration.get_max_velocity() == new_max_velocity:
-        print("Max. velocity register has the new value.")
+    # Load the configuration file made previously
+    mc.configuration.load_configuration(config_path)
 
     mc.communication.disconnect()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -332,7 +332,8 @@ def test_load_save_configuration_register_changes_success(mocker, capsys):
     mocker.patch.object(Communication, "disconnect")
     mocker.patch.object(Configuration, "save_configuration")
     mocker.patch.object(Configuration, "load_configuration")
-    mocker.patch.object(Configuration, "get_max_velocity", side_effect=[10.0, 10.0, 20.0])
+    test_velocities = [10.0, 10.0, 20.0]
+    mocker.patch.object(Configuration, "get_max_velocity", side_effect=test_velocities)
     mocker.patch.object(Configuration, "set_max_velocity")
 
     main_load_save_config_register_changes()
@@ -342,8 +343,16 @@ def test_load_save_configuration_register_changes_success(mocker, capsys):
 
     assert all_outputs[0] == "The initial configuration is saved."
     assert all_outputs[1] == "The configuration file is saved with the modification."
-    assert all_outputs[2] == "Max. velocity register has the initial value."
-    assert all_outputs[3] == "Max. velocity register has the new value."
+    assert (
+        all_outputs[2]
+        == f"Max. velocity register should be set to its initial value ({test_velocities[1]}). "
+        f"Current value: {test_velocities[1]}"
+    )
+    assert (
+        all_outputs[3]
+        == f"Max. velocity register should now be set to the new value ({test_velocities[2]}). "
+        f"Current value: {test_velocities[2]}"
+    )
 
 
 @pytest.mark.virtual

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -4,7 +4,9 @@ from ingenialink.exceptions import ILFirmwareLoadError
 
 from examples.load_fw_canopen import load_firmware_canopen
 from examples.load_save_configuration import main as main_load_save_configuration
-from examples.load_save_config_register_changes import main as main_load_save_config_register_changes
+from examples.load_save_config_register_changes import (
+    main as main_load_save_config_register_changes,
+)
 from ingeniamotion import MotionController
 from ingeniamotion.communication import Communication
 from ingeniamotion.configuration import Configuration
@@ -309,7 +311,9 @@ def test_can_bootloader_example_failed(mocker, capsys):
 
 @pytest.mark.virtual
 def test_load_save_configuration(mocker):
-    connect_servo_ethercat_interface_index = mocker.patch.object(Communication, "connect_servo_ethercat_interface_index")
+    connect_servo_ethercat_interface_index = mocker.patch.object(
+        Communication, "connect_servo_ethercat_interface_index"
+    )
     disconnect = mocker.patch.object(Communication, "disconnect")
     save_configuration = mocker.patch.object(Configuration, "save_configuration")
     load_configuration = mocker.patch.object(Configuration, "load_configuration")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -4,6 +4,7 @@ from ingenialink.exceptions import ILFirmwareLoadError
 
 from examples.load_fw_canopen import load_firmware_canopen
 from examples.load_save_configuration import main as main_load_save_configuration
+from examples.load_save_config_register_changes import main as main_load_save_config_register_changes
 from ingeniamotion import MotionController
 from ingeniamotion.communication import Communication
 from ingeniamotion.configuration import Configuration
@@ -307,7 +308,22 @@ def test_can_bootloader_example_failed(mocker, capsys):
 
 
 @pytest.mark.virtual
-def test_load_save_configuration_success(mocker, capsys):
+def test_load_save_configuration(mocker):
+    connect_servo_ethercat_interface_index = mocker.patch.object(Communication, "connect_servo_ethercat_interface_index")
+    disconnect = mocker.patch.object(Communication, "disconnect")
+    save_configuration = mocker.patch.object(Configuration, "save_configuration")
+    load_configuration = mocker.patch.object(Configuration, "load_configuration")
+
+    main_load_save_configuration()
+
+    connect_servo_ethercat_interface_index.assert_called_once()
+    save_configuration.assert_called_once()
+    load_configuration.assert_called_once()
+    disconnect.assert_called_once()
+
+
+@pytest.mark.virtual
+def test_load_save_configuration_register_changes_success(mocker, capsys):
     mocker.patch.object(Communication, "connect_servo_ethercat_interface_index")
     mocker.patch.object(Communication, "disconnect")
     mocker.patch.object(Configuration, "save_configuration")
@@ -315,7 +331,7 @@ def test_load_save_configuration_success(mocker, capsys):
     mocker.patch.object(Configuration, "get_max_velocity", side_effect=[10.0, 10.0, 20.0])
     mocker.patch.object(Configuration, "set_max_velocity")
 
-    main_load_save_configuration()
+    main_load_save_config_register_changes()
 
     captured_outputs = capsys.readouterr()
     all_outputs = captured_outputs.out.split("\n")
@@ -327,7 +343,7 @@ def test_load_save_configuration_success(mocker, capsys):
 
 
 @pytest.mark.virtual
-def test_load_save_configuration_failed(mocker, capsys):
+def test_load_save_configuration_register_changes_failed(mocker, capsys):
     mocker.patch.object(Communication, "connect_servo_ethercat_interface_index")
     mocker.patch.object(Communication, "disconnect")
     mocker.patch.object(Configuration, "save_configuration")
@@ -335,7 +351,7 @@ def test_load_save_configuration_failed(mocker, capsys):
     mocker.patch.object(Configuration, "get_max_velocity", return_value=20.0)
     mocker.patch.object(Configuration, "set_max_velocity")
 
-    main_load_save_configuration()
+    main_load_save_config_register_changes()
 
     captured_outputs = capsys.readouterr()
     all_outputs = captured_outputs.out.split("\n")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -324,3 +324,22 @@ def test_load_save_configuration_success(mocker, capsys):
     assert all_outputs[1] == "The configuration file is saved with the modification."
     assert all_outputs[2] == "Max. velocity register has the initial value."
     assert all_outputs[3] == "Max. velocity register has the new value."
+
+
+@pytest.mark.virtual
+def test_load_save_configuration_failed(mocker, capsys):
+    mocker.patch.object(Communication, "connect_servo_ethercat_interface_index")
+    mocker.patch.object(Communication, "disconnect")
+    mocker.patch.object(Configuration, "save_configuration")
+    mocker.patch.object(Configuration, "load_configuration")
+    mocker.patch.object(Configuration, "get_max_velocity", return_value = 20.0)
+    mocker.patch.object(Configuration, "set_max_velocity")
+
+    main_load_save_configuration()
+
+    captured_outputs = capsys.readouterr()
+    all_outputs = captured_outputs.out.split("\n")
+
+    assert all_outputs[0] == "The initial configuration is saved."
+    assert all_outputs[1] == "This max. velocity value is already set."
+    

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,5 @@
-from ingenialink import CAN_BAUDRATE, CAN_DEVICE
 import pytest
+from ingenialink import CAN_BAUDRATE, CAN_DEVICE
 from ingenialink.exceptions import ILFirmwareLoadError
 
 from examples.load_fw_canopen import load_firmware_canopen
@@ -312,7 +312,7 @@ def test_load_save_configuration_success(mocker, capsys):
     mocker.patch.object(Communication, "disconnect")
     mocker.patch.object(Configuration, "save_configuration")
     mocker.patch.object(Configuration, "load_configuration")
-    mocker.patch.object(Configuration, "get_max_velocity", side_effect = [10.0, 10.0, 20.0])
+    mocker.patch.object(Configuration, "get_max_velocity", side_effect=[10.0, 10.0, 20.0])
     mocker.patch.object(Configuration, "set_max_velocity")
 
     main_load_save_configuration()
@@ -332,7 +332,7 @@ def test_load_save_configuration_failed(mocker, capsys):
     mocker.patch.object(Communication, "disconnect")
     mocker.patch.object(Configuration, "save_configuration")
     mocker.patch.object(Configuration, "load_configuration")
-    mocker.patch.object(Configuration, "get_max_velocity", return_value = 20.0)
+    mocker.patch.object(Configuration, "get_max_velocity", return_value=20.0)
     mocker.patch.object(Configuration, "set_max_velocity")
 
     main_load_save_configuration()
@@ -342,4 +342,3 @@ def test_load_save_configuration_failed(mocker, capsys):
 
     assert all_outputs[0] == "The initial configuration is saved."
     assert all_outputs[1] == "This max. velocity value is already set."
-    

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,7 +3,10 @@ import pytest
 from ingenialink.exceptions import ILFirmwareLoadError
 
 from examples.load_fw_canopen import load_firmware_canopen
+from examples.load_save_configuration import main as main_load_save_configuration
 from ingeniamotion import MotionController
+from ingeniamotion.communication import Communication
+from ingeniamotion.configuration import Configuration
 from ingeniamotion.enums import SeverityLevel
 
 
@@ -301,3 +304,23 @@ def test_can_bootloader_example_failed(mocker, capsys):
     assert all_outputs[3] == "Starts to load the firmware."
     assert all_outputs[4] == f"Firmware loading failed: {fw_error_message}"
     assert all_outputs[5] == "Drive is disconnected."
+
+
+@pytest.mark.virtual
+def test_load_save_configuration_success(mocker, capsys):
+    mocker.patch.object(Communication, "connect_servo_ethercat_interface_index")
+    mocker.patch.object(Communication, "disconnect")
+    mocker.patch.object(Configuration, "save_configuration")
+    mocker.patch.object(Configuration, "load_configuration")
+    mocker.patch.object(Configuration, "get_max_velocity", side_effect = [10.0, 10.0, 20.0])
+    mocker.patch.object(Configuration, "set_max_velocity")
+
+    main_load_save_configuration()
+
+    captured_outputs = capsys.readouterr()
+    all_outputs = captured_outputs.out.split("\n")
+
+    assert all_outputs[0] == "The initial configuration is saved."
+    assert all_outputs[1] == "The configuration file is saved with the modification."
+    assert all_outputs[2] == "Max. velocity register has the initial value."
+    assert all_outputs[3] == "Max. velocity register has the new value."


### PR DESCRIPTION
### Load and Save configuration example

### Description

The example load and save a configuration, and checks how it affects to Max. Velocity register value.

Fixes # INGM-408

### Type of change

- [x] Basic Load/Save configuration example
- [x] Load/Save configuration with register changes example

### Tests
- [x] Run basic Load/Save configuration example.
- [x] Run Load/Save configuration with register changes example successfully.
- [x] Run Load/Save configuration with register changes example failed.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.