### PR TITLE
INGM-496 get available canopen devices does not work because an ingenialink change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - Notify process data before start PDO
+- Adapt changes of function get_available_devices from ingenialink 
 
 ## [0.8.3] - 2024-07-26
 ### Changed

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -444,8 +444,7 @@ class Communication(metaclass=MCMetaClass):
         """
         return [x.nice_name for x in ifaddr.get_adapters()]
 
-    @staticmethod
-    def get_available_canopen_devices() -> dict[CAN_DEVICE, list[int]]:
+    def get_available_canopen_devices(self) -> dict[CAN_DEVICE, list[int]]:
         """Return the list of available CAN devices (those connected and with drivers installed).
 
         Returns:
@@ -456,7 +455,14 @@ class Communication(metaclass=MCMetaClass):
             }
         """
         available_devices: dict[CAN_DEVICE, list[int]] = {}
-        for device, channel in CanopenNetwork.get_available_devices():
+        can_net = None
+        for net in self.mc.net:
+            if isinstance(net, CanopenNetwork):
+                can_net = net
+                break
+        if can_net is None:
+            can_net = CanopenNetwork(CAN_DEVICE.KVASER)
+        for device, channel in can_net.get_available_devices():
             can_device = CAN_DEVICE(device)
             can_channel = CAN_CHANNELS[device].index(channel)
             if can_device not in available_devices:

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -456,7 +456,8 @@ class Communication(metaclass=MCMetaClass):
         """
         available_devices: dict[CAN_DEVICE, list[int]] = {}
         can_net = None
-        for net in self.mc.net:
+        for net_key in self.mc.net:
+            net = self.mc.net[net_key]
             if isinstance(net, CanopenNetwork):
                 can_net = net
                 break


### PR DESCRIPTION
### Description

In ingenialink, get_available_devices is no longer a static function, adapt ingeniamotion.

Fixes # INGM-496

### Type of change

- [x] get_available_canopen_devices is not longer a static function, it uses an existing CanopenNetwork or creates it if necessary


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.


### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
