### PR TITLE
Ingm 494 call notify send process data before first processdata send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Changed
 - BaseTest class typing
 
+### Fixed
+- Notify process data before start PDO
+
 ## [0.8.3] - 2024-07-26
 ### Changed
 - Make fsoe_master an optional requirement

--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -109,10 +109,6 @@ class FSoEMasterHandler:
     def _configure_pdo_maps(self) -> None:
         """Configure the PDOMaps used for the Safety PDUs."""
         PDUMapper.configure_rpdo_map(self.safety_master_pdu_map)
-        # Set the default initial value to the Safety Master PDU PDOMap
-        self.safety_master_pdu_map.set_item_bytes(
-            int(0).to_bytes(self.safety_master_pdu_map.data_length_bytes, "little")
-        )
         PDUMapper.configure_tpdo_map(self.safety_slave_pdu_map)
 
     def _configure_master(self) -> None:

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -239,27 +239,21 @@ class PDONetworkManager:
 
         def run(self) -> None:
             """Start the PDO exchange"""
-            try:
-                self._net.start_pdos()
-            except ILError as il_error:
-                self._pd_thread_stop_event.set()
-                if self._notify_exceptions is not None:
-                    im_exception = IMException(
-                        f"Could not start the PDOs due to the following exception: {il_error}"
-                    )
-                    self._notify_exceptions(im_exception)
+            first_iteration = True
             iteration_duration: float = -1
             while not self._pd_thread_stop_event.is_set():
                 time_start = time.perf_counter()
                 if self._notify_send_process_data is not None:
                     self._notify_send_process_data()
                 try:
-                    self._net.send_receive_processdata(self._refresh_rate)
+                    if first_iteration:
+                        self._net.start_pdos()
+                        first_iteration = False
+                    else:
+                        self._net.send_receive_processdata(self._refresh_rate)
                 except ILWrongWorkingCount as il_error:
                     self._pd_thread_stop_event.set()
                     self._net.stop_pdos()
-                    if iteration_duration == -1:
-                        iteration_duration = time.perf_counter() - time_start
                     duration_error = ""
                     if iteration_duration > self._watchdog_timeout:
                         duration_error = (
@@ -272,6 +266,13 @@ class PDONetworkManager:
                         im_exception = IMException(
                             "Stopping the PDO thread due to the following exception:"
                             f" {il_error} {duration_error}"
+                        )
+                        self._notify_exceptions(im_exception)
+                except ILError as il_error:
+                    self._pd_thread_stop_event.set()
+                    if self._notify_exceptions is not None:
+                        im_exception = IMException(
+                            f"Could not start the PDOs due to the following exception: {il_error}"
                         )
                         self._notify_exceptions(im_exception)
                 else:


### PR DESCRIPTION
Notify process data before start PDO

Fixes # INGM-494

### Type of change

- [x] In ProcessDataThread, notify send and receive processdata before and after start pdo
- [x] Don't set the default initial value to the Safety Master PDU PDOMap (not necessary any more)


### Tests
- [ ] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
