### PR TITLE
INGM-347 Add the COM-KIT part number to the product name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Method to get the available CAN devices.
 - GPIO module.
 - Optional password for the FOE bootloader.
+- Method to check if drive is connected via a COM-KIT.
 
 ### Fix
 - Bug retrieving interface adapter name in Linux.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Method to check if drive is connected via a COM-KIT.
+
 ## [0.8.2] - 2024-07-15
 ### Added
 - FSoE module.
@@ -9,7 +13,6 @@
 - Method to get the available CAN devices.
 - GPIO module.
 - Optional password for the FOE bootloader.
-- Method to check if drive is connected via a COM-KIT.
 
 ### Fix
 - Bug retrieving interface adapter name in Linux.

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -24,6 +24,9 @@ logger = ingenialogger.get_logger(__name__)
 class Information(metaclass=MCMetaClass):
     """Information."""
 
+    PRODUCT_CODE_COMKIT = 0x3214001
+    PART_NUMBER_COMKIT = "COM-KIT"
+
     def __init__(self, motion_controller: "MotionController"):
         self.mc = motion_controller
 
@@ -155,9 +158,9 @@ class Information(metaclass=MCMetaClass):
         """
         drive = self.mc.servos[servo]
         product_name = drive.dictionary.part_number
-        if product_name is not None:
-            return f"{product_name}"
-        return None
+        if self.is_comkit(servo):
+            return f"{product_name} + {self.PART_NUMBER_COMKIT}"
+        return product_name
 
     def get_node_id(self, servo: str = DEFAULT_SERVO) -> int:
         """Get the node ID for CANopen communications.
@@ -326,3 +329,16 @@ class Information(metaclass=MCMetaClass):
         """
         drive = self.mc.servos[servo]
         return drive.dictionary.image
+
+    def is_comkit(self, servo: str = DEFAULT_SERVO) -> bool:
+        """Check if drive is connected via a COM-KIT.
+
+        Args:
+            servo: Alias of the drive.
+
+        Returns:
+            True if using COM-KIT, False otherwise.
+
+        """
+        drive = self.mc.servos[servo]
+        return drive.dictionary.coco_product_code == self.PRODUCT_CODE_COMKIT

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@develop
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@INGK-950-create-coco-product-code-attribute
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
### Description

 Add the COM-KIT part number to the product name.

Fixes # INGM-347

### Type of change

- Add the is_comkit method.
- Add the COM-KIT part number to the product name


### Tests
- Connect to a COM-KIT.
- Check that the product name shows the CORE and COM-KIT part numbers.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingeniamotion tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
