### PR TITLE
Ingm 489 set gpo voltage level inverted logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Changed
 - BaseTest class typing
 
+### Fix
+- Fix set_gpo_voltage_level and get_gpi_voltage_level functions
+
 ## [0.8.3] - 2024-07-26
 ### Changed
 - Make fsoe_master an optional requirement

--- a/docs/ingeniamotion/io.rst
+++ b/docs/ingeniamotion/io.rst
@@ -1,0 +1,5 @@
+IO
+==
+
+.. autoclass:: ingeniamotion.io.InputsOutputs
+   :members:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -13,5 +13,6 @@ Ingenia Motion
    ingeniamotion/fsoe
    ingeniamotion/errors
    ingeniamotion/info
+   ingeniamotion/io
    ingeniamotion/enums
    ingeniamotion/exceptions

--- a/ingeniamotion/io.py
+++ b/ingeniamotion/io.py
@@ -24,11 +24,11 @@ class InputsOutputs(metaclass=MCMetaClass):
 
     @staticmethod
     def __get_gpio_bit_value(io_register_value: int, gpio_id: Union[GPI, GPO]) -> bool:
-        """Get the the bit value of a specific GPIO.
+        """Get the bit value of a specific GPIO.
 
         Args:
             io_register_value: Register value including the bits of all GPIOs.
-            gpi_id: The GPIO identifier.
+            gpio_id: The GPIO identifier.
 
         Returns:
             GPIO bit value.
@@ -40,7 +40,7 @@ class InputsOutputs(metaclass=MCMetaClass):
     def __set_gpio_bit_value(
         io_register_value: int, gpio_id: Union[GPI, GPO], bit_value: bool
     ) -> int:
-        """Set the the bit value of a specific GPIO.
+        """Set the bit value of a specific GPIO.
 
         Args:
             io_register_value: Register value including the bits of all GPIOs.
@@ -119,7 +119,7 @@ class InputsOutputs(metaclass=MCMetaClass):
             axis : axis that will run the test. 1 by default.
 
         Returns:
-            LOW if the voltage level is 0, HIGH if the voltage level  is 1.
+            LOW if the voltage level is 0, HIGH if the voltage level is 1.
 
         """
         gpi_value = int(
@@ -128,7 +128,7 @@ class InputsOutputs(metaclass=MCMetaClass):
         gpi_bit_value = self.__get_gpio_bit_value(gpi_value, gpi_id)
         gpi_bit_polarity = self.get_gpi_polarity(gpi_id, servo=servo, axis=axis)
 
-        return DigitalVoltageLevel(int(gpi_bit_value ^ gpi_bit_polarity))
+        return DigitalVoltageLevel(int(not gpi_bit_value ^ gpi_bit_polarity))
 
     def get_gpo_polarity(
         self, gpo_id: GPO, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS
@@ -211,8 +211,7 @@ class InputsOutputs(metaclass=MCMetaClass):
         )
         polarity = self.get_gpo_polarity(gpo_id, servo=servo, axis=axis)
 
-        new_bit_value = bool(voltage_level.value ^ polarity)
-
+        new_bit_value = not bool(voltage_level.value ^ polarity)
         gpos_new_set_point = self.__set_gpio_bit_value(gpos_previous_value, gpo_id, new_bit_value)
         self.mc.communication.set_register(
             self.GPIO_OUT_SET_POINT_REGISTER, gpos_new_set_point, servo=servo, axis=axis

--- a/ingeniamotion/io.py
+++ b/ingeniamotion/io.py
@@ -113,6 +113,9 @@ class InputsOutputs(metaclass=MCMetaClass):
     ) -> DigitalVoltageLevel:
         """Get the board voltage level (not the logic level at the uC) of a single GPI.
 
+        .. warning::
+            Ensure the polarity is right, if not this function will return a wrong value.
+
         Args:
             gpi_id: the gpi to get the voltage level
             servo : servo alias to reference it. ``default`` by default.
@@ -194,6 +197,9 @@ class InputsOutputs(metaclass=MCMetaClass):
             the corresponding bit of the desired GPO.
 
             Finally, it checks that GPOs final value matches with the desired GPOs set point
+
+            .. warning::
+                Ensure the polarity is right, if not the output will be wrong.
 
         Args:
             gpo_id: the GPO to be set.

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -49,19 +49,19 @@ def test_get_gpi_voltage_level(motion_controller):
 
     mc.communication.set_register("IO_IN_POLARITY", 0, servo=alias)
 
-    assert mc.io.get_gpi_voltage_level(GPI.GPI1, servo=alias) == DigitalVoltageLevel.HIGH
+    assert mc.io.get_gpi_voltage_level(GPI.GPI1, servo=alias) == DigitalVoltageLevel.LOW
     mc.io.set_gpi_polarity(GPI.GPI1, GPIOPolarity.REVERSED, servo=alias)
     assert mc.io.get_gpi_voltage_level(GPI.GPI1, servo=alias) == DigitalVoltageLevel.LOW
 
-    assert mc.io.get_gpi_voltage_level(GPI.GPI2, servo=alias) == DigitalVoltageLevel.LOW
+    assert mc.io.get_gpi_voltage_level(GPI.GPI2, servo=alias) == DigitalVoltageLevel.HIGH
     mc.io.set_gpi_polarity(GPI.GPI2, GPIOPolarity.REVERSED, servo=alias)
     assert mc.io.get_gpi_voltage_level(GPI.GPI2, servo=alias) == DigitalVoltageLevel.HIGH
 
