### PR TITLE
INGM-447 Set the boot_in_app flag according to the file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Set the boot_in_app flag according to the file extension.
+
 ### Fix
 - Bug retrieving interface adapter name in Linux.
 - The stoppable_sleep method of the wizard tests does not block the main thread.

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1283,6 +1283,7 @@ class Communication(metaclass=MCMetaClass):
             fw_file: Path to the ensemble FW file.
             slave: Slave ID (any slave in the ensemble)
             boot_in_app: true if the bootloader is included in the application, false otherwise.
+                If None, the file extension is used to define it.
         """
         mapping = self.__unzip_ensemble_fw_file(fw_file)
         scanned_slaves = net.scan_slaves_info()

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1003,7 +1003,7 @@ class Communication(metaclass=MCMetaClass):
 
     @staticmethod
     def __get_boot_in_app(fw_file: str) -> bool:
-        """Return true if the FoE is included in the application (file extension is .sfu)
+        """Return true if the bootloader is included in the application. (file extension is .sfu)
 
         Args:
             fw_file: Path to the FW file.

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1043,11 +1043,11 @@ class Communication(metaclass=MCMetaClass):
         """
 
         net = EthercatNetwork(ifname)
-        boot_in_app = self.__get_boot_in_app(fw_file) if boot_in_app is None else boot_in_app
         if fw_file.endswith(self.ENSEMBLE_FIRMWARE_EXTENSION):
             self.__load_ensemble_fw_ecat(net, fw_file, slave, boot_in_app)
         else:
-            net.load_firmware(fw_file, boot_in_app, slave_id=slave)
+            boot_in_app = self.__get_boot_in_app(fw_file) if boot_in_app is None else boot_in_app
+            net.load_firmware(fw_file, boot_in_app, slave)
 
     def load_firmware_ecat_interface_index(
         self, if_index: int, fw_file: str, slave: int = 1
@@ -1271,7 +1271,7 @@ class Communication(metaclass=MCMetaClass):
             )
 
     def __load_ensemble_fw_ecat(
-        self, net: EthercatNetwork, fw_file: str, slave: int, boot_in_app: bool
+        self, net: EthercatNetwork, fw_file: str, slave: int, boot_in_app: Optional[bool]
     ) -> None:
         """Load FW to an ensemble of servos through Ethercat.
 
@@ -1289,10 +1289,15 @@ class Communication(metaclass=MCMetaClass):
         first_slave_in_ensemble = self.__check_ensemble(scanned_slaves, slave, mapping)
         try:
             for slave_id_offset, fw_file_prod_code in mapping.items():
+                boot_in_app_drive = (
+                    self.__get_boot_in_app(fw_file_prod_code[0])
+                    if boot_in_app is None
+                    else boot_in_app
+                )
                 net.load_firmware(
                     fw_file_prod_code[0],
-                    boot_in_app,
-                    slave_id=first_slave_in_ensemble + slave_id_offset,
+                    boot_in_app_drive,
+                    first_slave_in_ensemble + slave_id_offset,
                 )
         except ILError as e:
             raise e

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1003,7 +1003,7 @@ class Communication(metaclass=MCMetaClass):
 
     @staticmethod
     def __get_boot_in_app(fw_file: str) -> bool:
-        """Return true if the bootloader is included in the application. (file extension is .sfu)
+        """Return true if the bootloader is included in the application (file extension is .sfu).
 
         Args:
             fw_file: Path to the FW file.
@@ -1020,7 +1020,9 @@ class Communication(metaclass=MCMetaClass):
             )
         return fw_file.endswith(FILE_EXT_SFU)
 
-    def load_firmware_ecat(self, ifname: str, fw_file: str, slave: int = 1) -> None:
+    def load_firmware_ecat(
+        self, ifname: str, fw_file: str, slave: int = 1, boot_in_app: Optional[bool] = None
+    ) -> None:
         """Load firmware via ECAT.
 
         Args:
@@ -1028,6 +1030,8 @@ class Communication(metaclass=MCMetaClass):
                 ``\\Device\\NPF_[...]``.
             fw_file : Firmware file path.
             slave : slave index. ``1`` by default.
