### PR TITLE
INGM-470 Add optional password for the FOE bootloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Check that registers to be mapped in monitoring are CYCLIC_TX.
 - Method to get the available CAN devices.
 - GPIO module.
+- Optional password for the FOE bootloader.
 
 ### Fix
 - Bug retrieving interface adapter name in Linux.


### PR DESCRIPTION
### Description

Add an optional password for the FOE bootloader

Fixes # INGM-470

### Type of change

- Add an optional password for the FOE bootloader

### Tests
- Load firmware without setting a password.
- Check that the firmware loading process is successful.
- Load firmware using a custom password.
- Check that the firmware loading process fails.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
