### PR TITLE
INGM-410: make new example about perform a commutation with different encoders

### DIFF
--- a/docs/examples/drive_tests.rst
+++ b/docs/examples/drive_tests.rst
@@ -10,3 +10,8 @@ Commutation example
 -------------------
 
 .. literalinclude:: ../../examples/commutation_test.py
+
+Commutation with different feedbacks configurations examples
+------------------------------------------------------------
+
+.. literalinclude:: ../../examples/commutation_test_encoders.py

--- a/examples/commutation_test.py
+++ b/examples/commutation_test.py
@@ -1,77 +1,31 @@
+import logging
+import argparse
 from ingeniamotion import MotionController
-from ingeniamotion.enums import SensorType
 
 
-def use_only_incremental_encoders(mc: MotionController):
-    """All feedbacks are using an Incremental encoder.
-
-    Args:
-        mc: Controller to configure the type of encoder for each feedback
-
-    """
-    mc.configuration.set_auxiliar_feedback(SensorType.QEI)
-    mc.configuration.set_commutation_feedback(SensorType.QEI)
-    mc.configuration.set_position_feedback(SensorType.QEI)
-    mc.configuration.set_velocity_feedback(SensorType.QEI)
-    mc.configuration.set_reference_feedback(SensorType.QEI)
+def setup_command():
+    parser = argparse.ArgumentParser(description='Run commutation test')
+    parser.add_argument('dictionary_path', help='path to drive dictionary')
+    parser.add_argument('-ip', default="192.168.2.22", help='drive ip address')
+    parser.add_argument('--axis', default=1, help='drive axis')
+    parser.add_argument('--debug', action='store_true',
+                        help="with this flag test doesn't apply any change")
+    return parser.parse_args()
 
 
-def use_only_absolute_encoders(mc: MotionController):
-    """All feedbacks are using an Absolute encoder.
-
-    Args:
-        mc: Controller to configure the type of encoder for each feedback
-
-    """
-    mc.configuration.set_auxiliar_feedback(SensorType.ABS1)
-    mc.configuration.set_commutation_feedback(SensorType.ABS1)
-    mc.configuration.set_position_feedback(SensorType.ABS1)
-    mc.configuration.set_velocity_feedback(SensorType.ABS1)
-    mc.configuration.set_reference_feedback(SensorType.ABS1)
-
-
-def use_incremental_encoders_and_digital_halls(mc: MotionController):
-    """All feedbacks are using an incremental encoder and a digital halls.
-
-    Args:
-        mc: Controller to configure the type of encoder for each feedback
-
-    """
-    mc.configuration.set_auxiliar_feedback(SensorType.HALLS)
-    mc.configuration.set_commutation_feedback(SensorType.QEI)
-    mc.configuration.set_position_feedback(SensorType.HALLS)
-    mc.configuration.set_velocity_feedback(SensorType.QEI)
-    mc.configuration.set_reference_feedback(SensorType.QEI)
-
-
-def main() -> None:
+def main(args):
+    # Create MotionController instance
     mc = MotionController()
-
-    interface_index = 3
-    slave_id = 1
-    dictionary_path = (
-        "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
-    )
-    mc.communication.connect_servo_ethercat_interface_index(
-        interface_index, slave_id, dictionary_path
-    )
-
-    # Feedbacks configuration:
-    # Indicate the type of encoder you are using for each feedback
-    # There are some examples of feedbacks configuration below.
-    # Uncomment the configuration you want to try:
-    # -------------------------------------------------------------
-    # use_only_incremental_encoders(mc)
-    # use_only_absolute_encoders(mc)
-    use_incremental_encoders_and_digital_halls(mc)
-    # -------------------------------------------------------------
-
+    # Connect Servo with MotionController instance
+    mc.communication.connect_servo_eoe(args.ip, args.dictionary_path)
     # Run Commutation test
-    result = mc.tests.commutation()
-    print(f"Commutation Result: {result['result_message']}")
-
+    result = mc.tests.commutation(axis=args.axis,
+                                  apply_changes=not args.debug)
+    logging.info(result["result_message"])
     mc.communication.disconnect()
 
 
-if __name__ == "__main__":
-    main()
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    args = setup_command()
+    main(args)

--- a/examples/commutation_test.py
+++ b/examples/commutation_test.py
@@ -2,9 +2,51 @@ from ingeniamotion import MotionController
 from ingeniamotion.enums import SensorType
 
 
