### PR TITLE
INGM-466 Disable the motor while the STO is deactivated

### DIFF
--- a/examples/safety_torque_off.py
+++ b/examples/safety_torque_off.py
@@ -31,12 +31,12 @@ def main(interface_ip, slave_id, dict_path):
     mc.motion.set_velocity(target_velocity)
     with contextlib.suppress(IMTimeoutError):
         mc.motion.wait_for_velocity(velocity=target_velocity, timeout=5)
+    # Disable the motor
+    mc.motion.motor_disable()
     # Activate the STO
     mc.fsoe.sto_activate()
     # Stop the FSoE master handler
     mc.fsoe.stop_master(stop_pdos=True)
-    # Disable the motor
-    mc.motion.motor_disable()
     # Restore the operation mode
     mc.motion.set_operation_mode(current_operation_mode)
     # Disconnect from the servo drive


### PR DESCRIPTION
### Description

The motor disable had no effect because it was performed when the STO was activated.

Fixes # INGM-466

### Type of change

- Perform the motor disable while the STO is deactivated.

### Tests
- Run the example script.
- Check that the drive does not end in a fault state.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
