### PR TITLE
Improve the fsoe master optional optionality

### DIFF
--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1,4 +1,3 @@
-import contextlib
 import json
 import platform
 import shutil
@@ -859,8 +858,7 @@ class Communication(metaclass=MCMetaClass):
         del self.mc.servos[servo]
         net_name = self.mc.servo_net.pop(servo)
         servo_count = list(self.mc.servo_net.values()).count(net_name)
-        # TODO: Remove once INGK-912 is resolved
-        with contextlib.suppress(NotImplementedError):
+        if self.mc.fsoe_is_installed:
             self.mc.fsoe._delete_master_handler(servo)
         if servo_count == 0:
             del self.mc.net[net_name]

--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -203,7 +203,7 @@ class FSoEMasterHandler:
             raise ValueError(f"Wrong value type. Expected type bool, got {type(sto_command)}")
         return sto_command
 
-    def __state_change_callback(self, state: "State"):
+    def __state_change_callback(self, state: "State") -> None:
         if state == StateData:
             self.__state_is_data.set()
         else:

--- a/ingeniamotion/motion_controller.py
+++ b/ingeniamotion/motion_controller.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import Dict
+from typing import Dict, Optional
 
 from ingenialink.network import Network
 from ingenialink.servo import Servo
@@ -31,8 +31,9 @@ class MotionController:
         self.__errors: Errors = Errors(self)
         self.__info: Information = Information(self)
         self.__io = InputsOutputs(self)
+        self.__fsoe: Optional[FSoEMaster] = None
         if FSOE_MASTER_INSTALLED:
-            self.__fsoe: FSoEMaster = FSoEMaster(self)
+            self.__fsoe = FSoEMaster(self)
 
     def servo_name(self, servo: str = DEFAULT_SERVO) -> str:
         return "{} ({})".format(self.servos[servo].info["product_code"], servo)
@@ -147,13 +148,18 @@ class MotionController:
     @property
     def fsoe(self) -> "FSoEMaster":
         """Instance of :class:`~ingeniamotion.fsoe.FSoEMaster` class"""
-        if not FSOE_MASTER_INSTALLED:
+        if self.__fsoe is None:
             raise NotImplementedError(
                 "The FSoE module is not available. "
                 "Install ingeniamotion with FSoE feature: "
                 "pip install ingeniamotion[FSoE]"
             )
         return self.__fsoe
+
+    @property
+    def fsoe_is_installed(self) -> bool:
+        """Indicates if the FSoE Module is available"""
+        return self.__fsoe is not None
 
     @property
     def io(self) -> InputsOutputs:


### PR DESCRIPTION
### Description

Found a dead comment regarding the optionality of the fsoe module mentioning an issue that was already closed.
Re-reviewed the topic, no usability changes.

### Type of change

- [x] Created a public flag on motion controller that indicates if the module is installed
- [x] Make sure the __fsoe attribute always exists (Optional) as it's a good practice for type safety.


### Tests
- [x] Run safety_torque_off