### PR TITLE
Fix coverage reports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -361,11 +361,6 @@ pipeline {
             }
         }
         stage('Publish coverage') {
-            // TODO: Remove when condition when INGM-395 is fixed 
-            when {
-                beforeAgent true
-                expression { false }
-            }
             agent {
                 docker {
                     label SW_NODE

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -384,7 +384,7 @@ pipeline {
                             py -${DEFAULT_PYTHON_VERSION} -m tox -e coverage -- .coverage_eoe .coverage_canopen .coverage_virtual .coverage_soem
                         """
 
-                        publishCoverage adapters: [coberturaReportAdapter('coverage.xml')]
+                        recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'coverage.xml']])
                         archiveArtifacts artifacts: '*.xml'
                     }
                 }


### PR DESCRIPTION
Simply removing the condition combined and published the report.
It only contains overview information. No line, branch coverage and others, but seems to be the case for all SW projects, not specific to ingeniamotion.
The plugin seems to be deprecated: https://www.jenkins.io/doc/pipeline/steps/code-coverage-api/
We should migrate to this newer that seems way better: https://plugins.jenkins.io/coverage/