### PR TITLE
Improve jenkins build performance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,58 +6,84 @@ def ECAT_NODE_LOCK = "test_execution_lock_ecat"
 def CAN_NODE = "canopen-test"
 def CAN_NODE_LOCK = "test_execution_lock_can"
 
-def DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:1.4"
+def LIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/docker-python:dev"
+def WIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:dev"
 
-def DEFAULT_TOX_PYTHON_VERSION = "39"
-def DEFAULT_PYTHON_VERSION = "3.9"
-def TOX_VERSION = "4.12.1"
+DEFAULT_PYTHON_VERSION = "3.9"
 
-def SMOKE_TESTS_FLAG = ""
+ALL_PYTHON_VERSIONS = "py39,py310,py311,py312"
+RUN_PYTHON_VERSIONS = ""
+def PYTHON_VERSION_MIN = "py39"
+def PYTHON_VERSION_MAX = "py312"
+
+SMOKE_TESTS_FLAG = ""
 
 def BRANCH_NAME_MASTER = "master"
 def DISTEXT_PROJECT_DIR = "doc/ingeniamotion"
 
-def dockerInstallTox = {
-    bat """
-        py -${DEFAULT_PYTHON_VERSION} -m pip install tox==${TOX_VERSION}
-    """
-}
+coverage_stashes = []
 
