### PR TITLE
INGM-499 Load CANopen firmware files sequentially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 - BaseTest class typing
+- The loading of several CANopen firmware files (ensemble) is done sequentially.
 
 ### Fixed
 - Notify process data before start PDO


### PR DESCRIPTION
### Description

Load CANopen firmware files sequentially.

Fixes # INGM-499

### Type of change

- Load CANopen firmware files sequentially.
- Update CHANGELOG.

### Tests
- Using the K2 app, connect to a K2 device.
- Load the ensemble firmware file
- Check that the firmware file is updated in both drives correctly.

### Documentation

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
