### PR TITLE
INGM-495 ProcessDataThread thread exceptions are not shown to the user

### DIFF
--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -10,6 +10,7 @@ from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.exceptions import ILError, ILWrongWorkingCount
 from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
+import ingenialogger
 
 from ingeniamotion.enums import COMMUNICATION_TYPE
 from ingeniamotion.exceptions import IMException
@@ -304,6 +305,7 @@ class PDONetworkManager:
 
     def __init__(self, motion_controller: "MotionController") -> None:
         self.mc = motion_controller
+        self.logger = ingenialogger.get_logger(__name__)
         self._pdo_thread: Optional[PDONetworkManager.ProcessDataThread] = None
         self._pdo_send_observers: List[Callable[[], None]] = []
         self._pdo_receive_observers: List[Callable[[], None]] = []
@@ -750,5 +752,6 @@ class PDONetworkManager:
         Args:
             exc: Exception that was raised in the PDO process data thread.
         """
+        self.logger.error(exc)
         for callback in self._pdo_exceptions_observers:
             callback(exc)

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -3,6 +3,7 @@ import time
 from collections import deque
 from typing import TYPE_CHECKING, Callable, Deque, Dict, List, Optional, Tuple, Type, Union
 
+import ingenialogger
 from ingenialink.canopen.network import CanopenNetwork
 from ingenialink.enums.register import RegCyclicType
 from ingenialink.ethercat.network import EthercatNetwork
@@ -10,7 +11,6 @@ from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.exceptions import ILError, ILWrongWorkingCount
 from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
-import ingenialogger
 
 from ingeniamotion.enums import COMMUNICATION_TYPE
 from ingeniamotion.exceptions import IMException


### PR DESCRIPTION
### Description

Log the PDO thread exceptions.

Fixes # INGM-495

### Type of change

- Log the PDO thread exceptions.
- Fix the PDO subscribe_exceptions test.

### Tests
- [x] Run tests.

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
