### PR TITLE
INGM-469 The FSoE watchdog is started before it should

### DIFF
--- a/examples/safety_torque_off.py
+++ b/examples/safety_torque_off.py
@@ -16,7 +16,7 @@ def main(interface_ip, slave_id, dict_path):
     mc.motion.set_operation_mode(OperationMode.VELOCITY)
     # Create and start the FSoE master handler
     mc.fsoe.create_fsoe_master_handler()
-    mc.fsoe.start_master(start_pdos=True)
+    mc.fsoe.configure_pdos(start_pdos=True)
     # Wait for the master to reach the Data state
     mc.fsoe.wait_for_state_data()
     # Deactivate the STO
@@ -47,5 +47,5 @@ if __name__ == '__main__':
     # Modify these parameters according to your setup
     network_interface_ip = "192.168.2.1"
     ethercat_slave_id = 1
-    dictionary_path = "safe_dict.xdf"
+    dictionary_path = "C://Users//martin.acosta//OneDrive - Novanta//Documents//issues//INGK-911//den-s-net-e_eoe_2.6.0.xdf"
     main(network_interface_ip, ethercat_slave_id, dictionary_path)

--- a/examples/safety_torque_off.py
+++ b/examples/safety_torque_off.py
@@ -47,5 +47,5 @@ if __name__ == '__main__':
     # Modify these parameters according to your setup
     network_interface_ip = "192.168.2.1"
     ethercat_slave_id = 1
-    dictionary_path = "C://Users//martin.acosta//OneDrive - Novanta//Documents//issues//INGK-911//den-s-net-e_eoe_2.6.0.xdf"
+    dictionary_path = "safe_dict.xdf"
     main(network_interface_ip, ethercat_slave_id, dictionary_path)


### PR DESCRIPTION
### Description

The FSoE watchdog was being started before it should. It should be started once the first Safety Master PDU is sent to the slave.

Fixes # INGM-469

### Type of change

Please add a description and delete options that are not relevant.

- Start the FSoE watchdog once the first request for the Safety PDU Master is received.
- Rename the start_master method to configure_pdos.

### Tests
- Run the example script.
- Check that it works correctly.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
