### PR TITLE
INGM-445 Add GPIO module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - FSoE module.
 - STO example for Safe servo drives.
 - Use only one queue in the PDO Poller to store both the timestamps and the register values.
+- GPIO module.
 
 ### Fix
 - Bug retrieving interface adapter name in Linux.

--- a/ingeniamotion/enums/__init__.py
+++ b/ingeniamotion/enums/__init__.py
@@ -212,3 +212,35 @@ class FilterNumber(IntEnum):
 
     FILTER1 = 1
     FILTER2 = 2
+
+
+class DigitalVoltageLevel(IntEnum):
+    """GPIOs voltage level (HIGH/LOW) enum"""
+
+    HIGH = 1
+    LOW = 0
+
+
+class GPIOPolarity(IntEnum):
+    """GPIOs polarity enum"""
+
+    NORMAL = 0
+    REVERSED = 1
+
+
+class GPI(IntEnum):
+    """GPIs identifier enum"""
+
+    GPI1 = 1
+    GPI2 = 2
+    GPI3 = 3
+    GPI4 = 4
+
+
+class GPO(IntEnum):
+    """GPOs identifier enum"""
+
+    GPO1 = 1
+    GPO2 = 2
+    GPO3 = 3
+    GPO4 = 4

--- a/ingeniamotion/io.py
+++ b/ingeniamotion/io.py
@@ -1,0 +1,225 @@
+from typing import TYPE_CHECKING, Union
+
+import ingenialogger
+
+from ingeniamotion.enums import GPI, GPO, DigitalVoltageLevel, GPIOPolarity
+from ingeniamotion.exceptions import IMException
+from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
+
+if TYPE_CHECKING:
+    from ingeniamotion.motion_controller import MotionController
+
+
+class InputsOutputs(metaclass=MCMetaClass):
+    GPIO_IN_VALUE_REGISTER = "IO_IN_VALUE"
+    GPIO_IN_POLARITY_REGISTER = "IO_IN_POLARITY"
+
+    GPIO_OUT_VALUE_REGISTER = "IO_OUT_VALUE"
+    GPIO_OUT_SET_POINT_REGISTER = "IO_OUT_SET_POINT"
+    GPIO_OUT_POLARITY_REGISTER = "IO_OUT_POLARITY"
+
+    def __init__(self, motion_controller: "MotionController") -> None:
+        self.mc = motion_controller
+        self.logger = ingenialogger.get_logger(__name__)
+
+    @staticmethod
+    def __get_gpio_bit_value(io_register_value: int, gpio_id: Union[GPI, GPO]) -> bool:
+        """Get the the bit value of a specific GPIO.
+
+        Args:
+            io_register_value: Register value including the bits of all GPIOs.
+            gpi_id: The GPIO identifier.
+
+        Returns:
+            GPIO bit value.
+        """
+        gpio_bit_mask = 1 << (gpio_id - 1)
+        return bool(io_register_value & gpio_bit_mask)
+
+    @staticmethod
+    def __set_gpio_bit_value(
+        io_register_value: int, gpio_id: Union[GPI, GPO], bit_value: bool
+    ) -> int:
+        """Set the the bit value of a specific GPIO.
+
+        Args:
+            io_register_value: Register value including the bits of all GPIOs.
+            gpi_id: The GPIO identifier.
+            bit_value: Bit value to be set.
+
+        Returns:
+            The register value with the corresponding bit set accordingly.
+        """
+        gpio_bit_mask = 1 << (gpio_id - 1)
+        if bit_value:
+            new_register_value = io_register_value | gpio_bit_mask
+        else:
+            new_register_value = io_register_value & ~gpio_bit_mask
+
+        return new_register_value
+
+    def get_gpi_polarity(
+        self, gpi_id: GPI, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS
+    ) -> GPIOPolarity:
+        """Get the polarity of a single GPI.
+
+        Args:
+            gpi_id: the GPI to get the polarity.
+            servo : servo alias to reference it. ``default`` by default.
+            axis : axis that will run the test. 1 by default.
+
+        Returns:
+            Polarity of the specified GPI.
+
+        """
+        gpi_polarity = int(
+            self.mc.communication.get_register(
+                self.GPIO_IN_POLARITY_REGISTER, servo=servo, axis=axis
+            )
+        )
+        gpi_bit_polarity = self.__get_gpio_bit_value(gpi_polarity, gpi_id)
+        return GPIOPolarity(int(gpi_bit_polarity))
+
+    def set_gpi_polarity(
+        self,
+        gpi_id: GPI,
+        polarity: GPIOPolarity,
+        servo: str = DEFAULT_SERVO,
+        axis: int = DEFAULT_AXIS,
+    ) -> None:
+        """Set the polarity of a single GPI.
+
+        Args:
+            gpi_id: the GPI polarity to be set.
+            polarity: polarity to be set.
+            servo : servo alias to reference it. ``default`` by default.
+            axis : axis that will run the test. 1 by default.
+
+        """
+        gpis_actual_polarity = int(
+            self.mc.communication.get_register(
+                self.GPIO_IN_POLARITY_REGISTER, servo=servo, axis=axis
+            )
+        )
+        gpis_new_polarity = self.__set_gpio_bit_value(
+            gpis_actual_polarity, gpi_id, bool(polarity.value)
+        )
+        self.mc.communication.set_register(
+            self.GPIO_IN_POLARITY_REGISTER, gpis_new_polarity, servo=servo, axis=axis
+        )
+
+    def get_gpi_voltage_level(
+        self, gpi_id: GPI, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS
+    ) -> DigitalVoltageLevel:
+        """Get the board voltage level (not the logic level at the uC) of a single GPI.
+
+        Args:
+            gpi_id: the gpi to get the voltage level
+            servo : servo alias to reference it. ``default`` by default.
+            axis : axis that will run the test. 1 by default.
+
+        Returns:
+            LOW if the voltage level is 0, HIGH if the voltage level  is 1.
+
+        """
+        gpi_value = int(
+            self.mc.communication.get_register(self.GPIO_IN_VALUE_REGISTER, servo=servo, axis=axis)
+        )
+        gpi_bit_value = self.__get_gpio_bit_value(gpi_value, gpi_id)
+        gpi_bit_polarity = self.get_gpi_polarity(gpi_id, servo=servo, axis=axis)
+
+        return DigitalVoltageLevel(int(gpi_bit_value ^ gpi_bit_polarity))
+
+    def get_gpo_polarity(
+        self, gpo_id: GPO, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS
+    ) -> GPIOPolarity:
+        """Get the polarity of a single GPO.
+
+        Args:
+            gpo_id: the GPO to get the polarity.
+            servo : servo alias to reference it. ``default`` by default.
+            axis : axis that will run the test. 1 by default.
+
+        Returns:
+            Polarity of the specified GPI.
+
+        """
+        gpo_polarity = int(
+            self.mc.communication.get_register(
+                self.GPIO_OUT_POLARITY_REGISTER, servo=servo, axis=axis
+            )
+        )
+        gpo_bit_polarity = self.__get_gpio_bit_value(gpo_polarity, gpo_id)
+        return GPIOPolarity(int(gpo_bit_polarity))
+
+    def set_gpo_polarity(
+        self,
+        gpo_id: GPO,
+        polarity: GPIOPolarity,
+        servo: str = DEFAULT_SERVO,
+        axis: int = DEFAULT_AXIS,
+    ) -> None:
+        """Set the polarity of a single GPO.
+
+        Args:
+            gpo_id: the GPO polarity to be set.
+            polarity: polarity to be set.
+            servo : servo alias to reference it. ``default`` by default.
+            axis : axis that will run the test. 1 by default.
+
+        """
+        gpos_actual_polarity = int(
+            self.mc.communication.get_register(
+                self.GPIO_OUT_POLARITY_REGISTER, servo=servo, axis=axis
+            )
+        )
+        gpos_new_polarity = self.__set_gpio_bit_value(
+            gpos_actual_polarity, gpo_id, bool(polarity.value)
+        )
+        self.mc.communication.set_register(
+            self.GPIO_OUT_POLARITY_REGISTER, gpos_new_polarity, servo=servo, axis=axis
+        )
+
+    def set_gpo_voltage_level(
+        self,
+        gpo_id: GPO,
+        voltage_level: DigitalVoltageLevel,
+        servo: str = DEFAULT_SERVO,
+        axis: int = DEFAULT_AXIS,
+    ) -> None:
+        """
+        Description:
+            Set the board voltage level (not the logic level at the uC) of a single GPO.
+
+            This function generates the GPO set point from the actual GPO value and modifies
+            the corresponding bit of the desired GPO.
+
+            Finally, it checks that GPOs final value matches with the desired GPOs set point
+
+        Args:
+            gpo_id: the GPO to be set.
+            voltage_level: For each bit, 0 if voltage level is LOW, 1 if voltage level is HIGH
+            servo : servo alias to reference it. ``default`` by default.
+            axis : axis that will run the test. 1 by default.
+
+        Raise:
+            IMException: if the GPOs final value does not match with the desired GPOs set point.
+        """
+
+        gpos_previous_value = int(
+            self.mc.communication.get_register(self.GPIO_OUT_VALUE_REGISTER, servo=servo, axis=axis)
+        )
+        polarity = self.get_gpo_polarity(gpo_id, servo=servo, axis=axis)
+
+        new_bit_value = bool(voltage_level.value ^ polarity)
+
+        gpos_new_set_point = self.__set_gpio_bit_value(gpos_previous_value, gpo_id, new_bit_value)
+        self.mc.communication.set_register(
+            self.GPIO_OUT_SET_POINT_REGISTER, gpos_new_set_point, servo=servo, axis=axis
+        )
+        gpos_final_value = int(
+            self.mc.communication.get_register(self.GPIO_OUT_VALUE_REGISTER, servo=servo, axis=axis)
+        )
+
+        if gpos_final_value != gpos_new_set_point:
+            raise IMException("Unable to set the GPOs set point value.")

