### PR TITLE
INGM-441 Set feedbacks to internal generator during brake testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fix
 - Bug retrieving interface adapter name in Linux.
 - The stoppable_sleep method of the wizard tests does not block the main thread.
+- Set feedbacks to internal generator during brake testing.
 
 ## [0.8.1] - 2024-06-05
 ### Added

--- a/ingeniamotion/wizard_tests/brake.py
+++ b/ingeniamotion/wizard_tests/brake.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Dict, Union
 import ingenialogger
 from ingenialink.exceptions import ILError
 
-from ingeniamotion.enums import CommutationMode, OperationMode, SeverityLevel
+from ingeniamotion.enums import CommutationMode, OperationMode, SensorType, SeverityLevel
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 from ingeniamotion.wizard_tests.base_test import BaseTest
 from ingeniamotion.wizard_tests.stoppable import StopException
@@ -15,13 +15,20 @@ if TYPE_CHECKING:
 class Brake(BaseTest):
     BRAKE_OVERRIDE_REGISTER = "MOT_BRAKE_OVERRIDE"
 
+    PRIMARY_ABSOLUTE_SLAVE_1_PROTOCOL = "FBK_BISS1_SSI1_PROTOCOL"
+
     BACKUP_REGISTERS = [
         "MOT_BRAKE_OVERRIDE",
         "DRV_OP_CMD",
         "MOT_PAIR_POLES",
         "COMMU_PHASING_MODE",
         "COMMU_ANGLE_SENSOR",
+        "COMMU_ANGLE_REF_SENSOR",
+        "CL_VEL_FBK_SENSOR",
+        "CL_POS_FBK_SENSOR",
+        "CL_AUX_FBK_SENSOR",
         "MOT_COMMU_MOD",
+        PRIMARY_ABSOLUTE_SLAVE_1_PROTOCOL,
     ]
 
     def __init__(
@@ -42,6 +49,21 @@ class Brake(BaseTest):
         )
         self.mc.motion.set_internal_generator_configuration(
             OperationMode.VOLTAGE, servo=self.servo, axis=self.axis
+        )
+        self.mc.configuration.set_reference_feedback(
+            SensorType.INTGEN, servo=self.servo, axis=self.axis
+        )
+        self.mc.configuration.set_velocity_feedback(
+            SensorType.INTGEN, servo=self.servo, axis=self.axis
+        )
+        self.mc.configuration.set_position_feedback(
+            SensorType.INTGEN, servo=self.servo, axis=self.axis
+        )
+        self.mc.configuration.set_auxiliar_feedback(
+            SensorType.ABS1, servo=self.servo, axis=self.axis
+        )
+        self.mc.communication.set_register(
+            self.PRIMARY_ABSOLUTE_SLAVE_1_PROTOCOL, 1, servo=self.servo, axis=self.axis
         )
 
     def loop(self) -> None:


### PR DESCRIPTION
##  Set feedbacks to internal generator during brake testing

Fixes # INGM-441

### Type of change

Please add a description and delete options that are not relevant.

- [x] Set feedbacks to internal generator during brake testing
- [x] Add feedback registers to the list of backup registers.


### Tests
- [x] Tested it in ML3 following the steps described in the verification.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
