### PR TITLE
INGM-521 Enable CAP-XCR Ethernet tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -229,10 +229,6 @@ pipeline {
                             }
                         }
                         stage("Ethernet Capitan") {
-                            when {
-                                // Remove this after fixing CAP-924
-                                expression { false }
-                            }
                             steps {
                                 runTestHW("eoe", "ETH_CAP_SETUP")
                             }


### PR DESCRIPTION
### Type of change

- Enable CAP-XCR Ethernet tests


### Tests
- [x] Run tests.

### Others

- [x] Set fix version field in the Jira issue.