--- a/ingeniamotion/motion_controller.py
+++ b/ingeniamotion/motion_controller.py
@@ -10,6 +10,7 @@ from ingeniamotion.configuration import Configuration
 from ingeniamotion.drive_tests import DriveTests
 from ingeniamotion.errors import Errors
 from ingeniamotion.information import Information
+from ingeniamotion.io import InputsOutputs
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 from ingeniamotion.motion import Motion
 
@@ -35,6 +36,7 @@ class MotionController:
         self.__tests: DriveTests = DriveTests(self)
         self.__errors: Errors = Errors(self)
         self.__info: Information = Information(self)
+        self.__io = InputsOutputs(self)
         if FSOE_MASTER_INSTALLED:
             self.__fsoe: FSoEMaster = FSoEMaster(self)
 
@@ -154,3 +156,8 @@ class MotionController:
         if not FSOE_MASTER_INSTALLED:
             raise NotImplementedError("The FSoE module is not available.")
         return self.__fsoe
+
+    @property
+    def io(self) -> InputsOutputs:
+        """Instance of :class:`~ingeniamotion.io.InputsOutputs` class"""
+        return self.__io

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ from typing import Dict
 
 import numpy as np
 import pytest
+from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE
 from virtual_drive.core import VirtualDrive
-from ingenialink.canopen.network import CAN_DEVICE, CAN_BAUDRATE
 
 from ingeniamotion import MotionController
 from ingeniamotion.enums import SensorType
