### PR TITLE
Ingm 508 use tests markers to select tests on jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ RUN_PYTHON_VERSIONS = ""
 def PYTHON_VERSION_MIN = "py39"
 def PYTHON_VERSION_MAX = "py312"
 
-SMOKE_TESTS_FLAG = ""
+RUN_ONLY_SMOKE_TESTS = false
 
 def BRANCH_NAME_MASTER = "master"
 def DISTEXT_PROJECT_DIR = "doc/ingeniamotion"
@@ -24,9 +24,15 @@ def DISTEXT_PROJECT_DIR = "doc/ingeniamotion"
 coverage_stashes = []
 
 def runTestHW(protocol, slave) {
+    markers = "protocol"
+
+    if (RUN_ONLY_SMOKE_TESTS) {
+        markers = markers + " and smoke"
+    }
+
     try {
         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
-                "${SMOKE_TESTS_FLAG} " +
+                "-m ${markers} " +
                 "--protocol ${protocol} " +
                 "--slave ${slave} " +
                 "--junitxml=pytest_reports/pytest_${protocol}_${slave}_report_py.xml"
@@ -55,17 +61,17 @@ pipeline {
                 script {
                     if (env.BRANCH_NAME == 'master') {
                         RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
-                        SMOKE_TESTS_FLAG = ""
+                        RUN_ONLY_SMOKE_TESTS = false
                     } else if (env.BRANCH_NAME == 'develop') {
                         RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
-                        SMOKE_TESTS_FLAG = ""
+                        RUN_ONLY_SMOKE_TESTS = false
                     } else if (env.BRANCH_NAME.startsWith('release/')) {
                         RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
-                        SMOKE_TESTS_FLAG = ""
+                        RUN_ONLY_SMOKE_TESTS = false
                     } else {
                         RUN_PYTHON_VERSIONS = "${PYTHON_VERSION_MIN},${PYTHON_VERSION_MAX}"
                         if (params.TESTS == 'Smoke') {
-                            SMOKE_TESTS_FLAG = "-m smoke"
+                            RUN_ONLY_SMOKE_TESTS = true
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ def DISTEXT_PROJECT_DIR = "doc/ingeniamotion"
 coverage_stashes = []
 
 def runTestHW(protocol, slave) {
-    markers = "protocol"
+    markers = protocol
 
     if (RUN_ONLY_SMOKE_TESTS) {
         markers = markers + " and smoke"
@@ -32,7 +32,7 @@ def runTestHW(protocol, slave) {
 
     try {
         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
-                "-m ${markers} " +
+                "-m \"${markers}\" " +
                 "--protocol ${protocol} " +
                 "--slave ${slave} " +
                 "--junitxml=pytest_reports/pytest_${protocol}_${slave}_report_py.xml"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,18 +24,6 @@ def pytest_addoption(parser):
     parser.addoption("--slave", type="int", default=0, help="Slave index in config.json")
 
 
-def pytest_collection_modifyitems(config, items):
-    protocol = config.getoption("--protocol")
-    negate_protocols = [x for x in ALLOW_PROTOCOLS if x != protocol]
-    skip_by_protocol = pytest.mark.skip(reason="Protocol does not match")
-    for item in items:
-        if protocol in item.keywords:
-            continue
-        for not_protocol in negate_protocols:
-            if not_protocol in item.keywords:
-                item.add_marker(skip_by_protocol)
-
-
 @pytest.fixture(scope="session")
 def read_config(request):
     slave = request.config.getoption("--slave")

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -39,6 +39,7 @@ def feedback_test_setup(motion_controller):
     mc, alias = motion_controller
     mc.tests.commutation(servo=alias)
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -54,6 +55,7 @@ def test_digital_halls_test(motion_controller, feedback_list):
             mc.tests.digital_halls_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -68,6 +70,7 @@ def test_incremental_encoder_1_test(motion_controller, feedback_list):
         with pytest.raises(TestError):
             mc.tests.incremental_encoder_1_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -86,6 +89,7 @@ def test_incremental_encoder_2_test(motion_controller, feedback_list):
             mc.tests.incremental_encoder_2_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -101,6 +105,7 @@ def test_absolute_encoder_1_test(motion_controller, feedback_list):
             mc.tests.absolute_encoder_1_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -115,6 +120,7 @@ def test_absolute_encoder_2_test(motion_controller, feedback_list):
         with pytest.raises(TestError):
             mc.tests.absolute_encoder_2_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -133,6 +139,7 @@ def test_secondary_ssi_test(motion_controller, feedback_list):
             mc.tests.secondary_ssi_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -140,6 +147,7 @@ def test_commutation(motion_controller_teardown):
     mc, alias = motion_controller_teardown
     results = mc.tests.commutation(servo=alias)
     assert results["result_severity"] == SeverityLevel.SUCCESS
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -149,6 +157,7 @@ def test_commutation_error(motion_controller, force_fault):
     mc, alias = motion_controller
     with pytest.raises(force_fault):
         mc.tests.commutation(servo=alias)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -160,6 +169,7 @@ def test_phasing_check(motion_controller):
     results = mc.tests.phasing_check(servo=alias)
     assert results["result_severity"] == SeverityLevel.SUCCESS
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -168,6 +178,7 @@ def test_phasing_check_error(motion_controller, force_fault):
     mc, alias = motion_controller
     with pytest.raises(force_fault):
         mc.tests.phasing_check(servo=alias)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -198,6 +209,7 @@ def test_sto_test_error(mocker, motion_controller, sto_value, message):
     assert results["result_severity"] == SeverityLevel.FAIL
     assert results["result_message"] == message
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -227,6 +239,7 @@ def run_test_and_stop(test):
     time.sleep(2)
     test.stop()
     test_thread.join()
+
 
 @pytest.mark.eoe
 @pytest.mark.soem

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -39,7 +39,9 @@ def feedback_test_setup(motion_controller):
     mc, alias = motion_controller
     mc.tests.commutation(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("feedback_test_setup")
 def test_digital_halls_test(motion_controller, feedback_list):
     mc, alias = motion_controller
@@ -52,7 +54,9 @@ def test_digital_halls_test(motion_controller, feedback_list):
             mc.tests.digital_halls_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("feedback_test_setup")
 def test_incremental_encoder_1_test(motion_controller, feedback_list):
     mc, alias = motion_controller
@@ -65,7 +69,9 @@ def test_incremental_encoder_1_test(motion_controller, feedback_list):
             mc.tests.incremental_encoder_1_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("feedback_test_setup")
 def test_incremental_encoder_2_test(motion_controller, feedback_list):
     mc, alias = motion_controller
@@ -80,7 +86,9 @@ def test_incremental_encoder_2_test(motion_controller, feedback_list):
             mc.tests.incremental_encoder_2_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("feedback_test_setup")
 def test_absolute_encoder_1_test(motion_controller, feedback_list):
     mc, alias = motion_controller
@@ -93,7 +101,9 @@ def test_absolute_encoder_1_test(motion_controller, feedback_list):
             mc.tests.absolute_encoder_1_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("feedback_test_setup")
 def test_absolute_encoder_2_test(motion_controller, feedback_list):
     mc, alias = motion_controller
@@ -106,7 +116,9 @@ def test_absolute_encoder_2_test(motion_controller, feedback_list):
             mc.tests.absolute_encoder_2_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("feedback_test_setup")
 def test_secondary_ssi_test(motion_controller, feedback_list):
     mc, alias = motion_controller
@@ -121,20 +133,26 @@ def test_secondary_ssi_test(motion_controller, feedback_list):
             mc.tests.secondary_ssi_test(servo=alias)
     assert commutation_fdbk == mc.configuration.get_commutation_feedback(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 def test_commutation(motion_controller_teardown):
     mc, alias = motion_controller_teardown
     results = mc.tests.commutation(servo=alias)
     assert results["result_severity"] == SeverityLevel.SUCCESS
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_commutation_error(motion_controller, force_fault):
     mc, alias = motion_controller
     with pytest.raises(force_fault):
         mc.tests.commutation(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.skip("Skip until is fixed INGM-352")
 def test_phasing_check(motion_controller):
     mc, alias = motion_controller
@@ -142,14 +160,18 @@ def test_phasing_check(motion_controller):
     results = mc.tests.phasing_check(servo=alias)
     assert results["result_severity"] == SeverityLevel.SUCCESS
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_phasing_check_error(motion_controller, force_fault):
     mc, alias = motion_controller
     with pytest.raises(force_fault):
         mc.tests.phasing_check(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_sto_test(motion_controller):
     mc, alias = motion_controller
@@ -176,7 +198,9 @@ def test_sto_test_error(mocker, motion_controller, sto_value, message):
     assert results["result_severity"] == SeverityLevel.FAIL
     assert results["result_message"] == message
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_brake_test(motion_controller):
     mc, alias = motion_controller
@@ -204,7 +228,9 @@ def run_test_and_stop(test):
     test.stop()
     test_thread.join()
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("feedback_test_setup")
 @pytest.mark.parametrize(
     "feedback_class",

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -23,7 +23,9 @@ def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
 
     return np.allclose(fft_received, fft_expected, rtol=0, atol=fft_tol)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 def test_create_poller(motion_controller):
     registers = [{"name": "CL_CUR_Q_SET_POINT", "axis": 1}]
     sampling_time = 0.125
@@ -45,9 +47,11 @@ def test_create_poller(motion_controller):
     assert len(received_signal) == len(expected_signal)
     assert __compare_signals(expected_signal, received_signal)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 def test_create_monitoring_no_trigger(
-    skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
+        skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
 ):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     mc, alias = motion_controller
@@ -77,29 +81,31 @@ def test_create_monitoring_no_trigger(
     assert len(data[0]) == len(expected_signal)
     assert __compare_signals(expected_signal, data[0])
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.parametrize(
     "trigger_mode, trigger_config, values_list",
     [
         (
-            MonitoringSoCType.TRIGGER_EVENT_EDGE,
-            MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
-            [0, 0.25, 0.5, 0.75],
+                MonitoringSoCType.TRIGGER_EVENT_EDGE,
+                MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
+                [0, 0.25, 0.5, 0.75],
         ),
         (
-            MonitoringSoCType.TRIGGER_EVENT_EDGE,
-            MonitoringSoCConfig.TRIGGER_CONFIG_FALLING,
-            [0.75, 0.5, 0.25, 0],
+                MonitoringSoCType.TRIGGER_EVENT_EDGE,
+                MonitoringSoCConfig.TRIGGER_CONFIG_FALLING,
+                [0.75, 0.5, 0.25, 0],
         ),
     ],
 )
 def test_create_monitoring_edge_trigger(
-    skip_if_monitoring_not_available,
-    motion_controller,
-    trigger_mode,
-    trigger_config,
-    values_list,
-    disable_monitoring_disturbance,
+        skip_if_monitoring_not_available,
+        motion_controller,
+        trigger_mode,
+        trigger_config,
+        values_list,
+        disable_monitoring_disturbance,
 ):
     register = {"name": "CL_POS_REF_VALUE", "axis": 1}
     mc, alias = motion_controller
@@ -135,18 +141,20 @@ def test_create_monitoring_edge_trigger(
             pass
         value = int(values_list[i] * samples)
         mc.motion.move_to_position(value, alias)
-        expected_signal[i * quarter_num_samples : (i + 1) * quarter_num_samples] = value
+        expected_signal[i * quarter_num_samples: (i + 1) * quarter_num_samples] = value
 
     data = monitoring.read_monitoring_data()
     assert len(data[0]) == len(expected_signal)
     assert __compare_signals(expected_signal, data[0])
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.parametrize("trigger_delay_rate", [-1 / 4, 1 / 4])
 def test_create_monitoring_trigger_delay(
-    skip_if_monitoring_not_available,
-    motion_controller,
-    trigger_delay_rate,
+        skip_if_monitoring_not_available,
+        motion_controller,
+        trigger_delay_rate,
 ):
     trigger_mode = MonitoringSoCType.TRIGGER_EVENT_EDGE
     trigger_config = MonitoringSoCConfig.TRIGGER_CONFIG_RISING
@@ -187,7 +195,7 @@ def test_create_monitoring_trigger_delay(
             pass
         value = int(values_list[i] * samples)
         mc.motion.move_to_position(value, alias)
-        expected_signal[i * quarter_num_samples : (i + 1) * quarter_num_samples] = value
+        expected_signal[i * quarter_num_samples: (i + 1) * quarter_num_samples] = value
 
     expected_signal = np.roll(expected_signal, -trigger_delay_samples)
     if trigger_delay_samples < 0:
@@ -199,8 +207,11 @@ def test_create_monitoring_trigger_delay(
     assert __compare_signals(expected_signal, data[0])
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 def test_create_disturbance(
-    skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
+        skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
 ):
     mc, alias = motion_controller
     target_register = "CL_POS_SET_POINT_VALUE"
@@ -241,6 +252,9 @@ def test_mcb_synchronization(mocker, motion_controller):
     disable_mon.assert_called_once_with(servo=alias)
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_mcb_synchronization_fail(motion_controller):
     mc, alias = motion_controller
@@ -273,9 +287,12 @@ def test_monitoring_max_sample_size(skip_if_monitoring_not_available, motion_con
     assert max_sample_size == value
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_get_frequency(
-    skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
+        skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
 ):
     mc, alias = motion_controller
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
@@ -411,15 +428,15 @@ def test_get_monitoring_process_stage_v3(mocker, motion_controller, monitor_stat
 )
 @pytest.mark.virtual
 def test_get_monitoring_process_stage_v1_v2(
-    mocker, motion_controller, monitoring_status, expected_stage
+        mocker, motion_controller, monitoring_status, expected_stage
 ):
     mc, alias = motion_controller
     mocker.patch.object(mc.capture, "get_monitoring_status", return_value=monitoring_status)
     assert (
-        mc.capture.get_monitoring_process_stage(
-            servo=alias, version=MonitoringVersion.MONITORING_V2
-        )
-        == expected_stage
+            mc.capture.get_monitoring_process_stage(
+                servo=alias, version=MonitoringVersion.MONITORING_V2
+            )
+            == expected_stage
     )
 
 

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -23,6 +23,7 @@ def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
 
     return np.allclose(fft_received, fft_expected, rtol=0, atol=fft_tol)
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -47,11 +48,12 @@ def test_create_poller(motion_controller):
     assert len(received_signal) == len(expected_signal)
     assert __compare_signals(expected_signal, received_signal)
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
 def test_create_monitoring_no_trigger(
-        skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
+    skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
 ):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     mc, alias = motion_controller
@@ -81,6 +83,7 @@ def test_create_monitoring_no_trigger(
     assert len(data[0]) == len(expected_signal)
     assert __compare_signals(expected_signal, data[0])
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -88,24 +91,24 @@ def test_create_monitoring_no_trigger(
     "trigger_mode, trigger_config, values_list",
     [
         (
-                MonitoringSoCType.TRIGGER_EVENT_EDGE,
-                MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
-                [0, 0.25, 0.5, 0.75],
+            MonitoringSoCType.TRIGGER_EVENT_EDGE,
+            MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
+            [0, 0.25, 0.5, 0.75],
         ),
         (
-                MonitoringSoCType.TRIGGER_EVENT_EDGE,
-                MonitoringSoCConfig.TRIGGER_CONFIG_FALLING,
-                [0.75, 0.5, 0.25, 0],
+            MonitoringSoCType.TRIGGER_EVENT_EDGE,
+            MonitoringSoCConfig.TRIGGER_CONFIG_FALLING,
+            [0.75, 0.5, 0.25, 0],
         ),
     ],
 )
 def test_create_monitoring_edge_trigger(
-        skip_if_monitoring_not_available,
-        motion_controller,
-        trigger_mode,
-        trigger_config,
-        values_list,
-        disable_monitoring_disturbance,
+    skip_if_monitoring_not_available,
+    motion_controller,
+    trigger_mode,
+    trigger_config,
+    values_list,
+    disable_monitoring_disturbance,
 ):
     register = {"name": "CL_POS_REF_VALUE", "axis": 1}
     mc, alias = motion_controller
@@ -141,20 +144,21 @@ def test_create_monitoring_edge_trigger(
             pass
         value = int(values_list[i] * samples)
         mc.motion.move_to_position(value, alias)
-        expected_signal[i * quarter_num_samples: (i + 1) * quarter_num_samples] = value
+        expected_signal[i * quarter_num_samples : (i + 1) * quarter_num_samples] = value
 
     data = monitoring.read_monitoring_data()
     assert len(data[0]) == len(expected_signal)
     assert __compare_signals(expected_signal, data[0])
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("trigger_delay_rate", [-1 / 4, 1 / 4])
 def test_create_monitoring_trigger_delay(
-        skip_if_monitoring_not_available,
-        motion_controller,
-        trigger_delay_rate,
+    skip_if_monitoring_not_available,
+    motion_controller,
+    trigger_delay_rate,
 ):
     trigger_mode = MonitoringSoCType.TRIGGER_EVENT_EDGE
     trigger_config = MonitoringSoCConfig.TRIGGER_CONFIG_RISING
@@ -195,7 +199,7 @@ def test_create_monitoring_trigger_delay(
             pass
         value = int(values_list[i] * samples)
         mc.motion.move_to_position(value, alias)
-        expected_signal[i * quarter_num_samples: (i + 1) * quarter_num_samples] = value
+        expected_signal[i * quarter_num_samples : (i + 1) * quarter_num_samples] = value
 
     expected_signal = np.roll(expected_signal, -trigger_delay_samples)
     if trigger_delay_samples < 0:
@@ -211,7 +215,7 @@ def test_create_monitoring_trigger_delay(
 @pytest.mark.soem
 @pytest.mark.canopen
 def test_create_disturbance(
-        skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
+    skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
 ):
     mc, alias = motion_controller
     target_register = "CL_POS_SET_POINT_VALUE"
@@ -292,7 +296,7 @@ def test_monitoring_max_sample_size(skip_if_monitoring_not_available, motion_con
 @pytest.mark.canopen
 @pytest.mark.smoke
 def test_get_frequency(
-        skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
+    skip_if_monitoring_not_available, motion_controller, disable_monitoring_disturbance
 ):
     mc, alias = motion_controller
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
@@ -428,15 +432,15 @@ def test_get_monitoring_process_stage_v3(mocker, motion_controller, monitor_stat
 )
 @pytest.mark.virtual
 def test_get_monitoring_process_stage_v1_v2(
-        mocker, motion_controller, monitoring_status, expected_stage
+    mocker, motion_controller, monitoring_status, expected_stage
 ):
     mc, alias = motion_controller
     mocker.patch.object(mc.capture, "get_monitoring_status", return_value=monitoring_status)
     assert (
-            mc.capture.get_monitoring_process_stage(
-                servo=alias, version=MonitoringVersion.MONITORING_V2
-            )
-            == expected_stage
+        mc.capture.get_monitoring_process_stage(
+            servo=alias, version=MonitoringVersion.MONITORING_V2
+        )
+        == expected_stage
     )
 
 

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -245,6 +245,7 @@ def test_set_register_wrong_access(motion_controller):
 def dummy_callback(status, _, axis):
     pass
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -248,7 +248,9 @@ def test_set_register_wrong_access(motion_controller):
 def dummy_callback(status, _, axis):
     pass
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_subscribe_servo_status(mocker, motion_controller):
     mc, alias = motion_controller

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -91,6 +91,7 @@ def remove_file_if_exist():
     if os.path.isfile(file_path):
         os.remove(file_path)
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -280,6 +281,7 @@ def test_get_status_word(motion_controller):
     test_value = mc.configuration.get_status_word(servo=alias)
     reg_value = mc.communication.get_register(STATUS_WORD_REGISTER, servo=alias)
     assert test_value == reg_value
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -511,6 +513,7 @@ def test_is_sto_abnormal_latched(mocker, motion_controller, sto_status_value, ex
     value = mc.configuration.is_sto_abnormal_latched(servo=alias)
     assert value == expected_result
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -518,6 +521,7 @@ def test_is_sto_abnormal_latched(mocker, motion_controller, sto_status_value, ex
 def test_store_configuration(motion_controller):
     mc, alias = motion_controller
     mc.configuration.store_configuration(servo=alias)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -91,7 +91,9 @@ def remove_file_if_exist():
     if os.path.isfile(file_path):
         os.remove(file_path)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.usefixtures("remove_file_if_exist")
 def test_save_configuration_and_load_configuration(motion_controller):
@@ -279,7 +281,9 @@ def test_get_status_word(motion_controller):
     reg_value = mc.communication.get_register(STATUS_WORD_REGISTER, servo=alias)
     assert test_value == reg_value
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_is_motor_enabled_1(motion_controller):
     mc, alias = motion_controller
@@ -444,6 +448,9 @@ def test_check_sto_power_supply(mocker, motion_controller, sto_status_value, exp
     assert value == expected_result
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value, expected_result",
@@ -504,13 +511,17 @@ def test_is_sto_abnormal_latched(mocker, motion_controller, sto_status_value, ex
     value = mc.configuration.is_sto_abnormal_latched(servo=alias)
     assert value == expected_result
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_store_configuration(motion_controller):
     mc, alias = motion_controller
     mc.configuration.store_configuration(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_restore_configuration(motion_controller):
     mc, alias = motion_controller

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -25,7 +25,9 @@ def test_disturbance_max_sample_size(motion_controller, disturbance):
     )
     assert max_sample_size == value
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
 def test_set_frequency_divider(motion_controller, disturbance, prescaler):
@@ -36,14 +38,18 @@ def test_set_frequency_divider(motion_controller, disturbance, prescaler):
     )
     assert value == prescaler
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_set_frequency_divider_exception(disturbance):
     prescaler = -1
     with pytest.raises(ValueError):
         disturbance.set_frequency_divider(prescaler)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "axis, name, expected_value",
@@ -62,7 +68,9 @@ def test_disturbance_map_registers(motion_controller, disturbance, axis, name, e
     value = mc.communication.get_register("DIST_CFG_MAP_REGS", servo=alias, axis=0)
     assert value == 1
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize("number_registers", list(range(1, 17)))
 def test_disturbance_number_map_registers(motion_controller, disturbance, number_registers):
@@ -73,7 +81,9 @@ def test_disturbance_number_map_registers(motion_controller, disturbance, number
     value = mc.communication.get_register("DIST_CFG_MAP_REGS", servo=alias, axis=0)
     assert value == number_registers
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_disturbance_map_registers_sample_number(disturbance):
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]
@@ -96,7 +106,9 @@ def test_disturbance_map_registers_empty(disturbance):
     with pytest.raises(IMDisturbanceError):
         disturbance.map_registers(registers)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.usefixtures("disturbance_map_registers")
 def test_write_disturbance_data_buffer_exception(disturbance):
@@ -110,7 +122,9 @@ def test_write_disturbance_data_not_configured(disturbance):
     with pytest.raises(IMDisturbanceError):
         disturbance.write_disturbance_data([0] * 100)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_write_disturbance_data_enabled(
     motion_controller, disturbance, disable_monitoring_disturbance

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -25,6 +25,7 @@ def test_disturbance_max_sample_size(motion_controller, disturbance):
     )
     assert max_sample_size == value
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -38,6 +39,7 @@ def test_set_frequency_divider(motion_controller, disturbance, prescaler):
     )
     assert value == prescaler
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -46,6 +48,7 @@ def test_set_frequency_divider_exception(disturbance):
     prescaler = -1
     with pytest.raises(ValueError):
         disturbance.set_frequency_divider(prescaler)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -68,6 +71,7 @@ def test_disturbance_map_registers(motion_controller, disturbance, axis, name, e
     value = mc.communication.get_register("DIST_CFG_MAP_REGS", servo=alias, axis=0)
     assert value == 1
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -80,6 +84,7 @@ def test_disturbance_number_map_registers(motion_controller, disturbance, number
     disturbance.map_registers(registers)
     value = mc.communication.get_register("DIST_CFG_MAP_REGS", servo=alias, axis=0)
     assert value == number_registers
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -106,6 +111,7 @@ def test_disturbance_map_registers_empty(disturbance):
     with pytest.raises(IMDisturbanceError):
         disturbance.map_registers(registers)
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -121,6 +127,7 @@ def test_write_disturbance_data_buffer_exception(disturbance):
 def test_write_disturbance_data_not_configured(disturbance):
     with pytest.raises(IMDisturbanceError):
         disturbance.write_disturbance_data([0] * 100)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -51,6 +51,9 @@ def force_warning(motion_controller):
 
 
 class TestErrors:
+    @pytest.mark.eoe
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.smoke
     def test_get_last_error(self, motion_controller, generate_drive_errors):
         mc, alias = motion_controller
@@ -62,12 +65,18 @@ class TestErrors:
         assert subnode is None
         assert warning is None
 
+    @pytest.mark.eoe
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.smoke
     def test_get_last_buffer_error(self, motion_controller, generate_drive_errors):
         mc, alias = motion_controller
         last_error, subnode, warning = mc.errors.get_last_buffer_error(servo=alias)
         assert last_error == generate_drive_errors[0]
 
+    @pytest.mark.eoe
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.smoke
     def test_get_buffer_error_by_index(self, motion_controller, generate_drive_errors):
         mc, alias = motion_controller
@@ -76,18 +85,27 @@ class TestErrors:
             last_error, subnode, warning = mc.errors.get_buffer_error_by_index(i, servo=alias)
             assert last_error == generate_drive_errors[i]
 
+    @pytest.mark.eoe
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.smoke
     def test_get_buffer_error_by_index_exception(self, motion_controller, generate_drive_errors):
         mc, alias = motion_controller
         with pytest.raises(ValueError):
             mc.errors.get_buffer_error_by_index(33, servo=alias)
 
+    @pytest.mark.eoe
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.smoke
     def test_get_number_total_errors(self, motion_controller, error_number, generate_drive_errors):
         mc, alias = motion_controller
         test_error_number = mc.errors.get_number_total_errors(servo=alias)
         assert test_error_number == error_number + len(generate_drive_errors)
 
+    @pytest.mark.eoe
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.smoke
     def test_get_all_errors(self, motion_controller, generate_drive_errors):
         mc, alias = motion_controller
@@ -96,6 +114,9 @@ class TestErrors:
             test_code_error, axis, warning = test_all_errors[i]
             assert test_code_error == code_error
 
+    @pytest.mark.eoe
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.smoke
     def test_is_fault_active(self, motion_controller, generate_drive_errors):
         mc, alias = motion_controller
@@ -103,6 +124,9 @@ class TestErrors:
         mc.motion.fault_reset(servo=alias)
         assert not mc.errors.is_fault_active(servo=alias)
 
+    @pytest.mark.eoe
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.smoke
     @pytest.mark.usefixtures("force_warning")
     def test_is_warning_active(self, motion_controller):

--- a/tests/test_homing.py
+++ b/tests/test_homing.py
@@ -63,6 +63,7 @@ def test_set_homing_timeout(motion_controller, homing_timeout):
     test_homing_timeout = mc.communication.get_register(HOMING_TIMEOUT_REGISTER, servo=alias)
     assert test_homing_timeout == homing_timeout
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -76,6 +77,7 @@ def test_homing_on_current_position(motion_controller, homing_offset):
         homing_offset,
         abs=feedback_resolution * RELATIVE_ERROR_ALLOWED,
     ) == mc.motion.get_actual_position(servo=alias)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -119,6 +121,7 @@ def test_homing_on_switch_limit(motion_controller, direction):
     assert pytest.approx(zero_vel) == test_zero_vel
     assert pytest.approx(search_vel) == test_search_vel
     assert test_switch == switch
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -174,6 +177,7 @@ def __check_homing_was_successful(mc, alias, timeout_ms):
             return True
     return False
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -219,6 +223,7 @@ def test_homing_on_index_pulse(motion_controller, feedback_list, direction):
         assert (
             pytest.approx(homing_offset, abs=resolution * RELATIVE_ERROR_ALLOWED) == actual_position
         )
+
 
 @pytest.mark.eoe
 @pytest.mark.soem

--- a/tests/test_homing.py
+++ b/tests/test_homing.py
@@ -63,7 +63,9 @@ def test_set_homing_timeout(motion_controller, homing_timeout):
     test_homing_timeout = mc.communication.get_register(HOMING_TIMEOUT_REGISTER, servo=alias)
     assert test_homing_timeout == homing_timeout
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.parametrize("homing_offset", [0, 1000])
 @pytest.mark.usefixtures("initial_position")
 def test_homing_on_current_position(motion_controller, homing_offset):
@@ -75,7 +77,9 @@ def test_homing_on_current_position(motion_controller, homing_offset):
         abs=feedback_resolution * RELATIVE_ERROR_ALLOWED,
     ) == mc.motion.get_actual_position(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("initial_position")
 @pytest.mark.parametrize("direction", [1, 0])
 def test_homing_on_switch_limit(motion_controller, direction):
@@ -116,7 +120,9 @@ def test_homing_on_switch_limit(motion_controller, direction):
     assert pytest.approx(search_vel) == test_search_vel
     assert test_switch == switch
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("initial_position")
 def test_homing_on_switch_limit_timeout(motion_controller):
     mc, alias = motion_controller
@@ -168,7 +174,9 @@ def __check_homing_was_successful(mc, alias, timeout_ms):
             return True
     return False
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("initial_position")
 @pytest.mark.parametrize("direction", [1, 0])
 def test_homing_on_index_pulse(motion_controller, feedback_list, direction):
@@ -212,7 +220,9 @@ def test_homing_on_index_pulse(motion_controller, feedback_list, direction):
             pytest.approx(homing_offset, abs=resolution * RELATIVE_ERROR_ALLOWED) == actual_position
         )
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("initial_position")
 @pytest.mark.parametrize("direction", [1, 0])
 def test_homing_on_switch_limit_and_index_pulse(motion_controller, direction):

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -72,16 +72,16 @@ def test_get_trigger_type(motion_controller, monitoring, trigger_type):
     ],
 )
 def test_raise_forced_trigger(
-        motion_controller,
-        monitoring,
-        block,
-        timeout,
-        sample_t,
-        wait,
-        result,
-        mon_set_freq,
-        mon_map_registers,
-        disable_monitoring_disturbance,
+    motion_controller,
+    monitoring,
+    block,
+    timeout,
+    sample_t,
+    wait,
+    result,
+    mon_set_freq,
+    mon_map_registers,
+    disable_monitoring_disturbance,
 ):
     mc, alias = motion_controller
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_FORCED)
@@ -107,6 +107,7 @@ def test_raise_forced_trigger_fail(motion_controller, monitoring, disable_monito
     with pytest.raises(IMMonitoringError):
         monitoring.raise_forced_trigger()
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -120,7 +121,7 @@ def test_raise_forced_trigger_fail(motion_controller, monitoring, disable_monito
     ],
 )
 def test_read_monitoring_data_forced_trigger(
-        motion_controller, monitoring, timeout, sample_t, result, disable_monitoring_disturbance
+    motion_controller, monitoring, timeout, sample_t, result, disable_monitoring_disturbance
 ):
     mc, alias = motion_controller
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_FORCED)
@@ -193,15 +194,15 @@ def test_monitoring_map_registers_wrong_cyclic(monitoring):
         (MonitoringSoCType.TRIGGER_EVENT_AUTO, None, None, None),
         (MonitoringSoCType.TRIGGER_EVENT_FORCED, None, None, None),
         (
-                MonitoringSoCType.TRIGGER_EVENT_EDGE,
-                MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
-                {"axis": 1, "name": "CL_POS_FBK_VALUE"},
-                0.5,
+            MonitoringSoCType.TRIGGER_EVENT_EDGE,
+            MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
+            {"axis": 1, "name": "CL_POS_FBK_VALUE"},
+            0.5,
         ),
     ],
 )
 def test_monitoring_set_trigger(
-        motion_controller, monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
+    motion_controller, monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
 ):
     mc, alias = motion_controller
     monitoring.set_trigger(trigger_type, edge_condition, trigger_signal, trigger_value)
@@ -221,21 +222,21 @@ def test_monitoring_set_trigger(
     [
         (MonitoringSoCType.TRIGGER_EVENT_EDGE, None, {"axis": 1, "name": "CL_POS_FBK_VALUE"}, 0.5),
         (
-                MonitoringSoCType.TRIGGER_EVENT_EDGE,
-                MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
-                None,
-                0.5,
+            MonitoringSoCType.TRIGGER_EVENT_EDGE,
+            MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
+            None,
+            0.5,
         ),
         (
-                MonitoringSoCType.TRIGGER_EVENT_EDGE,
-                MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
-                {"axis": 1, "name": "CL_POS_FBK_VALUE"},
-                None,
+            MonitoringSoCType.TRIGGER_EVENT_EDGE,
+            MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
+            {"axis": 1, "name": "CL_POS_FBK_VALUE"},
+            None,
         ),
     ],
 )
 def test_monitoring_set_trigger_exceptions(
-        monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
+    monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
 ):
     with pytest.raises(TypeError):
         monitoring.set_trigger(trigger_type, edge_condition, trigger_signal, trigger_value)
@@ -258,6 +259,7 @@ def test_configure_number_samples(motion_controller, monitoring):
         monitoring.MONITORING_TRIGGER_DELAY_SAMPLES_REGISTER, servo=alias, axis=0
     )
     assert value == trigger_delay_samples
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -335,7 +337,7 @@ def test_read_monitoring_data_disabled(monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 def test_read_monitoring_data_timeout(
-        motion_controller, monitoring, disable_monitoring_disturbance
+    motion_controller, monitoring, disable_monitoring_disturbance
 ):
     timeout = 2
     sample_t = 0.8
@@ -353,7 +355,7 @@ def test_read_monitoring_data_timeout(
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 def test_read_monitoring_data_no_rearm(
-        motion_controller, monitoring, disable_monitoring_disturbance
+    motion_controller, monitoring, disable_monitoring_disturbance
 ):
     sample_t = 0.8
     timeout = 2
@@ -460,7 +462,7 @@ def test_monitoring_map_registers_invalid_register(mocker, motion_controller, mo
 @pytest.mark.virtual
 @pytest.mark.smoke
 def test_monitoring_map_registers_invalid_number_mapped_registers(
-        mocker, motion_controller, monitoring
+    mocker, motion_controller, monitoring
 ):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     mc, alias = motion_controller
@@ -480,7 +482,7 @@ def test_monitoring_map_registers_invalid_number_mapped_registers(
 @pytest.mark.virtual
 @pytest.mark.smoke
 def test_configure_sample_time_exceptions(
-        mocker, motion_controller, monitoring, trigger_delay, expected_exception
+    mocker, motion_controller, monitoring, trigger_delay, expected_exception
 ):
     mc, alias = motion_controller
     total_time = 5

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -59,6 +59,9 @@ def test_get_trigger_type(motion_controller, monitoring, trigger_type):
     assert test_trigger == trigger_type
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.parametrize(
     "block, timeout, sample_t, wait, result",
     [
@@ -69,16 +72,16 @@ def test_get_trigger_type(motion_controller, monitoring, trigger_type):
     ],
 )
 def test_raise_forced_trigger(
-    motion_controller,
-    monitoring,
-    block,
-    timeout,
-    sample_t,
-    wait,
-    result,
-    mon_set_freq,
-    mon_map_registers,
-    disable_monitoring_disturbance,
+        motion_controller,
+        monitoring,
+        block,
+        timeout,
+        sample_t,
+        wait,
+        result,
+        mon_set_freq,
+        mon_map_registers,
+        disable_monitoring_disturbance,
 ):
     mc, alias = motion_controller
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_FORCED)
@@ -90,6 +93,9 @@ def test_raise_forced_trigger(
     time.sleep(1)
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
@@ -101,7 +107,9 @@ def test_raise_forced_trigger_fail(motion_controller, monitoring, disable_monito
     with pytest.raises(IMMonitoringError):
         monitoring.raise_forced_trigger()
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.parametrize(
@@ -112,7 +120,7 @@ def test_raise_forced_trigger_fail(motion_controller, monitoring, disable_monito
     ],
 )
 def test_read_monitoring_data_forced_trigger(
-    motion_controller, monitoring, timeout, sample_t, result, disable_monitoring_disturbance
+        motion_controller, monitoring, timeout, sample_t, result, disable_monitoring_disturbance
 ):
     mc, alias = motion_controller
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_FORCED)
@@ -125,6 +133,9 @@ def test_read_monitoring_data_forced_trigger(
         assert len(test_output[0]) == 0
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
 def test_set_monitoring_frequency(motion_controller, monitoring, prescaler):
@@ -136,6 +147,9 @@ def test_set_monitoring_frequency(motion_controller, monitoring, prescaler):
     assert value == prescaler
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_set_monitoring_frequency_exception(monitoring):
     prescaler = 0.5
@@ -168,6 +182,9 @@ def test_monitoring_map_registers_wrong_cyclic(monitoring):
         monitoring.map_registers(registers)
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.parametrize(
@@ -176,15 +193,15 @@ def test_monitoring_map_registers_wrong_cyclic(monitoring):
         (MonitoringSoCType.TRIGGER_EVENT_AUTO, None, None, None),
         (MonitoringSoCType.TRIGGER_EVENT_FORCED, None, None, None),
         (
-            MonitoringSoCType.TRIGGER_EVENT_EDGE,
-            MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
-            {"axis": 1, "name": "CL_POS_FBK_VALUE"},
-            0.5,
+                MonitoringSoCType.TRIGGER_EVENT_EDGE,
+                MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
+                {"axis": 1, "name": "CL_POS_FBK_VALUE"},
+                0.5,
         ),
     ],
 )
 def test_monitoring_set_trigger(
-    motion_controller, monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
+        motion_controller, monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
 ):
     mc, alias = motion_controller
     monitoring.set_trigger(trigger_type, edge_condition, trigger_signal, trigger_value)
@@ -194,6 +211,9 @@ def test_monitoring_set_trigger(
     assert value == trigger_type
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.parametrize(
@@ -201,26 +221,29 @@ def test_monitoring_set_trigger(
     [
         (MonitoringSoCType.TRIGGER_EVENT_EDGE, None, {"axis": 1, "name": "CL_POS_FBK_VALUE"}, 0.5),
         (
-            MonitoringSoCType.TRIGGER_EVENT_EDGE,
-            MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
-            None,
-            0.5,
+                MonitoringSoCType.TRIGGER_EVENT_EDGE,
+                MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
+                None,
+                0.5,
         ),
         (
-            MonitoringSoCType.TRIGGER_EVENT_EDGE,
-            MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
-            {"axis": 1, "name": "CL_POS_FBK_VALUE"},
-            None,
+                MonitoringSoCType.TRIGGER_EVENT_EDGE,
+                MonitoringSoCConfig.TRIGGER_CONFIG_RISING,
+                {"axis": 1, "name": "CL_POS_FBK_VALUE"},
+                None,
         ),
     ],
 )
 def test_monitoring_set_trigger_exceptions(
-    monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
+        monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
 ):
     with pytest.raises(TypeError):
         monitoring.set_trigger(trigger_type, edge_condition, trigger_signal, trigger_value)
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_configure_number_samples(motion_controller, monitoring):
     mc, alias = motion_controller
@@ -236,7 +259,9 @@ def test_configure_number_samples(motion_controller, monitoring):
     )
     assert value == trigger_delay_samples
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize("total_num_samples, trigger_delay_samples", [(500, 510), (510, -500)])
 def test_configure_number_samples_exceptions(monitoring, total_num_samples, trigger_delay_samples):
@@ -244,6 +269,9 @@ def test_configure_number_samples_exceptions(monitoring, total_num_samples, trig
         monitoring.configure_number_samples(total_num_samples, trigger_delay_samples)
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_configure_sample_time(motion_controller, monitoring):
     mc, alias = motion_controller
@@ -264,6 +292,9 @@ def test_configure_sample_time(motion_controller, monitoring):
     assert value == trigger_delay_samples
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize("total_time, sign", [(5, 1), (5, -1)])
 def test_configure_sample_time_exception(monitoring, total_time, sign):
@@ -285,6 +316,9 @@ def test_read_monitoring_data_not_configured(motion_controller, monitoring):
     assert len(test_output[0]) == 0
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
@@ -295,10 +329,13 @@ def test_read_monitoring_data_disabled(monitoring):
     assert len(test_output[0]) == 0
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 def test_read_monitoring_data_timeout(
-    motion_controller, monitoring, disable_monitoring_disturbance
+        motion_controller, monitoring, disable_monitoring_disturbance
 ):
     timeout = 2
     sample_t = 0.8
@@ -310,10 +347,13 @@ def test_read_monitoring_data_timeout(
     assert len(test_output[0]) == 0
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 def test_read_monitoring_data_no_rearm(
-    motion_controller, monitoring, disable_monitoring_disturbance
+        motion_controller, monitoring, disable_monitoring_disturbance
 ):
     sample_t = 0.8
     timeout = 2
@@ -334,6 +374,9 @@ def test_read_monitoring_data_no_rearm(
     assert len(test_output[0]) == 0
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 def test_rearm_monitoring(motion_controller, monitoring, disable_monitoring_disturbance):
@@ -363,6 +406,9 @@ def run_read_monitoring_data_and_stop(monitoring, timeout):
     return test_thread.join()
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
@@ -414,7 +460,7 @@ def test_monitoring_map_registers_invalid_register(mocker, motion_controller, mo
 @pytest.mark.virtual
 @pytest.mark.smoke
 def test_monitoring_map_registers_invalid_number_mapped_registers(
-    mocker, motion_controller, monitoring
+        mocker, motion_controller, monitoring
 ):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     mc, alias = motion_controller
@@ -434,7 +480,7 @@ def test_monitoring_map_registers_invalid_number_mapped_registers(
 @pytest.mark.virtual
 @pytest.mark.smoke
 def test_configure_sample_time_exceptions(
-    mocker, motion_controller, monitoring, trigger_delay, expected_exception
+        mocker, motion_controller, monitoring, trigger_delay, expected_exception
 ):
     mc, alias = motion_controller
     total_time = 5

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -25,7 +25,9 @@ ACTUAL_DIRECT_CURRENT_REGISTER = "CL_CUR_D_VALUE"
 VOLTAGE_QUADRATURE_SET_POINT_REGISTER = "CL_VOL_Q_SET_POINT"
 VOLTAGE_DIRECT_SET_POINT_REGISTER = "CL_VOL_D_SET_POINT"
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 def test_target_latch(motion_controller):
     mc, alias = motion_controller
     mc.communication.set_register(PROFILER_LATCHING_MODE_REGISTER, 0x40, servo=alias)
@@ -52,7 +54,9 @@ def test_set_operation_mode(motion_controller, operation_mode):
     test_op = mc.communication.get_register(OPERATION_MODE_REGISTER, servo=alias)
     assert operation_mode.value == test_op
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize("operation_mode", list(OperationMode))
 def test_get_operation_mode(motion_controller, operation_mode):
@@ -61,14 +65,18 @@ def test_get_operation_mode(motion_controller, operation_mode):
     test_op = mc.motion.get_operation_mode(servo=alias)
     assert test_op == operation_mode.value
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_motor_enable(motion_controller):
     mc, alias = motion_controller
     mc.motion.motor_enable(servo=alias)
     assert mc.configuration.is_motor_enabled(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "uid, value, exception_type, message",
@@ -90,7 +98,9 @@ def test_motor_enable_error(motion_controller_teardown, uid, value, exception_ty
         mc.motion.motor_enable(servo=alias)
     assert str(excinfo.value) == "An error occurred enabling motor. Reason: {}".format(message)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_motor_enable_with_fault(motion_controller_teardown):
     uid = "DRV_PROT_USER_UNDER_VOLT"
@@ -106,7 +116,9 @@ def test_motor_enable_with_fault(motion_controller_teardown):
         mc.motion.motor_enable(servo=alias)
     assert str(excinfo_2.value) == "An error occurred enabling motor. Reason: {}".format(message)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize("enable_motor", [True, False])
 def test_motor_disable(motion_controller, enable_motor):
@@ -116,7 +128,9 @@ def test_motor_disable(motion_controller, enable_motor):
     mc.motion.motor_disable(servo=alias)
     assert not mc.configuration.is_motor_enabled(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_motor_disable_with_fault(motion_controller_teardown):
     uid = "DRV_PROT_USER_UNDER_VOLT"
@@ -129,7 +143,9 @@ def test_motor_disable_with_fault(motion_controller_teardown):
     mc.motion.motor_disable(servo=alias)
     assert not mc.configuration.is_motor_enabled(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 def test_fault_reset(motion_controller_teardown):
     mc, alias = motion_controller_teardown
@@ -153,7 +169,9 @@ def test_set_position(motion_controller, position_value):
     test_position = mc.communication.get_register(POSITION_SET_POINT_REGISTER, servo=alias)
     assert test_position == position_value
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize("position_value", [1000, 0, -1000, 4000])
 def test_move_position(motion_controller, position_value):
@@ -166,7 +184,9 @@ def test_move_position(motion_controller, position_value):
     pos_tolerance = pos_res * POSITION_PERCENTAGE_ERROR_ALLOWED / 100
     assert pytest.approx(position_value, abs=pos_tolerance) == test_position
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize("velocity_value", [0.5, 1, 0, -0.5])
@@ -176,7 +196,9 @@ def test_set_velocity(motion_controller, velocity_value):
     test_vel = mc.communication.get_register(VELOCITY_SET_POINT_REGISTER, servo=alias)
     assert test_vel == velocity_value
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 # TODO Update approx error. Well tuned motor is needed.
 @pytest.mark.parametrize("velocity_value", [0.5, 1, 0, -0.5])
@@ -253,7 +275,9 @@ def test_ramp_generator(mocker, init_v, final_v, total_t, t, result):
         test_result = next(generator)
         assert pytest.approx(result_v) == test_result
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize("position_value", [-4000, -1000, 1000, 4000])
 def test_get_actual_position(motion_controller, position_value):
@@ -269,7 +293,9 @@ def test_get_actual_position(motion_controller, position_value):
         reg_value[sample_ix] = mc.communication.get_register(ACTUAL_POSITION_REGISTER, servo=alias)
     assert np.abs(np.mean(test_position) - np.mean(reg_value)) < 0.5
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.parametrize("velocity_value", [1, 0, -1])
 def test_get_actual_velocity(motion_controller, velocity_value):
     mc, alias = motion_controller
@@ -325,7 +351,9 @@ def test_wait_for_function_timeout(motion_controller, function):
     final_time = time.time()
     assert pytest.approx(timeout_value, abs=0.1) == final_time - init_time
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.smoke
 @pytest.mark.parametrize("op_mode", [OperationMode.VOLTAGE, OperationMode.CURRENT])
 def test_set_internal_generator_configuration(motion_controller_teardown, op_mode):
@@ -334,7 +362,9 @@ def test_set_internal_generator_configuration(motion_controller_teardown, op_mod
     assert op_mode == mc.motion.get_operation_mode(servo=alias)
     assert 1 == mc.configuration.get_motor_pair_poles(servo=alias)
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.parametrize("op_mode", [OperationMode.VOLTAGE, OperationMode.CURRENT])
 @pytest.mark.parametrize("direction", [-1, 1])
 def test_internal_generator_saw_tooth_move(motion_controller_teardown, op_mode, direction):
@@ -359,7 +389,9 @@ def test_internal_generator_saw_tooth_move(motion_controller_teardown, op_mode, 
         < pos_resolution * POSITION_PERCENTAGE_ERROR_ALLOWED / 100
     )
 
-
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.parametrize("op_mode", [OperationMode.VOLTAGE, OperationMode.CURRENT])
 @pytest.mark.parametrize("direction", [-1, 1])
 def test_internal_generator_constant_move(motion_controller_teardown, op_mode, direction):

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -25,6 +25,7 @@ ACTUAL_DIRECT_CURRENT_REGISTER = "CL_CUR_D_VALUE"
 VOLTAGE_QUADRATURE_SET_POINT_REGISTER = "CL_VOL_Q_SET_POINT"
 VOLTAGE_DIRECT_SET_POINT_REGISTER = "CL_VOL_D_SET_POINT"
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -54,6 +55,7 @@ def test_set_operation_mode(motion_controller, operation_mode):
     test_op = mc.communication.get_register(OPERATION_MODE_REGISTER, servo=alias)
     assert operation_mode.value == test_op
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -65,6 +67,7 @@ def test_get_operation_mode(motion_controller, operation_mode):
     test_op = mc.motion.get_operation_mode(servo=alias)
     assert test_op == operation_mode.value
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -73,6 +76,7 @@ def test_motor_enable(motion_controller):
     mc, alias = motion_controller
     mc.motion.motor_enable(servo=alias)
     assert mc.configuration.is_motor_enabled(servo=alias)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -98,6 +102,7 @@ def test_motor_enable_error(motion_controller_teardown, uid, value, exception_ty
         mc.motion.motor_enable(servo=alias)
     assert str(excinfo.value) == "An error occurred enabling motor. Reason: {}".format(message)
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -116,6 +121,7 @@ def test_motor_enable_with_fault(motion_controller_teardown):
         mc.motion.motor_enable(servo=alias)
     assert str(excinfo_2.value) == "An error occurred enabling motor. Reason: {}".format(message)
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -127,6 +133,7 @@ def test_motor_disable(motion_controller, enable_motor):
         mc.motion.motor_enable(servo=alias)
     mc.motion.motor_disable(servo=alias)
     assert not mc.configuration.is_motor_enabled(servo=alias)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -142,6 +149,7 @@ def test_motor_disable_with_fault(motion_controller_teardown):
         mc.motion.motor_enable(servo=alias)
     mc.motion.motor_disable(servo=alias)
     assert not mc.configuration.is_motor_enabled(servo=alias)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -169,6 +177,7 @@ def test_set_position(motion_controller, position_value):
     test_position = mc.communication.get_register(POSITION_SET_POINT_REGISTER, servo=alias)
     assert test_position == position_value
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -184,6 +193,7 @@ def test_move_position(motion_controller, position_value):
     pos_tolerance = pos_res * POSITION_PERCENTAGE_ERROR_ALLOWED / 100
     assert pytest.approx(position_value, abs=pos_tolerance) == test_position
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -195,6 +205,7 @@ def test_set_velocity(motion_controller, velocity_value):
     mc.motion.set_velocity(velocity_value, servo=alias, target_latch=False)
     test_vel = mc.communication.get_register(VELOCITY_SET_POINT_REGISTER, servo=alias)
     assert test_vel == velocity_value
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -275,6 +286,7 @@ def test_ramp_generator(mocker, init_v, final_v, total_t, t, result):
         test_result = next(generator)
         assert pytest.approx(result_v) == test_result
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -292,6 +304,7 @@ def test_get_actual_position(motion_controller, position_value):
         test_position[sample_ix] = mc.motion.get_actual_position(servo=alias)
         reg_value[sample_ix] = mc.communication.get_register(ACTUAL_POSITION_REGISTER, servo=alias)
     assert np.abs(np.mean(test_position) - np.mean(reg_value)) < 0.5
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -351,6 +364,7 @@ def test_wait_for_function_timeout(motion_controller, function):
     final_time = time.time()
     assert pytest.approx(timeout_value, abs=0.1) == final_time - init_time
 
+
 @pytest.mark.eoe
 @pytest.mark.soem
 @pytest.mark.canopen
@@ -361,6 +375,7 @@ def test_set_internal_generator_configuration(motion_controller_teardown, op_mod
     mc.motion.set_internal_generator_configuration(op_mode, servo=alias)
     assert op_mode == mc.motion.get_operation_mode(servo=alias)
     assert 1 == mc.configuration.get_motor_pair_poles(servo=alias)
+
 
 @pytest.mark.eoe
 @pytest.mark.soem
@@ -388,6 +403,7 @@ def test_internal_generator_saw_tooth_move(motion_controller_teardown, op_mode, 
         abs(total_movement - expected_movement)
         < pos_resolution * POSITION_PERCENTAGE_ERROR_ALLOWED / 100
     )
+
 
 @pytest.mark.eoe
 @pytest.mark.soem


### PR DESCRIPTION
[Doc]
https://novantamotion.atlassian.net/browse/INGM-508
Removed filtering by protocol and select with marks. 
The test that did not have any mark implicitly were executed with all Hw machines. Added marks to be explicit
I did also contemplate the case where a test has no mark, in order to be unnoticed now tests with no mark are considered unit tests. They should not require a connection to any drive and are executed in it's own separate stage after virtual drive tests

[Test]
Run ALL tests on jenkins.
Now there's only a small portion of skipped:
![image](https://github.com/user-attachments/assets/8a4cb705-edde-4fb4-88bb-9bde4ef472ba)

Most of them are because of monitoring not available skip fixture, which I will review to see if there's an alternative
![image](https://github.com/user-attachments/assets/9855ce46-f171-493b-961c-79589ed79f80)