+def use_only_incremental_encoders(mc: MotionController):
+    """All feedbacks are using an Incremental encoder.
+
+    Args:
+        mc: Controller to configure the type of encoder for each feedback
+
+    """
+    mc.configuration.set_auxiliar_feedback(SensorType.QEI)
+    mc.configuration.set_commutation_feedback(SensorType.QEI)
+    mc.configuration.set_position_feedback(SensorType.QEI)
+    mc.configuration.set_velocity_feedback(SensorType.QEI)
+    mc.configuration.set_reference_feedback(SensorType.QEI)
+
+
+def use_only_absolute_encoders(mc: MotionController):
+    """All feedbacks are using an Absolute encoder.
+
+    Args:
+        mc: Controller to configure the type of encoder for each feedback
+
+    """
+    mc.configuration.set_auxiliar_feedback(SensorType.ABS1)
+    mc.configuration.set_commutation_feedback(SensorType.ABS1)
+    mc.configuration.set_position_feedback(SensorType.ABS1)
+    mc.configuration.set_velocity_feedback(SensorType.ABS1)
+    mc.configuration.set_reference_feedback(SensorType.ABS1)
+
+
+def use_incremental_encoders_and_digital_halls(mc: MotionController):
+    """All feedbacks are using an incremental encoder and a digital halls.
+
+    Args:
+        mc: Controller to configure the type of encoder for each feedback
+
+    """
+    mc.configuration.set_auxiliar_feedback(SensorType.HALLS)
+    mc.configuration.set_commutation_feedback(SensorType.QEI)
+    mc.configuration.set_position_feedback(SensorType.HALLS)
+    mc.configuration.set_velocity_feedback(SensorType.QEI)
+    mc.configuration.set_reference_feedback(SensorType.QEI)
+
+
 def main() -> None:
     mc = MotionController()