+            boot_in_app: true if the bootloader is included in the application, false otherwise.
+                If None, the file extension is used to define it.
 
         Raises:
             FileNotFoundError: If the firmware file cannot be found.
@@ -1039,11 +1043,11 @@ class Communication(metaclass=MCMetaClass):
         """
 
         net = EthercatNetwork(ifname)
+        boot_in_app = self.__get_boot_in_app(fw_file) if boot_in_app is None else boot_in_app
         if fw_file.endswith(self.ENSEMBLE_FIRMWARE_EXTENSION):
-            self.__load_ensemble_fw_ecat(net, fw_file, slave)
+            self.__load_ensemble_fw_ecat(net, fw_file, slave, boot_in_app)
         else:
-            boot_in_app = self.__get_boot_in_app(fw_file)
-            net.load_firmware(fw_file, slave, boot_in_app)
+            net.load_firmware(fw_file, boot_in_app, slave_id=slave)
 
     def load_firmware_ecat_interface_index(
         self, if_index: int, fw_file: str, slave: int = 1
@@ -1266,7 +1270,9 @@ class Communication(metaclass=MCMetaClass):
                 f"Load of FW in slave {slave_id} of ensemble failed. Exception: {exception}"
             )
 
-    def __load_ensemble_fw_ecat(self, net: EthercatNetwork, fw_file: str, slave: int) -> None:
+    def __load_ensemble_fw_ecat(
+        self, net: EthercatNetwork, fw_file: str, slave: int, boot_in_app: bool
+    ) -> None:
         """Load FW to an ensemble of servos through Ethercat.
 
         The FW files that are contained in the fw_file will be loaded by selecting any slave which
@@ -1276,15 +1282,17 @@ class Communication(metaclass=MCMetaClass):
             net: Ethercat network.
             fw_file: Path to the ensemble FW file.
             slave: Slave ID (any slave in the ensemble)
+            boot_in_app: true if the bootloader is included in the application, false otherwise.
         """
         mapping = self.__unzip_ensemble_fw_file(fw_file)
         scanned_slaves = net.scan_slaves_info()
         first_slave_in_ensemble = self.__check_ensemble(scanned_slaves, slave, mapping)
         try:
             for slave_id_offset, fw_file_prod_code in mapping.items():
-                boot_in_app = self.__get_boot_in_app(fw_file_prod_code[0])
                 net.load_firmware(
-                    fw_file_prod_code[0], first_slave_in_ensemble + slave_id_offset, boot_in_app
+                    fw_file_prod_code[0],
+                    boot_in_app,
+                    slave_id=first_slave_in_ensemble + slave_id_offset,
                 )
         except ILError as e:
             raise e

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1009,7 +1009,7 @@ class Communication(metaclass=MCMetaClass):
             fw_file: Path to the FW file.
 
         Returns:
-            True if the FoE is included in the application.
+            True if the bootloader is included in the application.
 
         Raises:
             ValueError: If the firmware file has the wrong extension.

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
 
 RUNNING_ON_WINDOWS = platform.system() == "Windows"
+FILE_EXT_SFU = ".sfu"
+FILE_EXT_LFU = ".lfu"
 
 
 class Communication(metaclass=MCMetaClass):
@@ -999,6 +1001,25 @@ class Communication(metaclass=MCMetaClass):
                 error_enabled_callback,
             )
 
+    @staticmethod
+    def __get_boot_in_app(fw_file: str) -> bool:
+        """Return true if the FoE is included in the application (file extension is .sfu)
+
+        Args:
+            fw_file: Path to the FW file.
+
+        Returns:
+            True if the FoE is included in the application.
+
+        Raises:
+            ValueError: If the firmware file has the wrong extension.
+        """
+        if not fw_file.endswith((FILE_EXT_SFU, FILE_EXT_LFU)):
+            raise ValueError(
+                f"Firmware file should have extension {FILE_EXT_SFU} or {FILE_EXT_LFU}."
+            )
+        return fw_file.endswith(FILE_EXT_SFU)
+
     def load_firmware_ecat(self, ifname: str, fw_file: str, slave: int = 1) -> None:
         """Load firmware via ECAT.
 
