### PR TITLE
INGM-464 Delete network from dictionary if connection is not successful

### DIFF
--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -253,14 +253,19 @@ class Communication(metaclass=MCMetaClass):
         if ifname not in self.mc.net:
             self.mc.net[ifname] = EoENetwork(ifname)
         net = self.mc.net[ifname]
-        servo = net.connect_to_slave(
-            slave,
-            ip,
-            dict_path,
-            port,
-            servo_status_listener=servo_status_listener,
-            net_status_listener=net_status_listener,
-        )
+        try:
+            servo = net.connect_to_slave(
+                slave,
+                ip,
+                dict_path,
+                port,
+                servo_status_listener=servo_status_listener,
+                net_status_listener=net_status_listener,
+            )
+        except ILError as e:
+            if len(net.servos) == 0:
+                del self.mc.net[ifname]
+            raise e
         servo.slave = slave  # type: ignore [attr-defined]
         self.mc.servos[alias] = servo
         self.mc.servo_net[alias] = ifname
@@ -599,12 +604,17 @@ class Communication(metaclass=MCMetaClass):
         if interface_name not in self.mc.net:
             self.mc.net[interface_name] = EthercatNetwork(interface_name)
         net = self.mc.net[interface_name]
-        servo = net.connect_to_slave(
-            slave_id,
-            dict_path,
-            servo_status_listener=servo_status_listener,
-            net_status_listener=net_status_listener,
-        )
+        try:
+            servo = net.connect_to_slave(
+                slave_id,
+                dict_path,
+                servo_status_listener=servo_status_listener,
+                net_status_listener=net_status_listener,
+            )
+        except ILError as e:
+            if len(net.servos) == 0:
+                del self.mc.net[interface_name]
+            raise e
         self.mc.servos[alias] = servo
         self.mc.servo_net[alias] = interface_name
 


### PR DESCRIPTION
### Description

If a connection to a drive fails, the Network instance remains in the network dictionary. Remove it from the network dictionary if no other drives are connected to it.

Fixes # INGM-464

### Type of change
- Delete the network from the dictionary if the connection is not successful.

### Tests
- Follow the steps described in the issue.
- Check that no error occurs.

### Code formatting
- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others
- [x] Set fix version field in the Jira issue.
