### PR TITLE
Ingm 476 make fsoe master module optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Changed
+- Make fsoe_master an optional requirement
+
 ## [0.8.2] - 2024-07-15
 ### Added
 - FSoE module.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ pipeline {
                             }
                             axis {
                                 name 'PYTHON'
-                                values '39', '310', '311'
+                                values '39', '310', '311', '312'
                             }
                         }
                         excludes {
@@ -293,7 +293,7 @@ pipeline {
                             }
                             axis {
                                 name 'PYTHON'
-                                values '39', '310', '311'
+                                values '39', '310', '311', '312'
                             }
                         }
                         excludes {

--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -2,14 +2,21 @@ import time
 from typing import TYPE_CHECKING, Dict, Optional
 
 import ingenialogger
-from fsoe_master.fsoe_master import (
-    ApplicationParameter,
-    Dictionary,
-    DictionaryItem,
-    DictionaryItemInputOutput,
-    MasterHandler,
-    StateData,
-)
+
+try:
+    from fsoe_master.fsoe_master import (
+        ApplicationParameter,
+        Dictionary,
+        DictionaryItem,
+        DictionaryItemInputOutput,
+        MasterHandler,
+        StateData,
+    )
+except ImportError:
+    FSOE_MASTER_INSTALLED = False
+else:
+    FSOE_MASTER_INSTALLED = True
+
 from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
@@ -36,6 +43,8 @@ class FSoEMasterHandler:
     PROCESS_DATA_COMMAND = 0x36
 
     def __init__(self, slave_address: int, connection_id: int, watchdog_timeout: float):
+        if not FSOE_MASTER_INSTALLED:
+            return
         self.__master_handler = MasterHandler(
             dictionary=self._saco_phase_1_dictionary(),
             slave_address=slave_address,
@@ -143,7 +152,7 @@ class FSoEMasterHandler:
                 raise IMTimeoutError("The FSoE Master did not reach the Data state")
 
     @staticmethod
-    def _saco_phase_1_dictionary() -> Dictionary:
+    def _saco_phase_1_dictionary() -> "Dictionary":
         """Get the SaCo phase 1 dictionary instance"""
         sto_command_dict_item = DictionaryItemInputOutput(
             key=0x040,

--- a/ingeniamotion/motion_controller.py
+++ b/ingeniamotion/motion_controller.py
@@ -9,11 +9,17 @@ from ingeniamotion.communication import Communication
 from ingeniamotion.configuration import Configuration
 from ingeniamotion.drive_tests import DriveTests
 from ingeniamotion.errors import Errors
-from ingeniamotion.fsoe import FSoEMaster
 from ingeniamotion.information import Information
 from ingeniamotion.io import InputsOutputs
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 from ingeniamotion.motion import Motion
+
+try:
+    from ingeniamotion.fsoe import FSoEMaster
+except ImportError:
+    FSOE_MASTER_INSTALLED = False
+else:
+    FSOE_MASTER_INSTALLED = True
 
 
 class MotionController:
@@ -31,7 +37,8 @@ class MotionController:
         self.__errors: Errors = Errors(self)
         self.__info: Information = Information(self)
         self.__io = InputsOutputs(self)
-        self.__fsoe: FSoEMaster = FSoEMaster(self)
+        if FSOE_MASTER_INSTALLED:
+            self.__fsoe: FSoEMaster = FSoEMaster(self)
 
     def servo_name(self, servo: str = DEFAULT_SERVO) -> str:
         return "{} ({})".format(self.servos[servo].info["product_code"], servo)
@@ -146,6 +153,8 @@ class MotionController:
     @property
     def fsoe(self) -> "FSoEMaster":
         """Instance of :class:`~ingeniamotion.fsoe.FSoEMaster` class"""
+        if not FSOE_MASTER_INSTALLED:
+            raise NotImplementedError("The FSoE module is not available.")
         return self.__fsoe
 
     @property

--- a/ingeniamotion/motion_controller.py
+++ b/ingeniamotion/motion_controller.py
@@ -9,17 +9,11 @@ from ingeniamotion.communication import Communication
 from ingeniamotion.configuration import Configuration
 from ingeniamotion.drive_tests import DriveTests
 from ingeniamotion.errors import Errors
+from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED, FSoEMaster
 from ingeniamotion.information import Information
 from ingeniamotion.io import InputsOutputs
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 from ingeniamotion.motion import Motion
-
-try:
-    from ingeniamotion.fsoe import FSoEMaster
-except ImportError:
-    FSOE_MASTER_INSTALLED = False
-else:
-    FSOE_MASTER_INSTALLED = True
 
 
 class MotionController:
@@ -154,7 +148,11 @@ class MotionController:
     def fsoe(self) -> "FSoEMaster":
         """Instance of :class:`~ingeniamotion.fsoe.FSoEMaster` class"""
         if not FSOE_MASTER_INSTALLED:
-            raise NotImplementedError("The FSoE module is not available.")
+            raise NotImplementedError(
+                "The FSoE module is not available. "
+                "Install ingeniamotion with FSoE feature: "
+                "pip install ingeniamotion[FSoE]"
+            )
         return self.__fsoe
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,9 @@ setuptools.setup(
         "ingenialink>=7.3.3, < 8.0.0",
         "ingenialogger>=0.2.1",
         "ifaddr==0.1.7",
-        "fsoe-master==0.1.1"
     ],
+    extras_require={
+        "FSoE": ["fsoe-master==0.1.1"],
+    },
     python_requires=">=3.9",
 )

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -4,10 +4,14 @@ import pytest
 
 
 @pytest.mark.virtual
-def test_import_fsoe_master():
-    if platform.system() != "Windows":
-        pytest.skip("Currently it can only be tested on Windows")
+def test_fsoe_master_not_installed():
     try:
         import fsoe_master
     except ModuleNotFoundError:
-        pytest.fail("Cannot import the fsoe_master module.")
+        pass
+    else:
+        pytest.skip("fsoe_master is installed")
+    import ingeniamotion
+    mc = ingeniamotion.MotionController()
+    with pytest.raises(NotImplementedError):
+        mc.fsoe

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -12,6 +12,7 @@ def test_fsoe_master_not_installed():
     else:
         pytest.skip("fsoe_master is installed")
     import ingeniamotion
+
     mc = ingeniamotion.MotionController()
     with pytest.raises(NotImplementedError):
         mc.fsoe

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = coverage, build, firmware, docs, format, type, py{39,310,311}, virtual
+env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, virtual
 
 # Use this deps to install custom requirements in develop.
 # For instance, to install ingenialink from a custom branch.


### PR DESCRIPTION
Fixes # INGM-476

### Type of change

- [x] Add fsoe_master as extra requirement
- [x] Turn on python 3.12 test again


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