@@ -1010,6 +1031,7 @@ class Communication(metaclass=MCMetaClass):
 
         Raises:
             FileNotFoundError: If the firmware file cannot be found.
+            ValueError: If the firmware file has the wrong extension.
             ingenialink.exceptions.ILFirmwareLoadError: If no slave is detected.
             ingenialink.exceptions.ILFirmwareLoadError: If the FoE write operation is not successful
             NotImplementedError: If FoE is not implemented for the current OS and architecture
@@ -1020,7 +1042,8 @@ class Communication(metaclass=MCMetaClass):
         if fw_file.endswith(self.ENSEMBLE_FIRMWARE_EXTENSION):
             self.__load_ensemble_fw_ecat(net, fw_file, slave)
         else:
-            net.load_firmware(fw_file, slave)
+            boot_in_app = self.__get_boot_in_app(fw_file)
+            net.load_firmware(fw_file, slave, boot_in_app)
 
     def load_firmware_ecat_interface_index(
         self, if_index: int, fw_file: str, slave: int = 1
@@ -1259,7 +1282,10 @@ class Communication(metaclass=MCMetaClass):
         first_slave_in_ensemble = self.__check_ensemble(scanned_slaves, slave, mapping)
         try:
             for slave_id_offset, fw_file_prod_code in mapping.items():
-                net.load_firmware(fw_file_prod_code[0], first_slave_in_ensemble + slave_id_offset)
+                boot_in_app = self.__get_boot_in_app(fw_file_prod_code[0])
+                net.load_firmware(
+                    fw_file_prod_code[0], first_slave_in_ensemble + slave_id_offset, boot_in_app
+                )
         except ILError as e:
             raise e
         finally:

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -4,7 +4,7 @@ import time
 from collections import OrderedDict
 
 import pytest
-from ingenialink.canopen.network import CanopenNetwork, CAN_DEVICE, CAN_BAUDRATE
+from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.exceptions import ILError
@@ -471,8 +471,8 @@ def test_load_ensemble_fw_ecat(mocker):
         )
         mc.communication.load_firmware_ecat("", TEST_ENSEMBLE_FW_FILE, slave=slave)
         assert len(patch_fw_callback.call_args_list) == 2
-        assert patch_fw_callback.call_args_list[0][0] == (fw_file1, 1)
-        assert patch_fw_callback.call_args_list[1][0] == (fw_file2, 2)
+        assert patch_fw_callback.call_args_list[0][0] == (fw_file1, False, 1)
+        assert patch_fw_callback.call_args_list[1][0] == (fw_file2, False, 2)
 
     for slave in [3, 4]:
         patch_fw_callback = mocker.patch(
@@ -480,8 +480,8 @@ def test_load_ensemble_fw_ecat(mocker):
         )
         mc.communication.load_firmware_ecat("", TEST_ENSEMBLE_FW_FILE, slave=slave)
         assert len(patch_fw_callback.call_args_list) == 2
-        assert patch_fw_callback.call_args_list[0][0] == (fw_file1, 3)
-        assert patch_fw_callback.call_args_list[1][0] == (fw_file2, 4)
+        assert patch_fw_callback.call_args_list[0][0] == (fw_file1, False, 3)
+        assert patch_fw_callback.call_args_list[1][0] == (fw_file2, False, 4)
 
     with pytest.raises(IMException) as exc_info:
         mc.communication.load_firmware_ecat("", TEST_ENSEMBLE_FW_FILE, slave=5)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@develop
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@INGK-892-add-boot-in-app-flag-in-the-load-firmware-of-ethercat
     fsoe_master_ref = 3fa5d29
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@INGK-892-add-boot-in-app-flag-in-the-load-firmware-of-ethercat
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@develop
     fsoe_master_ref = 3fa5d29
 
 [testenv]


### PR DESCRIPTION
## Set the boot_in_app flag according to the file extension

### Description

This PR sets the boot_in_app flag according to the file extension

Fixes # INGM-447

### Type of change

- [x] Sets the boot_in_app flag according to the file extension
- [x] Change 2 (description)

### Tests
- [x] Test the load FW using the unreleased FoE application.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