-def installTox = {
-    bat """
-        py -${DEFAULT_PYTHON_VERSION} -m venv venv
-        venv\\Scripts\\python.exe -m pip install tox==${TOX_VERSION}
-    """
+def runTestHW(protocol, slave) {
+    try {
+        bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
+                "${SMOKE_TESTS_FLAG} " +
+                "--protocol ${protocol} " +
+                "--slave ${slave} " +
+                "--junitxml=pytest_reports/pytest_${protocol}_${slave}_report_py.xml"
+    } catch (err) {
+        unstable(message: "Tests failed")
+    } finally {
+        coverage_stash = ".coverage_${protocol}_${slave}"
+        bat "move .coverage ${coverage_stash}"
+        junit "pytest_reports\\pytest_${protocol}_${slave}_report_py.xml"
+        stash includes: coverage_stash, name: coverage_stash
+        coverage_stashes.add(coverage_stash)
+    }
 }
 
 pipeline {
     agent none
     parameters {
         choice(
-            choices: ['Smoke', 'All'], 
-            name: 'TESTS'
+                choices: ['Smoke', 'All'],
+                name: 'TESTS'
         )
     }
     stages {
+        stage("Set env") {
+            steps {
+                script {
+                    if (env.BRANCH_NAME == 'master') {
+                        RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
+                        SMOKE_TESTS_FLAG = ""
+                    } else if (env.BRANCH_NAME == 'develop') {
+                        RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
+                        SMOKE_TESTS_FLAG = ""
+                    } else if (env.BRANCH_NAME.startsWith('release/')) {
+                        RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
+                        SMOKE_TESTS_FLAG = ""
+                    } else {
+                        RUN_PYTHON_VERSIONS = "${PYTHON_VERSION_MIN},${PYTHON_VERSION_MAX}"
+                        if (params.TESTS == 'Smoke') {
+                            SMOKE_TESTS_FLAG = "-m smoke"
+                        }
+                    }
+                }
+            }
+        }
+
         stage('Run tests on Linux') {
             agent {
                 docker {
                     label "worker"
-                    image "ingeniacontainers.azurecr.io/docker-python:1.4"
+                    image LIN_DOCKER_IMAGE
                 }
             }
             stages {
-                stage('Install deps') {
-                    steps {
-                        sh """
-                            python${DEFAULT_PYTHON_VERSION} -m pip install tox==${TOX_VERSION}
-                        """
-                    }
-                }
                 stage('Run no-connection tests') {
                     steps {
                         sh """
-                            python${DEFAULT_PYTHON_VERSION} -m tox -e py${DEFAULT_TOX_PYTHON_VERSION} -- -m virtual --protocol virtual --junitxml=pytest_virtual_report.xml
+                            python${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- -m virtual --protocol virtual --junitxml=pytest_virtual_report.xml
                         """
                     }
                     post {
@@ -72,56 +98,44 @@ pipeline {
             agent {
                 docker {
                     label SW_NODE
-                    image DOCKER_IMAGE
+                    image WIN_DOCKER_IMAGE
                 }
             }
             stages {
-                stage('Install deps') {
-                    steps {
-                        script {dockerInstallTox ()}
-                    }
-                }
                 stage('Build wheels') {
                     steps {
-                        bat """
-                             tox -e build
-                        """
+                        bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e build"
                     }
                 }
                 stage('Make a static type analysis') {
                     steps {
-                        bat """
-                            tox -e type
-                        """
+                        bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
                     }
                 }
                 stage('Check formatting') {
                     steps {
-                        bat """
-                            tox -e format
-                        """
+                        bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
                     }
                 }
                 stage('Generate documentation') {
                     steps {
-                        bat """
-                            tox -e docs
-                        """
+                        bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e docs"
                     }
                 }
                 stage("Run virtual drive tests") {
                     steps {
-                        bat """
-                            tox -e py${DEFAULT_TOX_PYTHON_VERSION} -- -m virtual --protocol virtual --junitxml=pytest_reports\\pytest_virtual_report.xml
-                        """
+                        bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- -m" +
+                                " virtual --protocol virtual " +
+                                "--junitxml=pytest_reports\\pytest_virtual_report.xml"
                     }
                     post {
                         always {
-                            bat """
-                                move .coverage .coverage_virtual
-                            """    
+                            bat "move .coverage .coverage_virtual"
                             junit "pytest_reports\\pytest_virtual_report.xml"
-                            stash includes: '.coverage_virtual', name: 'coverage_report_virtual'
+                            stash includes: '.coverage_virtual', name: '.coverage_virtual'
+                            script {
+                                coverage_stashes.add(".coverage_virtual")
+                            }
                         }
                     }
                 }
@@ -136,7 +150,7 @@ pipeline {
                 }
             }
         }
-        stage('Publish ingeniamotion'){
+        stage('Publish ingeniamotion') {
             when {
                 beforeAgent true
                 branch BRANCH_NAME_MASTER
@@ -154,238 +168,89 @@ pipeline {
                 publishPyPi("dist/*")
             }
         }
-        stage('Ecat tests') {
-            options {
-                lock(ECAT_NODE_LOCK)
-            }
-            agent {
-                label ECAT_NODE
-            }
-            stages {
-                stage("Checkout") {
-                    steps {
-                        checkout scm
-                        script {installTox ()}
+
+        stage('Run tests with HW') {
+            parallel {
+                stage('CanOpen and Ethernet') {
+                    options {
+                        lock(CAN_NODE_LOCK)
+                    }
+                    agent {
+                        label CAN_NODE
+                    }
+                    stages {
+                        stage("Canopen - Slave 0") {
+                            steps {
+                                runTestHW("canopen", 0)
+                            }
+                        }
+                        stage("Ethernet - Slave 0") {
+                            steps {
+                                runTestHW("eoe", 0)
+                            }
+                        }
+                        stage("Canopen - Slave 1") {
+                            steps {
+                                runTestHW("canopen", 1)
+                            }
+                        }
+                        stage("Ethernet - Slave 1") {
+                            when {
+                                // Remove this after fixing CAP-924
+                                expression { false }
+                            }
+                            steps {
+                                runTestHW("eoe", 1)
+                            }
+                        }
                     }
                 }
-                stage('Run tests') {
-                    matrix {
-                        axes {
-                            axis {
-                                name 'SLAVE'
-                                values '0', '1'
+                stage('Ethercat') {
+                    options {
+                        lock(ECAT_NODE_LOCK)
+                    }
+                    agent {
+                        label ECAT_NODE
+                    }
+                    stages {
+                        stage("Ethercat - Slave 0") {
+                            when {
+                                // Remove this after fixing INGM-376
+                                expression { false }
                             }
-                            axis {
-                                name 'PYTHON'
-                                values '39', '310', '311', '312'
-                            }
-                        }
-                        excludes {
-                            // Remove this exclude after fixing INGM-376
-                            exclude {
-                                axis {
-                                    name 'SLAVE'
-                                    values '0'
-                                }
+                            steps {
+                                runTestHW("soem", 0)
                             }
                         }
-                        stages {
-                            stage('Set env to run only smoke tests') {
-                                when {
-                                    allOf{
-                                        not{ branch 'master' };
-                                        not{ branch 'develop' };
-                                        expression { params.TESTS == 'Smoke' }
-                                    }
-                                }
-                                steps {
-                                    script {
-                                        SMOKE_TESTS_FLAG = "-m smoke"
-                                    }
-                                }
-                            }
-                            stage('Set env to run all tests') {
-                                when {
-                                    anyOf{
-                                        branch 'master';
-                                        branch 'develop';
-                                        expression { params.TESTS == 'All' }
-                                    }
-                                }
-                                steps {
-                                    script {
-                                        SMOKE_TESTS_FLAG = ""
-                                    }
-                                }
-                            }
-                            stage('Run tests') {
-                                options {
-                                    lock('sequential-matrix')
-                                }
-                                when {
-                                    anyOf{
-                                        expression { SMOKE_TESTS_FLAG == "" };
-                                        allOf {
-                                            expression { SMOKE_TESTS_FLAG == "-m smoke" };
-                                            expression { PYTHON == DEFAULT_TOX_PYTHON_VERSION }
-                                        }
-                                    }
-                                }
-                                steps {
-                                    bat """
-                                        venv\\Scripts\\python.exe -m tox -e py${PYTHON} -- ${SMOKE_TESTS_FLAG} --protocol soem --slave ${SLAVE} --junitxml=pytest_reports/pytest_soem_${SLAVE}_report_py${PYTHON}.xml
-                                    """
-                                }
-                                post {
-                                    always {
-                                        bat """
-                                            move .coverage .coverage_soem
-                                        """    
-                                        junit "pytest_reports\\pytest_soem_${SLAVE}_report_py${PYTHON}.xml"
-                                        archiveArtifacts artifacts: "pytest_reports\\pytest_soem_${SLAVE}_report_py${PYTHON}.xml"
-                                        stash includes: ".coverage_soem", name: "coverage_report_soem"
-                                    }
-                                }
+                        stage("Ethercat - Slave 1") {
+                            steps {
+                                runTestHW("soem", 1)
                             }
                         }
-                    }          
+                    }
                 }
             }
         }
-        stage('Canopen and ethernet tests') {
-            options {
-                lock(CAN_NODE_LOCK)
-            }
-            agent {
-                label CAN_NODE
-            }
-            stages {
-                stage("Checkout") {
-                    steps {
-                        checkout scm
-                        script {installTox ()}
-                    }
-                }
-                stage('Run tests') {
-                    matrix {
-                        axes {
-                            axis {
-                                name 'PROTOCOL'
-                                values 'canopen', 'eoe'
-                            }
-                            axis {
-                                name 'SLAVE'
-                                values '0', '1'
-                            }
-                            axis {
-                                name 'PYTHON'
-                                values '39', '310', '311', '312'
-                            }
-                        }
-                        excludes {
-                            // Remove this exclude after fixing CAP-924
-                            exclude {
-                                axis {
-                                    name 'PROTOCOL'
-                                    values 'eoe'
-                                }
-                                axis {
-                                    name 'SLAVE'
-                                    values '1'
-                                }
-                            }
-                        }
-                        stages {
-                            stage('Set env to run only smoke tests') {
-                                when {
-                                    allOf{
-                                        not{ branch 'master' };
-                                        not{ branch 'develop' };
-                                        expression { params.TESTS == 'Smoke' }
-                                    }
-                                }
-                                steps {
-                                    script {
-                                        SMOKE_TESTS_FLAG = "-m smoke"
-                                    }
-                                }
-                            }
-                            stage('Set env to run all tests') {
-                                when {
-                                    anyOf{
-                                        branch 'master';
-                                        branch 'develop';
-                                        expression { params.TESTS == 'All' }
-                                    }
-                                }
-                                steps {
-                                    script {
-                                        SMOKE_TESTS_FLAG = ""
-                                    }
-                                }
-                            }
-                            stage('Run tests') {
-                                options {
-                                    lock('sequential-matrix')
-                                }
-                                when {
-                                    anyOf{
-                                        expression { SMOKE_TESTS_FLAG == "" };
-                                        allOf {
-                                            expression { SMOKE_TESTS_FLAG == "-m smoke" };
-                                            expression { PYTHON == DEFAULT_TOX_PYTHON_VERSION }
-                                        }
-                                    }
-                                }
-                                steps {
-                                    bat """
-                                        venv\\Scripts\\python.exe -m tox -e py${PYTHON} -- ${SMOKE_TESTS_FLAG} --protocol ${PROTOCOL} --slave ${SLAVE} --junitxml=pytest_reports/pytest_${PROTOCOL}_${SLAVE}_report_py${PYTHON}.xml
-                                    """
-                                }
-                                post {
-                                    always {
-                                        bat """
-                                            move .coverage .coverage_${PROTOCOL}
-                                        """    
-                                        junit "pytest_reports\\pytest_${PROTOCOL}_${SLAVE}_report_py${PYTHON}.xml"
-                                        archiveArtifacts artifacts: "pytest_reports\\pytest_${PROTOCOL}_${SLAVE}_report_py${PYTHON}.xml"
-                                        stash includes: ".coverage_${PROTOCOL}", name: "coverage_report_${PROTOCOL}"
-                                    }
-                                }
-                            }
-                        }
-                    }          
-                }
-            }
-        }
+
         stage('Publish coverage') {
             agent {
                 docker {
                     label SW_NODE
-                    image DOCKER_IMAGE
+                    image WIN_DOCKER_IMAGE
                 }
             }
-            stages {
-                stage('Install deps') {
-                    steps {
-                        script {dockerInstallTox ()}
-                    }
-                }
-                stage('Publish coverage') {
-                    steps {
-                        unstash 'coverage_report_virtual'
-                        unstash 'coverage_report_eoe'
-                        unstash 'coverage_report_canopen'
-                        unstash 'coverage_report_soem'
- 
-                        bat """
-                            py -${DEFAULT_PYTHON_VERSION} -m tox -e coverage -- .coverage_eoe .coverage_canopen .coverage_virtual .coverage_soem
-                        """
+            steps {
+                script {
+                    def coverage_files = ""
 
-                        recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'coverage.xml']])
-                        archiveArtifacts artifacts: '*.xml'
+                    for (coverage_stash in coverage_stashes) {
+                        unstash coverage_stash
+                        coverage_files += " " + coverage_stash
                     }
+                    bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e coverage -- ${coverage_files}"
                 }
+                recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'coverage.xml']])
+                archiveArtifacts artifacts: '*.xml'
             }
         }
     }

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1425,10 +1425,14 @@ class Communication(metaclass=MCMetaClass):
             The ID offset (relative position in the ensemble) of the selected slave.
         """
         for slave_id_offset in mapping:
-            _, product_code, revision_number = mapping[slave_id_offset]
-            if product_code == slave_info.product_code and (
-                revision_number & self.ENSEMBLE_SLAVE_REV_NUM_MASK
-            ) == (slave_info.revision_number & self.ENSEMBLE_SLAVE_REV_NUM_MASK):
+            _, mapping_product_code, mapping_revision_number = mapping[slave_id_offset]
+            scanned_product_code = slave_info.product_code
+            scanned_revision_number = slave_info.revision_number
+            if scanned_product_code is None or scanned_revision_number is None:
+                continue
+            if mapping_product_code == scanned_product_code and (
+                mapping_revision_number & self.ENSEMBLE_SLAVE_REV_NUM_MASK
+            ) == (scanned_revision_number & self.ENSEMBLE_SLAVE_REV_NUM_MASK):
                 return slave_id_offset
         raise IMException("The selected drive is not part of the ensemble.")
 

--- a/tests/dictionaries/__init__.py
+++ b/tests/dictionaries/__init__.py
@@ -1,0 +1,4 @@
+from os.path import abspath, dirname, join
+
+PATH = dirname(abspath(__file__))
+VIRTUAL_DRIVE_XDF_PATH = join(PATH, "virtual_drive.xdf")

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 import pytest
 from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
-from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.exceptions import ILError
 from ingenialink.network import SlaveInfo
 from ingenialink.servo import SERVO_STATE
@@ -274,7 +273,8 @@ def test_load_firmware_canopen_exception(motion_controller):
 @pytest.mark.virtual
 def test_boot_mode_and_load_firmware_ethernet_exception(mocker, motion_controller):
     mc, alias = motion_controller
-    mocker.patch.object(mc, "_get_network", return_value=EthercatNetwork("fake_interface_name"))
+
+    mocker.patch.object(mc, "_get_network", return_value=object())
     with pytest.raises(ValueError):
         mc.communication.boot_mode_and_load_firmware_ethernet("fake_fw_file.lfu", servo=alias)
 
@@ -282,7 +282,7 @@ def test_boot_mode_and_load_firmware_ethernet_exception(mocker, motion_controlle
 @pytest.mark.virtual
 def test_load_firmware_moco_exception(mocker, motion_controller):
     mc, alias = motion_controller
-    mocker.patch.object(mc, "_get_network", return_value=EthercatNetwork("fake_interface_name"))
+    mocker.patch.object(mc, "_get_network", return_value=object())
     with pytest.raises(ValueError):
         mc.communication.load_firmware_moco("fake_fw_file.lfu", servo=alias)
 
@@ -329,6 +329,7 @@ def test_scan_servos_canopen(mocker):
 def test_scan_servos_ethercat_with_info(mocker):
     mc = MotionController()
     detected_slaves = OrderedDict({1: SlaveInfo(1234, 123), 2: SlaveInfo(1234, 123)})
+    mocker.patch("ingenialink.ethercat.network.EthercatNetwork.__init__", return_value=None)
     mocker.patch(
         "ingenialink.ethercat.network.EthercatNetwork.scan_slaves_info",
         return_value=detected_slaves,
@@ -340,6 +341,7 @@ def test_scan_servos_ethercat_with_info(mocker):
 def test_scan_servos_ethercat(mocker):
     mc = MotionController()
     detected_slaves = [1, 2]
+    mocker.patch("ingenialink.ethercat.network.EthercatNetwork.__init__", return_value=None)
     mocker.patch(
         "ingenialink.ethercat.network.EthercatNetwork.scan_slaves",
         return_value=detected_slaves,
@@ -462,6 +464,7 @@ def test_load_ensemble_fw_ecat(mocker):
     fw_file1 = os.path.join(temp_path, "cap-net-1-e_2.4.0.lfu")
     fw_file2 = os.path.join(temp_path, "cap-net-2-e_2.4.0.lfu")
     mc = MotionController()
+    mocker.patch("ingenialink.ethercat.network.EthercatNetwork.__init__", return_value=None)
     mocker.patch(
         "ingenialink.ethercat.network.EthercatNetwork.scan_slaves_info", return_value=slaves
     )

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -137,8 +137,12 @@ def test_get_name(motion_controller):
 @pytest.mark.virtual
 def test_get_communication_type(mocker, motion_controller, communication, expected_result, args):
     mc, alias = motion_controller
+
+    mocker.patch("ingenialink.ethercat.network.EthercatNetwork.__init__", return_value=None)
+
     if communication != EthernetNetwork:
         mocker.patch.object(mc, "_get_network", return_value=communication(args))
+
     communication_type = mc.info.get_communication_type(alias)
     assert communication_type == expected_result
 
@@ -155,6 +159,9 @@ def test_get_communication_type(mocker, motion_controller, communication, expect
 @pytest.mark.virtual
 def test_get_full_name(mocker, motion_controller, communication, expected_result, args):
     mc, alias = motion_controller
+
+    mocker.patch("ingenialink.ethercat.network.EthercatNetwork.__init__", return_value=None)
+
     if communication != EthernetNetwork:
         mocker.patch.object(mc, "_get_network", return_value=communication(args))
     full_name = mc.info.get_full_name(alias)
@@ -229,6 +236,7 @@ def test_get_node_id_exception(motion_controller):
 @pytest.mark.virtual
 def test_get_ip_exception(mocker, motion_controller):
     mc, alias = motion_controller
+    mocker.patch("ingenialink.ethercat.network.EthercatNetwork.__init__", return_value=None)
     mocker.patch.object(mc, "_get_network", return_value=EthercatNetwork("fake_interface_name"))
     with pytest.raises(IMException):
         mc.info.get_ip(alias)
@@ -260,6 +268,7 @@ def test_get_baudrate_success(motion_controller, mocker):
 def test_get_baudrate_failed(motion_controller, mocker):
     mc, alias = motion_controller
 
+    mocker.patch("ingenialink.ethercat.network.EthercatNetwork.__init__", return_value=None)
     mocker.patch.object(mc, "_get_network", return_value=EthercatNetwork("fake_interface_name"))
     with pytest.raises(IMException) as imexpeption_info:
         _ = mc.info.get_baudrate(alias)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@develop
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@ce95b0e
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
Improve the time it takes to build and test ingeniamotion.
The time it used to took was roughly 2:30h, now the last test I did took 54 min.

This is accomplished by
- Only running python versions 3.9 and 3.12 during development. On master, develop and release branches all will be built and tested.
- Parallelizing ethercat and canopen tests
- Reusing as much as possible the tox environments on HW Nodes. Now they are started once and all stages happen on the same session. Non-blocking tests are acomplished by marking the tests as unstable instead of fail. Rusage of the code is done throught groovy scripting instead of matrix.
- Using images that have tox built-in to avoid installing it.

Additionally some test with virtual drive had to be adapted since the new docker image doesnt have the DLLS necessary to instantiate a pysoem master

- [x] Update docker images with released ones