### PR TITLE
INGM-456 Ignore initial TPDO values

### DIFF
--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -82,7 +82,9 @@ class FSoEMasterHandler:
     def set_reply(self) -> None:
         """Get the FSoE slave response from the Safety Slave PDU PDOMap and set it
         to the FSoE master handler."""
-        self.__master_handler.set_reply(self.safety_slave_pdu_map.get_item_bytes())
+        safety_slave_pdu_bytes = self.safety_slave_pdu_map.get_item_bytes()
+        if int.from_bytes(safety_slave_pdu_bytes, "little") != 0:
+            self.__master_handler.set_reply(safety_slave_pdu_bytes)
 
     def sto_deactivate(self) -> None:
         """Set the STO command to deactivate the STO"""


### PR DESCRIPTION
### Description

Once the PDO starts, the first TPDO values are empty (with zeros). Ignore them as they are not valid Safety Slave PDUs.

Fixes # (issue)

### Type of change

- Ignore initial TPDO values


### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
