### PR TITLE
INGM-455 Turn the FailSafeData off

### DIFF
--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -86,6 +86,7 @@ class FSoEMasterHandler:
 
     def sto_deactivate(self) -> None:
         """Set the STO command to deactivate the STO"""
+        self.__master_handler.set_fail_safe(False)
         self.__master_handler.dictionary.set(self.STO_COMMAND_UID, True)
 
     def sto_activate(self) -> None:


### PR DESCRIPTION
### Description

Turn the FailSafeData off

Fixes # INGM-455

### Type of change

- Turn the FailSafeData off


### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
