### PR TITLE
INGM-367 Use a queue to manage stoppable sleeps in the wizard tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- The stoppable_sleep method of the wizard tests does not block the main thread.
+
 ## [0.8.0] - 2024-04-23
 ### Added
 - PDOs for the EtherCAT protocol.

--- a/ingeniamotion/wizard_tests/stoppable.py
+++ b/ingeniamotion/wizard_tests/stoppable.py
@@ -12,7 +12,6 @@ T = typing.TypeVar("T")
 
 
 class Stoppable:
-
     stop_queue = Queue(1)
 
     @staticmethod

--- a/ingeniamotion/wizard_tests/stoppable.py
+++ b/ingeniamotion/wizard_tests/stoppable.py
@@ -1,6 +1,6 @@
 import typing
 from functools import wraps
-from queue import Empty, Queue
+from queue import Empty, Full, Queue
 from typing import Callable
 
 
@@ -24,16 +24,24 @@ class Stoppable:
         return wrapper
 
     def reset_stop(self) -> None:
-        if self.stop_queue.full():
+        try:
             self.stop_queue.get(block=False)
+        except Empty:
+            pass
 
     def stop(self) -> None:
-        if not self.stop_queue.full():
+        try:
             self.stop_queue.put(StopException(), block=False)
+        except Full:
+            pass
 
     def check_stop(self) -> None:
-        if self.stop_queue.full():
-            raise self.stop_queue.get(block=False)
+        try:
+            stop_exception = self.stop_queue.get(block=False)
+        except Empty:
+            pass
+        else:
+            raise stop_exception
 
     def stoppable_sleep(self, timeout: float) -> None:
         try:

--- a/ingeniamotion/wizard_tests/stoppable.py
+++ b/ingeniamotion/wizard_tests/stoppable.py
@@ -12,7 +12,7 @@ T = typing.TypeVar("T")
 
 
 class Stoppable:
-    stop_queue = Queue(1)
+    stop_queue: Queue[StopException] = Queue(1)
 
     @staticmethod
     def stoppable(fun: Callable[..., T]) -> Callable[..., T]:
@@ -29,7 +29,7 @@ class Stoppable:
 
     def stop(self) -> None:
         if not self.stop_queue.full():
-            self.stop_queue.put(StopException, block=False)
+            self.stop_queue.put(StopException(), block=False)
 
     def check_stop(self) -> None:
         if self.stop_queue.full():

--- a/ingeniamotion/wizard_tests/stoppable.py
+++ b/ingeniamotion/wizard_tests/stoppable.py
@@ -37,7 +37,7 @@ class Stoppable:
 
     def stoppable_sleep(self, timeout: float) -> None:
         try:
-            stop_exception = self.stop_queue.get(block=True, timeout=timeout)
+            stop_exception = self.stop_queue.get(timeout=timeout)
         except Empty:
             pass
         else:


### PR DESCRIPTION
## Use a queue to manage stoppable sleeps in the wizard tests

### Description

In this PR, a queue is used to manage the stoppable sleeps in the wizard test so the main Python thread is not blocked.

Fixes # INGM-367

### Type of change

- [x] Use a queue to manage stoppable sleeps in the wizard tests

### Tests
- [x] Test that the brake tune tests in ML3 does not blocks the GUI.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
