### PR TITLE
Ignore initial zeros of saco and avoid session reset1 transitions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
     ruff check {posargs:ingeniamotion}
   
 [testenv:reformat]
-description = check format
+description = reformat files and fix lint errors
 skip_install = true
 deps =
     ruff==0.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,15 @@ deps =
 commands =
     ruff format --check {posargs:ingeniamotion tests}
     ruff check {posargs:ingeniamotion}
+  
+[testenv:reformat]
+description = check format
+skip_install = true
+deps =
+    ruff==0.2.2
+commands =
+    ruff format {posargs:ingeniamotion tests}
+    ruff check --fix {posargs:ingeniamotion}
 
 [testenv:type]
 description = run type checks


### PR DESCRIPTION
### Description

Saco responds with initial zeros after initializing FSoE, and while this is technically and error from it's part, we want to avoid triggering additional errors to the user. The master now will ignore all frames that start with 0 (which is invalid command) after start() is called. After a valid command is receive all frames will be passed and evaluated.

### Tests

RESET1 transition no longer appears on wizard test:
![image](https://github.com/user-attachments/assets/30b892e0-4fbc-4304-af79-4de5825cb01b)

DATA_RESET2 still appears when finishing the test:
https://novantamotion.atlassian.net/browse/INGK-958

- [x] Set fix version field in the Jira issue.