### PR TITLE
INGM-300 Check that registers to be mapped in monitoring are CYCLIC_TX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - FSoE module.
 - STO example for Safe servo drives.
+- Check that registers to be mapped in monitoring are CYCLIC_TX.
 
 ### Fix
 - Bug retrieving interface adapter name in Linux.

--- a/ingeniamotion/monitoring/base_monitoring.py
+++ b/ingeniamotion/monitoring/base_monitoring.py
@@ -138,7 +138,7 @@ class Monitoring(ABC):
             if not isinstance(register, str):
                 raise TypeError("Register has to be a string")
             register_obj = self.mc.info.register_info(register, subnode, servo=self.servo)
-            if register_obj.cyclic != RegCyclicType.TX:
+            if register_obj.cyclic not in [RegCyclicType.TX, RegCyclicType.TXRX]:
                 raise IMMonitoringError(
                     f"{register} can not be mapped as a monitoring register (wrong cyclic)"
                 )

--- a/ingeniamotion/monitoring/base_monitoring.py
+++ b/ingeniamotion/monitoring/base_monitoring.py
@@ -123,6 +123,7 @@ class Monitoring(ABC):
         Raises:
             IMMonitoringError: If register maps fails in the servo.
             IMMonitoringError: If buffer size is not enough for all the registers.
+            IMMonitoringError: If any register is not CYCLIC_TX.
             TypeError: If some parameter has a wrong type.
 
         """

--- a/ingeniamotion/monitoring/base_monitoring.py
+++ b/ingeniamotion/monitoring/base_monitoring.py
@@ -14,7 +14,7 @@ from ingeniamotion.enums import (
     MonitoringSoCType,
     MonitoringVersion,
 )
-from ingeniamotion.exceptions import IMMonitoringError, IMRegisterWrongCyclic
+from ingeniamotion.exceptions import IMMonitoringError
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 if TYPE_CHECKING:

--- a/ingeniamotion/monitoring/base_monitoring.py
+++ b/ingeniamotion/monitoring/base_monitoring.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
 import ingenialogger
 import numpy as np
-from ingenialink.enums.register import REG_DTYPE
+from ingenialink.enums.register import REG_DTYPE, RegCyclicType
 
 from ingeniamotion.enums import (
     MonitoringProcessStage,
@@ -14,7 +14,7 @@ from ingeniamotion.enums import (
     MonitoringSoCType,
     MonitoringVersion,
 )
-from ingeniamotion.exceptions import IMMonitoringError
+from ingeniamotion.exceptions import IMMonitoringError, IMRegisterWrongCyclic
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 if TYPE_CHECKING:
@@ -137,6 +137,10 @@ class Monitoring(ABC):
             if not isinstance(register, str):
                 raise TypeError("Register has to be a string")
             register_obj = self.mc.info.register_info(register, subnode, servo=self.servo)
+            if register_obj.cyclic != RegCyclicType.TX:
+                raise IMMonitoringError(
+                    f"{register} can not be mapped as a monitoring register (wrong cyclic)"
+                )
             dtype = register_obj.dtype
             channel["dtype"] = dtype
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,11 +1,10 @@
 import time
+from functools import partial
+from threading import Thread
 
 import pytest
 
-from threading import Thread
-from functools import partial
-
-from ingeniamotion.enums import MonitoringSoCType, MonitoringSoCConfig
+from ingeniamotion.enums import MonitoringSoCConfig, MonitoringSoCType
 from ingeniamotion.exceptions import IMMonitoringError
 
 MONITOR_START_CONDITION_TYPE_REGISTER = "MON_CFG_SOC_TYPE"
@@ -157,6 +156,14 @@ def test_monitoring_map_registers_size_exception(monitoring):
 @pytest.mark.smoke
 def test_monitoring_map_registers_fail(monitoring):
     registers = []
+    with pytest.raises(IMMonitoringError):
+        monitoring.map_registers(registers)
+
+
+@pytest.mark.virtual
+@pytest.mark.smoke
+def test_monitoring_map_registers_wrong_cyclic(monitoring):
+    registers = [{"axis": 1, "name": "DRV_STATE_CONTROL"}]
     with pytest.raises(IMMonitoringError):
         monitoring.map_registers(registers)
 


### PR DESCRIPTION
## Check that registers to be mapped in monitoring are CYCLIC_TX

### Description

Fixes # INGM-300 

### Type of change

- [x] Check that registers to be mapped in monitoring are CYCLIC_TX

### Tests
- [x] Add new unit test.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
