### PR TITLE
INGM-427: cyclic now are now enums instead of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - The get_subnodes method from the information module now returns a dictionary with the subnodes IDs as keys and their type as values.
 - Set the send_receive_processdata timeout in the ProcessDataThread according to the refresh rate.
+- Cyclic parameter is defined as a RegCyclicType variable instead of a string.
 
 ### Removed
 - The comkit module. Now ingenialink methods are use to merge the COM-KIT and CORE dictionaries.

--- a/ingeniamotion/disturbance.py
+++ b/ingeniamotion/disturbance.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import ingenialogger
 import numpy as np
-from ingenialink.enums.register import REG_DTYPE
+from ingenialink.enums.register import REG_DTYPE, RegCyclicType
 from ingenialink.exceptions import ILValueError
 from numpy import ndarray
 from numpy.typing import ArrayLike, NDArray
@@ -49,8 +49,6 @@ class Disturbance:
     DISTURBANCE_FREQUENCY_DIVIDER_REGISTER = "DIST_FREQ_DIV"
     DISTURBANCE_MAXIMUM_SAMPLE_SIZE_REGISTER = "DIST_MAX_SIZE"
     MONITORING_DISTURBANCE_STATUS_REGISTER = "MON_DIST_STATUS"
-
-    CYCLIC_RX = "CYCLIC_RX"
 
     DISTURBANCE_STATUS_ENABLED_BIT = 0x1000  # TODO: Not implemented yet
     MONITORING_STATUS_ENABLED_BIT = 0x1
@@ -157,7 +155,7 @@ class Disturbance:
             register_obj = self.mc.info.register_info(register, subnode, servo=self.servo)
             dtype = register_obj.dtype
             cyclic = register_obj.cyclic
-            if cyclic != self.CYCLIC_RX:
+            if cyclic != RegCyclicType.RX:
                 drive.disturbance_remove_all_mapped_registers()
                 raise IMDisturbanceError(
                     "{} can not be mapped as a disturbance register".format(register)

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -2,14 +2,26 @@ import threading
 import time
 from collections import deque
 from copy import deepcopy
-from typing import TYPE_CHECKING, Callable, Deque, Dict, List, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Deque,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 from ingenialink.canopen.network import CanopenNetwork
+from ingenialink.enums.register import RegCyclicType
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethercat.servo import EthercatServo
-from ingenialink.exceptions import ILError, ILStateError, ILWrongWorkingCount
+from ingenialink.exceptions import ILError, ILWrongWorkingCount
 from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
+
 from ingeniamotion.enums import COMMUNICATION_TYPE
 from ingeniamotion.exceptions import IMException
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
@@ -316,9 +328,9 @@ class PDONetworkManager:
             AttributeError: If an initial value is not provided for an RPDO register.
 
         """
-        pdo_map_item_dict: Dict[str, Type[Union[RPDOMapItem, TPDOMapItem]]] = {
-            "CYCLIC_RX": RPDOMapItem,
-            "CYCLIC_TX": TPDOMapItem,
+        pdo_map_item_dict: Dict[RegCyclicType, Type[Union[RPDOMapItem, TPDOMapItem]]] = {
+            RegCyclicType.RX: RPDOMapItem,
+            RegCyclicType.TX: TPDOMapItem,
         }
         drive = self.mc._get_drive(servo)
         register = drive.dictionary.registers(axis)[register_uid]


### PR DESCRIPTION
### Cyclic parameter is a RegCyclicType variable

### Description

It adapts changes that come from Ingenialink library.

Fixes # INGM-427

### Type of change

- [x] Cyclic parameter is converted from string to RegCyclicType variable.


### Tests
- [x] Add new unit tests if it applies.
- [x] Now test_write_disturbance_data_wrong_data_type from test_disturbance.py file works well.

### Documentation

Please update the documentation.

- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.