### PR TITLE
INGM-492 Ensure FSoE was configured before stop it

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,6 +245,7 @@ def load_firmware(pytestconfig, read_config, request):
     if drive_idx is None:
         pytest.fail(f"The drive {drive_identifier} cannot be found on the rack's configuration.")
     drive = config.drives[drive_idx]
+    client.exposed_turn_on_ps()
     client.exposed_firmware_load(
         drive_idx, read_config["fw_file"], drive.product_code, drive.serial_number
     )


### PR DESCRIPTION
fsoe.stop_master get stuck if fsoe was not configured previously

Fixes # INGM-492

### Type of change

- [x] Add a flag to know if FSoE was configured


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