@@ -86,6 +86,7 @@ def motion_controller(pytestconfig, read_config):
     elif protocol == "virtual":
         virtual_drive = VirtualDrive(read_config["port"], read_config["dictionary"])
         virtual_drive.start()
+        virtual_drive.set_value_by_id(1, "IO_IN_VALUE", 0xA)
         connect_eoe(mc, read_config, alias)
     else:
         connect_eoe(mc, read_config, alias)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,131 @@
+import pytest
+
+from ingeniamotion.enums import GPI, GPO, DigitalVoltageLevel, GPIOPolarity
+from ingeniamotion.exceptions import IMException
+
+
+@pytest.mark.virtual
+@pytest.mark.smoke
+def test_get_gpio_bit_value(motion_controller):
+    mc, _ = motion_controller
+    base_value = 0xA3  # 1010 0011
+    bits = [True, True, False, False, False, True, False, True]
+
+    for bit, bit_value in enumerate(bits):
+        gpio_id = bit + 1
+        assert mc.io._InputsOutputs__get_gpio_bit_value(base_value, gpio_id) == bit_value
+
+
+@pytest.mark.virtual
+@pytest.mark.smoke
+def test_set_gpio_bit_value(motion_controller):
+    mc, _ = motion_controller
+    base_value = 0xA3  # 1010 0011
+
+    assert mc.io._InputsOutputs__set_gpio_bit_value(base_value, 1, 0) == 0xA2
+    assert mc.io._InputsOutputs__set_gpio_bit_value(base_value, 2, 0) == 0xA1
+    assert mc.io._InputsOutputs__set_gpio_bit_value(base_value, 3, 1) == 0xA7
+    assert mc.io._InputsOutputs__set_gpio_bit_value(base_value, 4, 1) == 0xAB
+    assert mc.io._InputsOutputs__set_gpio_bit_value(base_value, 5, 1) == 0xB3
+    assert mc.io._InputsOutputs__set_gpio_bit_value(base_value, 6, 0) == 0x83
+    assert mc.io._InputsOutputs__set_gpio_bit_value(base_value, 7, 1) == 0xE3
+    assert mc.io._InputsOutputs__set_gpio_bit_value(base_value, 8, 0) == 0x23
+
+
+@pytest.mark.parametrize("gpi_id", [GPI.GPI1, GPI.GPI2, GPI.GPI3, GPI.GPI4])
+@pytest.mark.parametrize("polarity", [GPIOPolarity.NORMAL, GPIOPolarity.REVERSED])
+@pytest.mark.virtual
+@pytest.mark.smoke
+def test_set_get_gpi_polarity(motion_controller, gpi_id, polarity):
+    mc, alias = motion_controller
+    mc.io.set_gpi_polarity(gpi_id, polarity, servo=alias)
+    assert mc.io.get_gpi_polarity(gpi_id, servo=alias) == polarity
+
+
+@pytest.mark.virtual
+@pytest.mark.smoke
+def test_get_gpi_voltage_level(motion_controller):
+    mc, alias = motion_controller
+
+    mc.communication.set_register("IO_IN_POLARITY", 0, servo=alias)
+
+    assert mc.io.get_gpi_voltage_level(GPI.GPI1, servo=alias) == DigitalVoltageLevel.LOW
+    mc.io.set_gpi_polarity(GPI.GPI1, GPIOPolarity.REVERSED, servo=alias)
+    assert mc.io.get_gpi_voltage_level(GPI.GPI1, servo=alias) == DigitalVoltageLevel.HIGH
+
+    assert mc.io.get_gpi_voltage_level(GPI.GPI2, servo=alias) == DigitalVoltageLevel.HIGH
+    mc.io.set_gpi_polarity(GPI.GPI2, GPIOPolarity.REVERSED, servo=alias)
+    assert mc.io.get_gpi_voltage_level(GPI.GPI2, servo=alias) == DigitalVoltageLevel.LOW
+
+    assert mc.io.get_gpi_voltage_level(GPI.GPI3, servo=alias) == DigitalVoltageLevel.LOW
+    mc.io.set_gpi_polarity(GPI.GPI3, GPIOPolarity.REVERSED, servo=alias)
+    assert mc.io.get_gpi_voltage_level(GPI.GPI3, servo=alias) == DigitalVoltageLevel.HIGH
+
+    assert mc.io.get_gpi_voltage_level(GPI.GPI4, servo=alias) == DigitalVoltageLevel.HIGH
+    mc.io.set_gpi_polarity(GPI.GPI4, GPIOPolarity.REVERSED, servo=alias)
+    assert mc.io.get_gpi_voltage_level(GPI.GPI4, servo=alias) == DigitalVoltageLevel.LOW
+
+
+@pytest.mark.parametrize("gpo_id", [GPO.GPO1, GPO.GPO2, GPO.GPO3, GPO.GPO4])
+@pytest.mark.parametrize("polarity", [GPIOPolarity.NORMAL, GPIOPolarity.REVERSED])
+@pytest.mark.virtual
+@pytest.mark.smoke
+def test_set_get_gpo_polarity(motion_controller, gpo_id, polarity):
+    mc, alias = motion_controller
+    mc.io.set_gpo_polarity(gpo_id, polarity, servo=alias)
+    assert mc.io.get_gpo_polarity(gpo_id, servo=alias) == polarity
+
+
+@pytest.mark.canopen
+@pytest.mark.eoe
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "gpo_id,reg_value",
+    [
+        (GPO.GPO1, 1),
+        (GPO.GPO2, 2),
+        (GPO.GPO3, 4),
+        (GPO.GPO4, 8),
+    ],
+)
+def test_set_gpo_voltage_level(motion_controller, gpo_id, reg_value):
+    mc, alias = motion_controller
+
+    for map_reg in ["IO_OUT_MAP_1", "IO_OUT_MAP_2", "IO_OUT_MAP_3", "IO_OUT_MAP_4"]:
+        mc.communication.set_register(map_reg, 0, servo=alias)
+
+    mc.communication.set_register("IO_OUT_POLARITY", 0, servo=alias)
+    mc.communication.set_register("IO_OUT_SET_POINT", 0, servo=alias)
+
+    mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.HIGH, servo=alias)
+    assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == reg_value
+    mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.LOW, servo=alias)
+    assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == 0
+    mc.io.set_gpo_polarity(gpo_id, GPIOPolarity.REVERSED, servo=alias)
+    mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.LOW, servo=alias)
+    assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == reg_value
+    mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.HIGH, servo=alias)
+    assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == 0
+
+
+@pytest.mark.canopen
+@pytest.mark.eoe
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "gpo_id",
+    [
+        GPO.GPO1,
+        GPO.GPO2,
+        GPO.GPO3,
+        GPO.GPO4,
+    ],
+)
+def test_set_gpo_voltage_level_fail(motion_controller, gpo_id):
+    mc, alias = motion_controller
+
+    mc.communication.set_register("IO_OUT_POLARITY", 0, servo=alias)
+    for map_reg in ["IO_OUT_MAP_1", "IO_OUT_MAP_2", "IO_OUT_MAP_3", "IO_OUT_MAP_4"]:
+        mc.communication.set_register(map_reg, 3, servo=alias)
+
+    with pytest.raises(IMException):
+        mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.LOW, servo=alias)


### PR DESCRIPTION
## Add GPIO module

### Description

This PR adds a new module for GPIOs. It could be extended for configuring and reading analog inputs.

Fixes # INGM-445

### Type of change

- [x] Add IO module
- [x] Add GPIO-related enums.

### Tests
- [x] Add new unit tests.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
