### PR TITLE
INGM-465 Use the network adapter's index to retrieve its name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ def ECAT_NODE_LOCK = "test_execution_lock_ecat"
 def CAN_NODE = "canopen-test"
 def CAN_NODE_LOCK = "test_execution_lock_can"
 
-def DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:1.5"
+def DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:1.4"
 
 def DEFAULT_TOX_PYTHON_VERSION = "39"
 def DEFAULT_PYTHON_VERSION = "3.9"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ def ECAT_NODE_LOCK = "test_execution_lock_ecat"
 def CAN_NODE = "canopen-test"
 def CAN_NODE_LOCK = "test_execution_lock_can"
 
-def DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:1.4"
+def DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:1.5"
 
 def DEFAULT_TOX_PYTHON_VERSION = "39"
 def DEFAULT_PYTHON_VERSION = "3.9"

--- a/tests/config.json
+++ b/tests/config.json
@@ -15,7 +15,7 @@
   ],
   "soem": [
   {
-    "ifname": "\\Device\\NPF_{51BCF26D-647F-489D-A782-D69CBCB20BD2}",
+    "ifname": "\\Device\\NPF_{B24AA996-414A-4F95-95E6-2828D346209A}",
     "dictionary": "//awe-srv-max-prd/distext/products/EVE-XCR/firmware/2.5.1/eve-xcr-e_eoe_2.5.1.xdf",
     "slave": 1,
     "config_file": "//azr-srv-ingfs1/dist/setups/setup_eve_ecat/1.2.0/config.xml",
@@ -24,7 +24,7 @@
     "boot_in_app": true
   },
   {
-    "ifname": "\\Device\\NPF_{51BCF26D-647F-489D-A782-D69CBCB20BD2}",
+    "ifname": "\\Device\\NPF_{B24AA996-414A-4F95-95E6-2828D346209A}",
     "dictionary": "//awe-srv-max-prd/distext/products/CAP-XCR/firmware/2.5.1/cap-xcr-e_eoe_2.5.1.xdf",
     "slave": 2,
     "config_file": "//azr-srv-ingfs1/dist/setups/setup_cap_ecat/1.1.0/config.xml",

--- a/tests/config.json
+++ b/tests/config.json
@@ -15,8 +15,7 @@
   ],
   "soem": [
   {
-    "ip": "192.168.3.1",
-    "index": 3,
+    "ifname": "\\Device\\NPF_{51BCF26D-647F-489D-A782-D69CBCB20BD2}",
     "dictionary": "//awe-srv-max-prd/distext/products/EVE-XCR/firmware/2.5.1/eve-xcr-e_eoe_2.5.1.xdf",
     "slave": 1,
     "config_file": "//azr-srv-ingfs1/dist/setups/setup_eve_ecat/1.2.0/config.xml",
@@ -25,8 +24,7 @@
     "boot_in_app": true
   },
   {
-    "ip": "192.168.3.1",
-    "index": 3,
+    "ifname": "\\Device\\NPF_{51BCF26D-647F-489D-A782-D69CBCB20BD2}",
     "dictionary": "//awe-srv-max-prd/distext/products/CAP-XCR/firmware/2.5.1/cap-xcr-e_eoe_2.5.1.xdf",
     "slave": 2,
     "config_file": "//azr-srv-ingfs1/dist/setups/setup_cap_ecat/1.1.0/config.xml",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,8 +53,8 @@ def connect_eoe(mc, config, alias):
 
 
 def connect_soem(mc, config, alias):
-    mc.communication.connect_servo_ethercat_interface_index(
-        config["index"],
+    mc.communication.connect_servo_ethercat(
+        config["ifname"],
         config["slave"],
         config["dictionary"],
         alias,

--- a/tests/load_FWs.py
+++ b/tests/load_FWs.py
@@ -111,7 +111,7 @@ def load_can(drive_conf):
 
 def load_ecat(drive_conf):
     adapter = ifaddr.get_adapters()[drive_conf["index"]]
-    ifname = f'\\Device\\NPF_{bytes.decode(adapter.name)}'
+    ifname = f"\\Device\\NPF_{bytes.decode(adapter.name)}"
     net = EthercatNetwork(ifname)
     try:
         net.load_firmware(drive_conf["fw_file"], drive_conf["boot_in_app"], drive_conf["slave"])

--- a/tests/load_FWs.py
+++ b/tests/load_FWs.py
@@ -110,14 +110,8 @@ def load_can(drive_conf):
 
 
 def load_ecat(drive_conf):
-    ifname = None
-    for adapter in ifaddr.get_adapters():
-        for ip in adapter.ips:
-            if ip.is_IPv4 and ip.ip == drive_conf["ip"]:
-                ifname = "\\Device\\NPF_{}".format(bytes.decode(adapter.name))
-                break
-        if ifname is not None:
-            break
+    adapter = ifaddr.get_adapters()[drive_conf["index"]]
+    ifname = f'\\Device\\NPF_{bytes.decode(adapter.name)}'
     net = EthercatNetwork(ifname)
     try:
         net.load_firmware(drive_conf["fw_file"], drive_conf["boot_in_app"], drive_conf["slave"])

--- a/tests/load_FWs.py
+++ b/tests/load_FWs.py
@@ -110,8 +110,7 @@ def load_can(drive_conf):
 
 
 def load_ecat(drive_conf):
-    adapter = ifaddr.get_adapters()[drive_conf["index"]]
-    ifname = f"\\Device\\NPF_{bytes.decode(adapter.name)}"
+    ifname = drive_conf["ifname"]
     net = EthercatNetwork(ifname)
     try:
         net.load_firmware(drive_conf["fw_file"], drive_conf["boot_in_app"], drive_conf["slave"])

--- a/tests/test_pdo.py
+++ b/tests/test_pdo.py
@@ -29,8 +29,8 @@ def connect_to_all_slaves(motion_controller, pytestconfig):
             continue
         alias = f"test{slave_content['slave']}"
         aliases.append(alias)
-        mc.communication.connect_servo_ethercat_interface_index(
-            slave_content["index"],
+        mc.communication.connect_servo_ethercat(
+            slave_content["ifname"],
             slave_content["slave"],
             slave_content["dictionary"],
             alias,


### PR DESCRIPTION
### Description

Use the network adapter's index to retrieve its name.

Fixes # INGM-465

### Others

- [x] Set fix version field in the Jira issue.
