### PR TITLE
set and check monitoring._read_process_finished a to improve stabilit…

### DIFF
--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -401,9 +401,16 @@ def test_rearm_monitoring(motion_controller, monitoring, disable_monitoring_dist
 
 
 def run_read_monitoring_data_and_stop(monitoring, timeout):
+    # Set the flag to true to check that the read_monitoring_data
+    # clears it
+    monitoring._read_process_finished = True
     read_monitoring_data_timeout = partial(monitoring.read_monitoring_data, timeout=timeout)
     test_thread = ThreadWithReturnValue(target=read_monitoring_data_timeout)
     test_thread.start()
+    # Wait for read_monitoring_data to clear the flag, indicating that the thread has started
+    while monitoring._read_process_finished:
+        pass
+    # Now the stop reading data set the flag again and the thread stop on the next cycle
     monitoring.stop_reading_data()
     return test_thread.join()
 


### PR DESCRIPTION
[Doc]
Investigate and found a possible pitfall in the design of the test

Intended behaviour:
- Test starts thread
- Thread calls read_monitoring_data
- read_monitoring_data (in thread) sets flag _read_process_finished to False
- Test calls stop_reading_data
- stop_reading_data sets flag _read_process_finished to True
- read_monitoring_data stops

Spurious behaviour
- Test starts thread
- Test calls stop_reading_data
- stop_reading_data sets flag _read_process_finished to True
- Thread calls read_monitoring_data
- read_monitoring_data (in thread) sets flag _read_process_finished to False
- read_monitoring_data does not stop because _read_process_finished is False

Now behaviour:
- Set _read_process_finished to True
- Test starts thread
- Thread calls read_monitoring_data
- Wait main thread for _read_process_finished to be False
- read_monitoring_data (in thread) sets flag _read_process_finished to False
- Wait ends
- Test calls stop_reading_data
- stop_reading_data sets flag _read_process_finished to True
- read_monitoring_data stops

[Test]
Difficult to actually test because I've had difficulties reproducing the error. At least the jenkins build passes