### PR TITLE
INGM-376 Fix EtherCAT tests with EVE-XCR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -243,10 +243,6 @@ pipeline {
                     }
                     stages {
                         stage("Ethercat Everest") {
-                            when {
-                                // Remove this after fixing INGM-376
-                                expression { false }
-                            }
                             steps {
                                 runTestHW("soem", "ECAT_EVE_SETUP")
                             }

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -57,10 +57,11 @@ class TestErrors:
     @pytest.mark.smoke
     def test_get_last_error(self, motion_controller, generate_drive_errors):
         mc, alias, environment = motion_controller
-        last_error, subnode, warning = mc.errors.get_last_error(servo=alias)
+        # Axis 1 needs to be selected due to a bug in EVE-XCR. For more info check INGM-376.
+        last_error, subnode, warning = mc.errors.get_last_error(servo=alias, axis=1)
         assert last_error == generate_drive_errors[0]
         mc.motion.fault_reset(servo=alias)
-        last_error, subnode, warning = mc.errors.get_last_error(servo=alias)
+        last_error, subnode, warning = mc.errors.get_last_error(servo=alias, axis=1)
         assert last_error == 0
         assert subnode is None
         assert warning is None

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -110,7 +110,7 @@ class TestErrors:
     @pytest.mark.smoke
     def test_get_all_errors(self, motion_controller, generate_drive_errors):
         mc, alias, environment = motion_controller
-        test_all_errors = mc.errors.get_all_errors(servo=alias)
+        test_all_errors = mc.errors.get_all_errors(servo=alias, axis=1)
         for i, code_error in enumerate(generate_drive_errors):
             test_code_error, axis, warning = test_all_errors[i]
             assert test_code_error == code_error

--- a/tests/test_pdo.py
+++ b/tests/test_pdo.py
@@ -263,9 +263,19 @@ def test_start_pdos_number_of_network_exception(mocker, motion_controller):
 
 
 def skip_if_pdo_padding_is_not_available(mc, alias):
+    # Check if monitoring is available (To discard EVE-XCR-E)
+    try:
+        mc.capture._check_version(alias)
+    except NotImplementedError:
+        is_monitoring_available = False
+    else:
+        is_monitoring_available = True
     pdo_poller_fw_version = "2.5.0"
     firmware_version = mc.configuration.get_fw_version(alias, 1)
-    if version.parse(firmware_version) < version.parse(pdo_poller_fw_version):
+    if (
+        version.parse(firmware_version) < version.parse(pdo_poller_fw_version)
+        or not is_monitoring_available
+    ):
         pytest.skip(
             f"PDO poller is available for firmware version {pdo_poller_fw_version} or higher. "
             f"Firmware version found: {firmware_version}"


### PR DESCRIPTION
### Description

Fix EtherCAT tests with EVE-XCR.

Fixes # INGM-376

### Type of change

Please add a description and delete options that are not relevant.

- [ ] Change 1 (description)
- [ ] Change 2 (description)


### Tests
- Fix get_last_error test
- Fix check PDO padding availability.
- Enable EVE-XCR-E tests.

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
