### PR TITLE
generate name of junit report inside tox system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ _pdf
 
 #pytest
 .coverage
+
+# Tox
+.tox

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,14 +28,15 @@ def runTestHW(protocol, slave) {
         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
                 "${SMOKE_TESTS_FLAG} " +
                 "--protocol ${protocol} " +
-                "--slave ${slave} " +
-                "--junitxml=pytest_reports/pytest_${protocol}_${slave}_report_py.xml"
+                "--slave ${slave} "
     } catch (err) {
         unstable(message: "Tests failed")
     } finally {
         coverage_stash = ".coverage_${protocol}_${slave}"
         bat "move .coverage ${coverage_stash}"
-        junit "pytest_reports\\pytest_${protocol}_${slave}_report_py.xml"
+        junit "pytest_reports\\*.xml"
+        // Delete the junit after publishing it so it not re-published on the next stage
+        bat "del /S /Q pytest_reports\\*.xml"
         stash includes: coverage_stash, name: coverage_stash
         coverage_stashes.add(coverage_stash)
     }
@@ -83,12 +84,12 @@ pipeline {
                 stage('Run no-connection tests') {
                     steps {
                         sh """
-                            python${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- -m virtual --protocol virtual --junitxml=pytest_virtual_report.xml
+                            python${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- -m virtual --protocol virtual
                         """
                     }
                     post {
                         always {
-                            junit "pytest_virtual_report.xml"
+                            junit "pytest_reports/*.xml"
                         }
                     }
                 }
@@ -125,13 +126,12 @@ pipeline {
                 stage("Run virtual drive tests") {
                     steps {
                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- -m" +
-                                " virtual --protocol virtual " +
-                                "--junitxml=pytest_reports\\pytest_virtual_report.xml"
+                                " virtual --protocol virtual "
                     }
                     post {
                         always {
                             bat "move .coverage .coverage_virtual"
-                            junit "pytest_reports\\pytest_virtual_report.xml"
+                            junit "pytest_reports\\*.xml"
                             stash includes: '.coverage_virtual', name: '.coverage_virtual'
                             script {
                                 coverage_stashes.add(".coverage_virtual")

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     pytest-console-scripts==1.4.1
     matplotlib==3.8.2
 commands =
-    python -m pytest {posargs:tests}
+    python -m pytest {posargs:tests} --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
 
 [testenv:coverage]
 description = combine and export coverage report


### PR DESCRIPTION
[Doc]
Only one test execution per python version is shown on junit reports
Sometimes it fails on 3.9 and passed on 3.12.
Tox is creating the file for 3.9, but 3.12 is overwiting it, so we only have the last one, that doesnt have inffo on why it failed
https://novantamotion.atlassian.net/browse/INGM-503

Each command to the tox system should have a different file name for pytest, {envname} interpolation does the trick, but this means the file export must be inside of the tox file instead of externally.
Sol
[Test]
Now there are separate reports for each python version
![image](https://github.com/user-attachments/assets/2d3a4b77-9fd1-420e-8e3d-e45ecdf51832)