-    
+
     interface_index = 3
     slave_id = 1
     dictionary_path = (
@@ -13,26 +55,23 @@ def main() -> None:
     mc.communication.connect_servo_ethercat_interface_index(
         interface_index, slave_id, dictionary_path
     )
-    
-    # Encoder configuration
-    # If you are using only one encoder (e.g.: Incremental Encoder), set the type of sensors
-    # using the sensor_type variable below.
-    # If you are using more than one encoder (e.g.: Inc. Enc. and Abs. Enc.), set the type of 
-    # sensors one by one.
-    sensor_type = SensorType.QEI 
-    mc.configuration.set_auxiliar_feedback(sensor_type)
-    mc.configuration.set_commutation_feedback(sensor_type)
-    mc.configuration.set_position_feedback(sensor_type)
-    mc.configuration.set_velocity_feedback(sensor_type)
-    mc.configuration.set_reference_feedback(sensor_type)
-    
+
+    # Feedbacks configuration:
+    # Indicate the type of encoder you are using for each feedback
+    # There are some examples of feedbacks configuration below.
+    # Uncomment the configuration you want to try:
+    # -------------------------------------------------------------
+    # use_only_incremental_encoders(mc)
+    # use_only_absolute_encoders(mc)
+    use_incremental_encoders_and_digital_halls(mc)
+    # -------------------------------------------------------------
+
     # Run Commutation test
     result = mc.tests.commutation()
-    print(result["result_message"])
+    print(f"Commutation Result: {result['result_message']}")
 
     mc.communication.disconnect()
 
 
 if __name__ == "__main__":
-    # Before executing this example, make sure your motor is calibrated.
     main()

--- a/examples/commutation_test.py
+++ b/examples/commutation_test.py
@@ -1,31 +1,38 @@
-import logging
-import argparse
 from ingeniamotion import MotionController
+from ingeniamotion.enums import SensorType
 
 
-def setup_command():
-    parser = argparse.ArgumentParser(description='Run commutation test')
-    parser.add_argument('dictionary_path', help='path to drive dictionary')
-    parser.add_argument('-ip', default="192.168.2.22", help='drive ip address')
-    parser.add_argument('--axis', default=1, help='drive axis')
-    parser.add_argument('--debug', action='store_true',
-                        help="with this flag test doesn't apply any change")
-    return parser.parse_args()
-
-
-def main(args):
-    # Create MotionController instance
+def main() -> None:
     mc = MotionController()
-    # Connect Servo with MotionController instance
-    mc.communication.connect_servo_eoe(args.ip, args.dictionary_path)
+    
+    interface_index = 3
+    slave_id = 1
+    dictionary_path = (
+        "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+    )
+    mc.communication.connect_servo_ethercat_interface_index(
+        interface_index, slave_id, dictionary_path
+    )
+    
+    # Encoder configuration
+    # If you are using only one encoder (e.g.: Incremental Encoder), set the type of sensors
+    # using the sensor_type variable below.
+    # If you are using more than one encoder (e.g.: Inc. Enc. and Abs. Enc.), set the type of 
+    # sensors one by one.
+    sensor_type = SensorType.QEI 
+    mc.configuration.set_auxiliar_feedback(sensor_type)
+    mc.configuration.set_commutation_feedback(sensor_type)
+    mc.configuration.set_position_feedback(sensor_type)
+    mc.configuration.set_velocity_feedback(sensor_type)
+    mc.configuration.set_reference_feedback(sensor_type)
+    
     # Run Commutation test
-    result = mc.tests.commutation(axis=args.axis,
-                                  apply_changes=not args.debug)
-    logging.info(result["result_message"])
+    result = mc.tests.commutation()
+    print(result["result_message"])
+
     mc.communication.disconnect()
 
 
-if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
-    args = setup_command()
-    main(args)
+if __name__ == "__main__":
+    # Before executing this example, make sure your motor is calibrated.
+    main()

--- a/examples/commutation_test_encoders.py
+++ b/examples/commutation_test_encoders.py
@@ -1,0 +1,77 @@
+from ingeniamotion import MotionController
+from ingeniamotion.enums import SensorType
+
+
+def use_only_incremental_encoders(mc: MotionController):
+    """All feedbacks are using an Incremental encoder.
+
+    Args:
+        mc: Controller to configure the type of encoder for each feedback
+
+    """
+    mc.configuration.set_auxiliar_feedback(SensorType.QEI)
+    mc.configuration.set_commutation_feedback(SensorType.QEI)
+    mc.configuration.set_position_feedback(SensorType.QEI)
+    mc.configuration.set_velocity_feedback(SensorType.QEI)
+    mc.configuration.set_reference_feedback(SensorType.QEI)
+
+
+def use_only_absolute_encoders(mc: MotionController):
+    """All feedbacks are using an Absolute encoder.
+
+    Args:
+        mc: Controller to configure the type of encoder for each feedback
+
+    """
+    mc.configuration.set_auxiliar_feedback(SensorType.ABS1)
+    mc.configuration.set_commutation_feedback(SensorType.ABS1)
+    mc.configuration.set_position_feedback(SensorType.ABS1)
+    mc.configuration.set_velocity_feedback(SensorType.ABS1)
+    mc.configuration.set_reference_feedback(SensorType.ABS1)
+
+
+def use_incremental_encoders_and_digital_halls(mc: MotionController):
+    """All feedbacks are using an incremental encoder and a digital halls.
+
+    Args:
+        mc: Controller to configure the type of encoder for each feedback
+
+    """
+    mc.configuration.set_auxiliar_feedback(SensorType.HALLS)
+    mc.configuration.set_commutation_feedback(SensorType.QEI)
+    mc.configuration.set_position_feedback(SensorType.HALLS)
+    mc.configuration.set_velocity_feedback(SensorType.QEI)
+    mc.configuration.set_reference_feedback(SensorType.QEI)
+
+
+def main() -> None:
+    mc = MotionController()
+
+    interface_index = 3
+    slave_id = 1
+    dictionary_path = (
+        "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+    )
+    mc.communication.connect_servo_ethercat_interface_index(
+        interface_index, slave_id, dictionary_path
+    )
+
+    # Feedbacks configuration:
+    # Indicate the type of encoder you are using for each feedback
+    # There are some examples of feedbacks configuration below.
+    # Uncomment the configuration you want to try:
+    # -------------------------------------------------------------
+    # use_only_incremental_encoders(mc)
+    # use_only_absolute_encoders(mc)
+    use_incremental_encoders_and_digital_halls(mc)
+    # -------------------------------------------------------------
+
+    # Run Commutation test
+    result = mc.tests.commutation()
+    print(f"Commutation Result: {result['result_message']}")
+
+    mc.communication.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/commutation_test_encoders.py
+++ b/examples/commutation_test_encoders.py
@@ -50,7 +50,7 @@ def main() -> None:
     interface_index = 3
     slave_id = 1
     dictionary_path = (
-        "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+        "test_directory/dictionary_file.xdf"
     )
     mc.communication.connect_servo_ethercat_interface_index(
         interface_index, slave_id, dictionary_path
@@ -68,7 +68,7 @@ def main() -> None:
 
     # Run Commutation test
     result = mc.tests.commutation()
-    print(f"Commutation Result: {result['result_message']}")
+    print(f"Commutation Result: {result['result_message']} - {result['result_severity']}")
 
     mc.communication.disconnect()
 

--- a/examples/commutation_test_encoders.py
+++ b/examples/commutation_test_encoders.py
@@ -8,7 +8,7 @@ def set_feedbacks(mc: MotionController):
     All feedbacks can be set either the same encoder or different encoders.
     In this example we are using an Incremental Encoder (SensorType.QEI) and
     a Digital Halls (SensorType.HALLS).
-    
+
     Args:
         mc: Controller to configure the type of encoder for each feedback
 
@@ -25,12 +25,8 @@ def main() -> None:
 
     interface_ip = "192.168.2.1"
     slave_id = 1
-    dictionary_path = (
-        "test_directory/dictionary_file.xdf"
-    )
-    mc.communication.connect_servo_ethercat_interface_ip(
-        interface_ip, slave_id, dictionary_path
-    )
+    dictionary_path = "test_directory/dictionary_file.xdf"
+    mc.communication.connect_servo_ethercat_interface_ip(interface_ip, slave_id, dictionary_path)
 
     set_feedbacks(mc)
     # -------------------------------------------------------------

--- a/examples/commutation_test_encoders.py
+++ b/examples/commutation_test_encoders.py
@@ -2,37 +2,13 @@ from ingeniamotion import MotionController
 from ingeniamotion.enums import SensorType
 
 
-def use_only_incremental_encoders(mc: MotionController):
-    """All feedbacks are using an Incremental encoder.
+def set_feedbacks(mc: MotionController):
+    """Feedbacks configuration.
 
-    Args:
-        mc: Controller to configure the type of encoder for each feedback
-
-    """
-    mc.configuration.set_auxiliar_feedback(SensorType.QEI)
-    mc.configuration.set_commutation_feedback(SensorType.QEI)
-    mc.configuration.set_position_feedback(SensorType.QEI)
-    mc.configuration.set_velocity_feedback(SensorType.QEI)
-    mc.configuration.set_reference_feedback(SensorType.QEI)
-
-
-def use_only_absolute_encoders(mc: MotionController):
-    """All feedbacks are using an Absolute encoder.
-
-    Args:
-        mc: Controller to configure the type of encoder for each feedback
-
-    """
-    mc.configuration.set_auxiliar_feedback(SensorType.ABS1)
-    mc.configuration.set_commutation_feedback(SensorType.ABS1)
-    mc.configuration.set_position_feedback(SensorType.ABS1)
-    mc.configuration.set_velocity_feedback(SensorType.ABS1)
-    mc.configuration.set_reference_feedback(SensorType.ABS1)
-
-
-def use_incremental_encoders_and_digital_halls(mc: MotionController):
-    """All feedbacks are using an incremental encoder and a digital halls.
-
+    All feedbacks can be set either the same encoder or different encoders.
+    In this example we are using an Incremental Encoder (SensorType.QEI) and
+    a Digital Halls (SensorType.HALLS).
+    
     Args:
         mc: Controller to configure the type of encoder for each feedback
 
@@ -47,23 +23,16 @@ def use_incremental_encoders_and_digital_halls(mc: MotionController):
 def main() -> None:
     mc = MotionController()
 
-    interface_index = 3
+    interface_ip = "192.168.2.1"
     slave_id = 1
     dictionary_path = (
         "test_directory/dictionary_file.xdf"
     )
-    mc.communication.connect_servo_ethercat_interface_index(
-        interface_index, slave_id, dictionary_path
+    mc.communication.connect_servo_ethercat_interface_ip(
+        interface_ip, slave_id, dictionary_path
     )
 
-    # Feedbacks configuration:
-    # Indicate the type of encoder you are using for each feedback
-    # There are some examples of feedbacks configuration below.
-    # Uncomment the configuration you want to try:
-    # -------------------------------------------------------------
-    # use_only_incremental_encoders(mc)
-    # use_only_absolute_encoders(mc)
-    use_incremental_encoders_and_digital_halls(mc)
+    set_feedbacks(mc)
     # -------------------------------------------------------------
 
     # Run Commutation test

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -309,8 +309,8 @@ def test_can_bootloader_example_failed(mocker, capsys):
 
 @pytest.mark.virtual
 def test_commutation_test(mocker):
-    connect_servo_ethercat_interface_index = mocker.patch.object(
-        Communication, "connect_servo_ethercat_interface_index"
+    connect_servo_ethercat_interface_ip = mocker.patch.object(
+        Communication, "connect_servo_ethercat_interface_ip"
     )
     disconnect = mocker.patch.object(Communication, "disconnect")
     set_auxiliar_feedback = mocker.patch.object(Configuration, "set_auxiliar_feedback")
@@ -329,7 +329,7 @@ def test_commutation_test(mocker):
 
     main_commutation_test_encoders()
 
-    connect_servo_ethercat_interface_index.assert_called_once()
+    connect_servo_ethercat_interface_ip.assert_called_once()
     set_auxiliar_feedback.assert_called_once()
     set_commutation_feedback.assert_called_once()
     set_position_feedback.assert_called_once()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,7 +3,7 @@ import pytest
 from ingenialink.exceptions import ILFirmwareLoadError
 
 from examples.load_fw_canopen import load_firmware_canopen
-from examples.commutation_test import main as main_commutation_test
+from examples.commutation_test_encoders import main as main_commutation_test_encoders
 from ingeniamotion import MotionController
 from ingeniamotion.communication import Communication
 from ingeniamotion.configuration import Configuration
@@ -322,7 +322,7 @@ def test_commutation_test(mocker):
         DriveTests, "commutation", return_value={"result_message": "Commutation is called"}
     )
 
-    main_commutation_test()
+    main_commutation_test_encoders()
 
     connect_servo_ethercat_interface_index.assert_called_once()
     set_auxiliar_feedback.assert_called_once()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -319,7 +319,12 @@ def test_commutation_test(mocker):
     set_velocity_feedback = mocker.patch.object(Configuration, "set_velocity_feedback")
     set_reference_feedback = mocker.patch.object(Configuration, "set_reference_feedback")
     commutation_test = mocker.patch.object(
-        DriveTests, "commutation", return_value={"result_message": "Commutation is called"}
+        DriveTests,
+        "commutation",
+        return_value={
+            "result_message": "Commutation is called",
+            "result_severity": SeverityLevel.SUCCESS,
+        },
     )
 
     main_commutation_test_encoders()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,7 +3,11 @@ import pytest
 from ingenialink.exceptions import ILFirmwareLoadError
 
 from examples.load_fw_canopen import load_firmware_canopen
+from examples.commutation_test import main as main_commutation_test
 from ingeniamotion import MotionController
+from ingeniamotion.communication import Communication
+from ingeniamotion.configuration import Configuration
+from ingeniamotion.drive_tests import DriveTests
 from ingeniamotion.enums import SeverityLevel
 
 
@@ -301,3 +305,30 @@ def test_can_bootloader_example_failed(mocker, capsys):
     assert all_outputs[3] == "Starts to load the firmware."
     assert all_outputs[4] == f"Firmware loading failed: {fw_error_message}"
     assert all_outputs[5] == "Drive is disconnected."
+
+
+@pytest.mark.virtual
+def test_commutation_test(mocker):
+    connect_servo_ethercat_interface_index = mocker.patch.object(
+        Communication, "connect_servo_ethercat_interface_index"
+    )
+    disconnect = mocker.patch.object(Communication, "disconnect")
+    set_auxiliar_feedback = mocker.patch.object(Configuration, "set_auxiliar_feedback")
+    set_commutation_feedback = mocker.patch.object(Configuration, "set_commutation_feedback")
+    set_position_feedback = mocker.patch.object(Configuration, "set_position_feedback")
+    set_velocity_feedback = mocker.patch.object(Configuration, "set_velocity_feedback")
+    set_reference_feedback = mocker.patch.object(Configuration, "set_reference_feedback")
+    commutation_test = mocker.patch.object(
+        DriveTests, "commutation", return_value={"result_message": "Commutation is called"}
+    )
+
+    main_commutation_test()
+
+    connect_servo_ethercat_interface_index.assert_called_once()
+    set_auxiliar_feedback.assert_called_once()
+    set_commutation_feedback.assert_called_once()
+    set_position_feedback.assert_called_once()
+    set_velocity_feedback.assert_called_once()
+    set_reference_feedback.assert_called_once()
+    commutation_test.assert_called_once()
+    disconnect.assert_called_once()


### PR DESCRIPTION
### Run a commutation test with different feedbacks configurations

### Description

The example steps:
1. ECAT connection.
2. Set a Feedbacks configuration below:
    - Only incremental encoders.
    - Only absolute encoders.
    - Incremental encoders and Digital Halls.
3. Run the commutation test.
4. Disconnection.

Fixes # INGM-410

### Type of change

Please add a description and delete options that are not relevant.

- [x] A new example about running a commutation with different feedbacks configurations.


### Tests
- [x] Unit test for running a commutation.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.