### PR TITLE
INGM-430 Set the default watchdog timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - The get_subnodes method from the information module now returns a dictionary with the subnodes IDs as keys and their type as values.
 - Set the send_receive_processdata timeout in the ProcessDataThread according to the refresh rate.
 - Cyclic parameter is defined as a RegCyclicType variable instead of a string.
+- The default PDO watchdog timeout is set to 100 ms.
 
 ### Removed
 - The comkit module. Now ingenialink methods are use to merge the COM-KIT and CORE dictionaries.

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -202,7 +202,8 @@ class PDONetworkManager:
         DEFAULT_PDO_REFRESH_TIME = 0.01
         MINIMUM_PDO_REFRESH_TIME = 0.001
         MAXIMUM_PDO_REFRESH_TIME = 4
-        PDO_WATCHDOG_INCREMENT_FACTOR = 1.5
+        DEFAULT_WATCHDOG_TIMEOUT = 0.1
+        PDO_WATCHDOG_INCREMENT_FACTOR = 2
         # The time.sleep precision is 13 ms for Windows OS
         # https://stackoverflow.com/questions/1133857/how-accurate-is-pythons-time-sleep
         WINDOWS_TIME_SLEEP_PRECISION = 0.013
@@ -230,7 +231,10 @@ class PDONetworkManager:
                 )
             self._refresh_rate = refresh_rate
             if watchdog_timeout is None:
-                watchdog_timeout = self._refresh_rate * self.PDO_WATCHDOG_INCREMENT_FACTOR
+                watchdog_timeout = max(
+                    self.DEFAULT_WATCHDOG_TIMEOUT,
+                    self._refresh_rate * self.PDO_WATCHDOG_INCREMENT_FACTOR,
+                )
             self._watchdog_timeout = watchdog_timeout
             for servo in self._net.servos:
                 servo.set_pdo_watchdog_time(watchdog_timeout)


### PR DESCRIPTION
### Description

Set the default watchdog timeout

Fixes # INGM-430

### Type of change

Please add a description and delete options that are not relevant.

- Set the default watchdog timeout to 100 ms.
- Increase the PDO_WATCHDOG_INCREMENT_FACTOR to 2.

### Documentation

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.