### PR TITLE
use relative file sources for coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+relative_files = True


### PR DESCRIPTION
Same issue encountered in https://github.com/ingeniamc/ingenialink-python/pull/459/files#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449

The coverage reports have absolute paths, with reference to the source code on the node that they are being build.
But the report is (sometimes) generated on another node, where the path is no longer found.

https://github.com/ryanluker/vscode-coverage-gutters/issues/268#issuecomment-864035922
https://github.com/nedbat/coveragepy/issues/597
