### PR TITLE
INGM-411: make new example about position

### DIFF
--- a/docs/examples/motion.rst
+++ b/docs/examples/motion.rst
@@ -5,3 +5,8 @@ Velocity and Torque ramp example
 --------------------------------
 
 .. literalinclude:: ../../examples/velocity_torque_ramp.py
+
+Position ramp example
+---------------------
+
+.. literalinclude:: ../../examples/position_ramp.py

--- a/examples/position_ramp.py
+++ b/examples/position_ramp.py
@@ -1,10 +1,5 @@
-import time
 from ingeniamotion import MotionController
 from ingeniamotion.enums import OperationMode
-from ingenialink.exceptions import ILError
-
-# Set your motor torque constant
-TORQUE_CONSTANT = 0.0376
 
 
 def position_ramp(final_position, mc: MotionController) -> None:
@@ -13,7 +8,7 @@ def position_ramp(final_position, mc: MotionController) -> None:
 
     Args:
         final_position: target position in counts.
-        mc: Controller with all the functions needed to perform a position ramp. 
+        mc: Controller with all the functions needed to perform a position ramp.
     """
     done = False
     mc.motion.move_to_position(final_position)
@@ -26,9 +21,11 @@ def main() -> None:
     mc = MotionController()
     ip = "192.168.2.1"
     slave_id = 1
-    dictionary_path = "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+    dictionary_path = (
+        "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+    )
     mc.communication.connect_servo_ethercat_interface_ip(ip, slave_id, dictionary_path)
-    
+
     # Select the position mode and trapezoidal profiler
     mc.motion.set_operation_mode(OperationMode.PROFILE_POSITION)
     # Set all registers needed before activating the trapezoidal profiler
@@ -38,17 +35,16 @@ def main() -> None:
     mc.configuration.set_max_profile_deceleration(max_acceleration_deceleration)
     # Enable the motor
     mc.motion.motor_enable()
-    
+
     target_positions = [1500, 3000, 0]
     for current_target in target_positions:
         position_ramp(current_target, mc)
         actual_position = mc.motion.get_actual_position()
-        time.sleep(2)
         print(f"Actual final position: {actual_position}")
-    
+
     # Disable the motor
     mc.motion.motor_disable()
-    
+
     mc.communication.disconnect()
 
 

--- a/examples/position_ramp.py
+++ b/examples/position_ramp.py
@@ -2,21 +2,6 @@ from ingeniamotion import MotionController
 from ingeniamotion.enums import OperationMode
 
 
-def position_ramp(final_position, mc: MotionController) -> None:
-    """
-    Creates a position ramp from current position to ``final_position`` as a ramp slope.
-
-    Args:
-        final_position: target position in counts.
-        mc: Controller with all the functions needed to perform a position ramp.
-    """
-    done = False
-    mc.motion.move_to_position(final_position)
-    while not done:
-        mc.motion.wait_for_position(final_position)
-        done = True
-
-
 def main() -> None:
     mc = MotionController()
     ip = "192.168.2.1"
@@ -38,9 +23,9 @@ def main() -> None:
 
     target_positions = [1500, 3000, 0]
     for current_target in target_positions:
-        position_ramp(current_target, mc)
+        mc.motion.move_to_position(current_target, blocking=True, timeout=2.0)
         actual_position = mc.motion.get_actual_position()
-        print(f"Actual final position: {actual_position}")
+        print(f"Actual position: {actual_position}")
 
     # Disable the motor
     mc.motion.motor_disable()

--- a/examples/position_ramp.py
+++ b/examples/position_ramp.py
@@ -22,7 +22,7 @@ def main() -> None:
     ip = "192.168.2.1"
     slave_id = 1
     dictionary_path = (
-        "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+        "parent_directory/dictionary_file.xdf"
     )
     mc.communication.connect_servo_ethercat_interface_ip(ip, slave_id, dictionary_path)
 

--- a/examples/position_ramp.py
+++ b/examples/position_ramp.py
@@ -6,9 +6,7 @@ def main() -> None:
     mc = MotionController()
     ip = "192.168.2.1"
     slave_id = 1
-    dictionary_path = (
-        "parent_directory/dictionary_file.xdf"
-    )
+    dictionary_path = "parent_directory/dictionary_file.xdf"
     mc.communication.connect_servo_ethercat_interface_ip(ip, slave_id, dictionary_path)
 
     # Select the position mode and trapezoidal profiler

--- a/examples/position_ramp.py
+++ b/examples/position_ramp.py
@@ -34,5 +34,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    # Before running this example, setting-up the drive with a connected motor is required
+    # Make sure the drive is properly configured and connected to a motor
     main()

--- a/examples/position_ramp.py
+++ b/examples/position_ramp.py
@@ -1,0 +1,57 @@
+import time
+from ingeniamotion import MotionController
+from ingeniamotion.enums import OperationMode
+from ingenialink.exceptions import ILError
+
+# Set your motor torque constant
+TORQUE_CONSTANT = 0.0376
+
+
+def position_ramp(final_position, mc: MotionController) -> None:
+    """
+    Creates a position ramp from current position to ``final_position`` as a ramp slope.
+
+    Args:
+        final_position: target position in counts.
+        mc: Controller with all the functions needed to perform a position ramp. 
+    """
+    done = False
+    mc.motion.move_to_position(final_position)
+    while not done:
+        mc.motion.wait_for_position(final_position)
+        done = True
+
+
+def main() -> None:
+    mc = MotionController()
+    ip = "192.168.2.1"
+    slave_id = 1
+    dictionary_path = "\\\\awe-srv-max-prd\\distext\\products\\CAP-NET\\firmware\\2.5.1\\cap-net-e_eoe_2.5.1.xdf"
+    mc.communication.connect_servo_ethercat_interface_ip(ip, slave_id, dictionary_path)
+    
+    # Select the position mode and trapezoidal profiler
+    mc.motion.set_operation_mode(OperationMode.PROFILE_POSITION)
+    # Set all registers needed before activating the trapezoidal profiler
+    mc.configuration.set_max_profile_velocity(5.0)
+    max_acceleration_deceleration = 2.0
+    mc.configuration.set_max_profile_acceleration(max_acceleration_deceleration)
+    mc.configuration.set_max_profile_deceleration(max_acceleration_deceleration)
+    # Enable the motor
+    mc.motion.motor_enable()
+    
+    target_positions = [1500, 3000, 0]
+    for current_target in target_positions:
+        position_ramp(current_target, mc)
+        actual_position = mc.motion.get_actual_position()
+        time.sleep(2)
+        print(f"Actual final position: {actual_position}")
+    
+    # Disable the motor
+    mc.motion.motor_disable()
+    
+    mc.communication.disconnect()
+
+
+if __name__ == "__main__":
+    # Before running this example, setting-up the drive with a connected motor is required
+    main()

--- a/examples/process_data_object.py
+++ b/examples/process_data_object.py
@@ -50,8 +50,8 @@ def update_position_value_using_pdo(mc: MotionController) -> None:
     # Map the PDO maps to the slave
     mc.capture.pdo.set_pdo_maps_to_slave(rpdo_map, tpdo_map)
     # Start the PDO exchange
-    # Make sure how many time takes the processes inside the callbacks. A solution for that would be
-    # setting a higher refresh rate.
+    # Make sure to set an appropriate refresh rate considering the execution time of the send and 
+    # receive process data callbacks.
     mc.capture.pdo.start_pdos(refresh_rate=0.1)
     time.sleep(waiting_time_for_pdo_exchange)
     # Stop the PDO exchange

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -47,6 +47,8 @@ def teardown_for_test_examples(motion_controller, read_config, pytestconfig):
         connect_canopen(mc, read_config, alias)
     else:
         connect_eoe(mc, read_config, alias)
+
+
 from ingeniamotion.motion import Motion
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -452,7 +452,6 @@ def test_position_ramp(mocker, capsys):
     motor_disable = mocker.patch.object(Motion, "motor_disable")
     set_operation_mode = mocker.patch.object(Motion, "set_operation_mode")
     move_to_position = mocker.patch.object(Motion, "move_to_position")
-    wait_for_position = mocker.patch.object(Motion, "wait_for_position")
     test_actual_values = [1500, 3000, 0]
     get_actual_position = mocker.patch.object(
         Motion, "get_actual_position", side_effect=test_actual_values
@@ -466,8 +465,9 @@ def test_position_ramp(mocker, capsys):
     set_max_profile_deceleration.assert_called_once()
     set_max_profile_velocity.assert_called_once()
     motor_enable.assert_called_once()
+    for current_target in test_actual_values:
+        move_to_position.assert_any_call(current_target, blocking=True, timeout=2.0)
     assert move_to_position.call_count == len(test_actual_values)
-    assert wait_for_position.call_count == len(test_actual_values)
     assert get_actual_position.call_count == len(test_actual_values)
     motor_disable.assert_called_once()
     disconnect.assert_called_once()
@@ -475,4 +475,4 @@ def test_position_ramp(mocker, capsys):
     captured_outputs = capsys.readouterr()
     all_outputs = captured_outputs.out.split("\n")
     for i, expected_actual_value in enumerate(test_actual_values):
-        assert all_outputs[i] == f"Actual final position: {expected_actual_value}"
+        assert all_outputs[i] == f"Actual position: {expected_actual_value}"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,6 +9,7 @@ from ingenialink.pdo import RPDOMap, TPDOMap
 
 from examples.change_baudrate import change_baudrate
 from examples.change_node_id import change_node_id
+from examples.commutation_test_encoders import main as main_commutation_test_encoders
 from examples.connect_ecat_coe import connect_ethercat_coe
 from examples.load_fw_canopen import load_firmware_canopen
 from examples.load_save_config_register_changes import (
@@ -16,9 +17,8 @@ from examples.load_save_config_register_changes import (
 )
 from examples.load_save_configuration import main as main_load_save_configuration
 from examples.pdo_poller_example import main as set_up_pdo_poller
-from examples.process_data_object import main as main_process_data_object
-from examples.commutation_test_encoders import main as main_commutation_test_encoders
 from examples.position_ramp import main as main_position_ramp
+from examples.process_data_object import main as main_process_data_object
 from ingeniamotion import MotionController
 from ingeniamotion.communication import Communication
 from ingeniamotion.configuration import Configuration


### PR DESCRIPTION
### Example to perform a position ramp

### Description

This example move a position motor 3 times with a constant velocity.
To do that, the example follows the steps below:
1. Connect a drive via EtherCAT-CoE.
2. Select the operation mode in profile position, that is, position mode and trapezoidal profile.
3. According to [this documentation](https://drives.novantamotion.com/summit/position-modes-csp-pp-ip-p#Positionmodes(CSP,PP,IP,P)-Profileposition(PP)) Max. profile acceleration, Max. profile deceleration and Max. profile velocity have to be configured.
4. Enable the motor.
5. Run a position ramp 3 times.
6. Disable the motor.
7. Disconnect the drive. 

Fixes # INGM-411

### Type of change

Please add a description and delete options that are not relevant.

- [x] Position ramp example.


### Tests
- [x] Unit test for position_ramp example.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.