### PR TITLE
INGM-440 Fix get adapter name method in Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fix
+- Bug retrieving interface adapter name in Linux.
+
 ## [0.8.0] - 2024-04-23
 ### Added
 - PDOs for the EtherCAT protocol.

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -360,11 +360,10 @@ class Communication(metaclass=MCMetaClass):
             index : position of interface selected in
                 :func:`get_interface_name_list`.
         """
-        adapter = ifaddr.get_adapters()[index]
+        adapter = list(ifaddr.get_adapters())[index]
         if RUNNING_ON_WINDOWS:
             return f"\\Device\\NPF_{bytes.decode(adapter.name)}"
-        else:
-            return str(adapter.name)
+        return str(adapter.name)
 
     def get_ifname_from_interface_ip(self, address: str) -> str:
         """Returns interface name based on the address ip of an interface.

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import time
 from collections import OrderedDict
 
@@ -81,7 +82,7 @@ def test_connect_servo_comkit_no_dictionary_error(coco_dict_path, read_config):
 
 
 @pytest.mark.smoke
-@pytest.mark.soem
+@pytest.mark.virtual
 def test_get_ifname_from_interface_ip(mocker):
     ip = type("IP", (object,), {"ip": "192.168.2.1", "is_IPv4": True})
     adapter = type(
@@ -91,6 +92,19 @@ def test_get_ifname_from_interface_ip(mocker):
     mc = MotionController()
     ifname = mc.communication.get_ifname_from_interface_ip("192.168.2.1")
     assert ifname == "\\Device\\NPF_{192D1D2F-C684-467D-A637-EC07BD434A63}"
+
+
+@pytest.mark.smoke
+@pytest.mark.virtual
+def test_get_ifname_by_index():
+    mc = MotionController()
+    interface_name_list = mc.communication.get_interface_name_list()
+    assert len(interface_name_list) > 0
+    for index, interface_name in enumerate(interface_name_list):
+        ifname = mc.communication.get_ifname_by_index(index)
+        assert isinstance(ifname, str)
+        if platform.system() == "Linux":
+            assert ifname == interface_name
 
 
 @pytest.mark.skip(reason='This test enters in conflict with "disable_motor_fixture"')

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -85,13 +85,18 @@ def test_connect_servo_comkit_no_dictionary_error(coco_dict_path, read_config):
 @pytest.mark.virtual
 def test_get_ifname_from_interface_ip(mocker):
     ip = type("IP", (object,), {"ip": "192.168.2.1", "is_IPv4": True})
-    adapter = type(
-        "Adapter", (object,), {"ips": [ip], "name": b"{192D1D2F-C684-467D-A637-EC07BD434A63}"}
-    )
+    if platform.system() == "Linux":
+        name = "eth0"
+    else:
+        name = b"{192D1D2F-C684-467D-A637-EC07BD434A63}"
+    adapter = type("Adapter", (object,), {"ips": [ip], "name": name})
     mocker.patch("ifaddr.get_adapters", return_value=[adapter])
     mc = MotionController()
     ifname = mc.communication.get_ifname_from_interface_ip("192.168.2.1")
-    assert ifname == "\\Device\\NPF_{192D1D2F-C684-467D-A637-EC07BD434A63}"
+    if platform.system() == "Windows":
+        assert ifname == "\\Device\\NPF_{192D1D2F-C684-467D-A637-EC07BD434A63}"
+    else:
+        assert ifname == name
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
### Description

Fix get adapter name method in Linux.

Fixes # INGM-440

### Tests
- Call the get_interface_name_by_index method on a Linux machine.
- Check that no error occurs and that the correct interface name is retrieved.

### Documentation

Please update the documentation.

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
