### PR TITLE
INGM-463 Add a method to get the available CAN devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - FSoE module.
 - STO example for Safe servo drives.
+- Method to get the available CAN devices.
 
 ### Fix
 - Bug retrieving interface adapter name in Linux.

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
 
 import ifaddr
 import ingenialogger
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.canopen.network import CAN_BAUDRATE, CAN_CHANNELS, CAN_DEVICE, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.dictionary import Interface
 from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
@@ -438,6 +438,27 @@ class Communication(metaclass=MCMetaClass):
 
         """
         return [x.nice_name for x in ifaddr.get_adapters()]
+
+    @staticmethod
+    def get_available_canopen_devices() -> dict[CAN_DEVICE, list[int]]:
+        """Return the list of available CAN devices (those connected and with drivers installed).
+
+        Returns:
+            Dict of available CAN devices and channels. For example:
+            {
+                CAN_DEVICE.KVASER: [0, 1]
+                CAN_DEVICE.PCAN: [0]
+            }
+        """
+        available_devices: dict[CAN_DEVICE, list[int]] = {}
+        for device, channel in CanopenNetwork.get_available_devices():
+            can_device = CAN_DEVICE(device)
+            can_channel = CAN_CHANNELS[device].index(channel)
+            if can_device not in available_devices:
+                available_devices[can_device] = [can_channel]
+            else:
+                available_devices[can_device].append(can_channel)
+        return available_devices
 
     def connect_servo_eoe_service_interface_index(
         self,


### PR DESCRIPTION
## Add a method to get the available CAN devices

### Description

This PR adds a new method to get the available CAN devices and channels.

Fixes # INGM-463

### Type of change

- [x] Add a new method to get CAN devices and channels available.

### Tests
- [x] Tested in ML3.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