-    assert mc.io.get_gpi_voltage_level(GPI.GPI3, servo=alias) == DigitalVoltageLevel.HIGH
+    assert mc.io.get_gpi_voltage_level(GPI.GPI3, servo=alias) == DigitalVoltageLevel.LOW
     mc.io.set_gpi_polarity(GPI.GPI3, GPIOPolarity.REVERSED, servo=alias)
     assert mc.io.get_gpi_voltage_level(GPI.GPI3, servo=alias) == DigitalVoltageLevel.LOW
 
-    assert mc.io.get_gpi_voltage_level(GPI.GPI4, servo=alias) == DigitalVoltageLevel.LOW
+    assert mc.io.get_gpi_voltage_level(GPI.GPI4, servo=alias) == DigitalVoltageLevel.HIGH
     mc.io.set_gpi_polarity(GPI.GPI4, GPIOPolarity.REVERSED, servo=alias)
     assert mc.io.get_gpi_voltage_level(GPI.GPI4, servo=alias) == DigitalVoltageLevel.HIGH
 
@@ -97,9 +97,9 @@ def test_set_gpo_voltage_level(motion_controller, gpo_id, reg_value):
     mc.communication.set_register("IO_OUT_POLARITY", 0, servo=alias)
     mc.communication.set_register("IO_OUT_SET_POINT", 0, servo=alias)
 
-    mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.LOW, servo=alias)
-    assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == reg_value
     mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.HIGH, servo=alias)
+    assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == reg_value
+    mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.LOW, servo=alias)
     assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == 0
     mc.io.set_gpo_polarity(gpo_id, GPIOPolarity.REVERSED, servo=alias)
     mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.HIGH, servo=alias)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -49,21 +49,21 @@ def test_get_gpi_voltage_level(motion_controller):
 
     mc.communication.set_register("IO_IN_POLARITY", 0, servo=alias)
 
-    assert mc.io.get_gpi_voltage_level(GPI.GPI1, servo=alias) == DigitalVoltageLevel.LOW
-    mc.io.set_gpi_polarity(GPI.GPI1, GPIOPolarity.REVERSED, servo=alias)
     assert mc.io.get_gpi_voltage_level(GPI.GPI1, servo=alias) == DigitalVoltageLevel.HIGH
+    mc.io.set_gpi_polarity(GPI.GPI1, GPIOPolarity.REVERSED, servo=alias)
+    assert mc.io.get_gpi_voltage_level(GPI.GPI1, servo=alias) == DigitalVoltageLevel.LOW
 
-    assert mc.io.get_gpi_voltage_level(GPI.GPI2, servo=alias) == DigitalVoltageLevel.HIGH
-    mc.io.set_gpi_polarity(GPI.GPI2, GPIOPolarity.REVERSED, servo=alias)
     assert mc.io.get_gpi_voltage_level(GPI.GPI2, servo=alias) == DigitalVoltageLevel.LOW
+    mc.io.set_gpi_polarity(GPI.GPI2, GPIOPolarity.REVERSED, servo=alias)
+    assert mc.io.get_gpi_voltage_level(GPI.GPI2, servo=alias) == DigitalVoltageLevel.HIGH
 
-    assert mc.io.get_gpi_voltage_level(GPI.GPI3, servo=alias) == DigitalVoltageLevel.LOW
-    mc.io.set_gpi_polarity(GPI.GPI3, GPIOPolarity.REVERSED, servo=alias)
     assert mc.io.get_gpi_voltage_level(GPI.GPI3, servo=alias) == DigitalVoltageLevel.HIGH
+    mc.io.set_gpi_polarity(GPI.GPI3, GPIOPolarity.REVERSED, servo=alias)
+    assert mc.io.get_gpi_voltage_level(GPI.GPI3, servo=alias) == DigitalVoltageLevel.LOW
 
-    assert mc.io.get_gpi_voltage_level(GPI.GPI4, servo=alias) == DigitalVoltageLevel.HIGH
-    mc.io.set_gpi_polarity(GPI.GPI4, GPIOPolarity.REVERSED, servo=alias)
     assert mc.io.get_gpi_voltage_level(GPI.GPI4, servo=alias) == DigitalVoltageLevel.LOW
+    mc.io.set_gpi_polarity(GPI.GPI4, GPIOPolarity.REVERSED, servo=alias)
+    assert mc.io.get_gpi_voltage_level(GPI.GPI4, servo=alias) == DigitalVoltageLevel.HIGH
 
 
 @pytest.mark.parametrize("gpo_id", [GPO.GPO1, GPO.GPO2, GPO.GPO3, GPO.GPO4])
@@ -97,14 +97,14 @@ def test_set_gpo_voltage_level(motion_controller, gpo_id, reg_value):
     mc.communication.set_register("IO_OUT_POLARITY", 0, servo=alias)
     mc.communication.set_register("IO_OUT_SET_POINT", 0, servo=alias)
 
-    mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.HIGH, servo=alias)
-    assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == reg_value
     mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.LOW, servo=alias)
+    assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == reg_value
+    mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.HIGH, servo=alias)
     assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == 0
     mc.io.set_gpo_polarity(gpo_id, GPIOPolarity.REVERSED, servo=alias)
-    mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.LOW, servo=alias)
-    assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == reg_value
     mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.HIGH, servo=alias)
+    assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == reg_value
+    mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.LOW, servo=alias)
     assert mc.communication.get_register("IO_OUT_VALUE", servo=alias) == 0
 
 


### PR DESCRIPTION
Fix get_gpi_voltage_level and set_gpo_voltage_level and add IO module to doc

Fixes # INGM-489

### Type of change

- [x] Add IO module to docs
- [x] Fix  get_gpi_voltage_level and set_gpo_voltage_level


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
