### PR TITLE
Ingm 514 test gpios in rack with rack service

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,13 +84,13 @@ def connect_canopen(mc, config: DriveCanOpenSetup, alias):
 
 
 @pytest.fixture(scope="session")
-def motion_controller(tests_setup: Setup, pytestconfig):
+def motion_controller(tests_setup: Setup, pytestconfig, request):
     alias = "test"
     mc = MotionController()
 
     if isinstance(tests_setup, DriveHwSetup):
         if tests_setup.use_rack_service:
-            environment = RackServiceEnvironmentController()
+            environment = RackServiceEnvironmentController(request.getfixturevalue("connect_to_rack_service"))
         else:
             environment = ManualUserEnvironmentController(pytestconfig)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,8 +90,10 @@ def motion_controller(tests_setup: Setup, pytestconfig, request):
 
     if isinstance(tests_setup, DriveHwSetup):
         if tests_setup.use_rack_service:
+            rack_service_client = request.getfixturevalue("connect_to_rack_service")
+            drive_idx, drive = tests_setup.get_rack_drive(rack_service_client)
             environment = RackServiceEnvironmentController(
-                request.getfixturevalue("connect_to_rack_service")
+                rack_service_client, default_drive_idx=drive_idx
             )
         else:
             environment = ManualUserEnvironmentController(pytestconfig)
@@ -283,9 +285,8 @@ def load_firmware(pytestconfig, tests_setup: Setup, request):
     if not tests_setup.use_rack_service:
         return
 
-    drive_idx, drive = tests_setup.get_rack_drive()
-
     client = request.getfixturevalue("connect_to_rack_service")
+    drive_idx, drive = tests_setup.get_rack_drive(client)
 
     client.exposed_turn_on_ps()
     client.exposed_firmware_load(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,9 @@ def motion_controller(tests_setup: Setup, pytestconfig, request):
 
     if isinstance(tests_setup, DriveHwSetup):
         if tests_setup.use_rack_service:
-            environment = RackServiceEnvironmentController(request.getfixturevalue("connect_to_rack_service"))
+            environment = RackServiceEnvironmentController(
+                request.getfixturevalue("connect_to_rack_service")
+            )
         else:
             environment = ManualUserEnvironmentController(pytestconfig)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,9 @@ def motion_controller(tests_setup: Setup, pytestconfig, request):
 
     elif isinstance(tests_setup, EthercatMultiSlaveSetup):
         if tests_setup.drives[0].use_rack_service:
-            environment = RackServiceEnvironmentController()
+            environment = RackServiceEnvironmentController(
+                request.getfixturevalue("connect_to_rack_service")
+            )
         else:
             environment = ManualUserEnvironmentController(pytestconfig)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,17 +283,10 @@ def load_firmware(pytestconfig, tests_setup: Setup, request):
     if not tests_setup.use_rack_service:
         return
 
-    drive_identifier = tests_setup.identifier
-    drive_idx = None
+    drive_idx, drive = tests_setup.get_rack_drive()
+
     client = request.getfixturevalue("connect_to_rack_service")
-    config = client.exposed_get_configuration()
-    for idx, drive in enumerate(config.drives):
-        if drive_identifier == drive.identifier:
-            drive_idx = idx
-            break
-    if drive_idx is None:
-        pytest.fail(f"The drive {drive_identifier} cannot be found on the rack's configuration.")
-    drive = config.drives[drive_idx]
+
     client.exposed_turn_on_ps()
     client.exposed_firmware_load(
         drive_idx, tests_setup.fw_file, drive.product_code, drive.serial_number

--- a/tests/setups/descriptors.py
+++ b/tests/setups/descriptors.py
@@ -3,21 +3,21 @@ from dataclasses import dataclass
 from typing import Optional
 
 
-@dataclass
+@dataclass(frozen=True)
 class Setup:
     """Generic setup"""
 
     pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class EthernetSetup(Setup):
     """Any setup that uses Ethernet"""
 
     ip: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class VirtualDriveSetup(EthernetSetup):
     """Setup with virtual drive"""
 
@@ -25,7 +25,7 @@ class VirtualDriveSetup(EthernetSetup):
     port: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class DriveHwSetup(Setup):
     """Setup with physical hw drive"""
 
@@ -35,7 +35,7 @@ class DriveHwSetup(Setup):
     fw_file: str
     use_rack_service: bool
 
-    @functools.cache()
+    @functools.lru_cache()
     def get_rack_drive(self, rack_service_client):
         config = rack_service_client.exposed_get_configuration()
         for idx, drive in enumerate(config.drives):
@@ -47,7 +47,7 @@ class DriveHwSetup(Setup):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class DriveEthernetSetup(DriveHwSetup, EthernetSetup):
     """Setup with drive with Ethernet.
 
@@ -57,7 +57,7 @@ class DriveEthernetSetup(DriveHwSetup, EthernetSetup):
     pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class DriveEcatSetup(DriveHwSetup):
     """Setup with drive connected with Ethercat"""
 
@@ -67,7 +67,7 @@ class DriveEcatSetup(DriveHwSetup):
     boot_in_app: bool
 
 
-@dataclass
+@dataclass(frozen=True)
 class DriveCanOpenSetup(DriveHwSetup):
     """Setup with drive connected with canopen"""
 
@@ -77,7 +77,7 @@ class DriveCanOpenSetup(DriveHwSetup):
     baudrate: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class EthercatMultiSlaveSetup(Setup):
     """Setup with multiple drives connected with Ethercat"""
 

--- a/tests/setups/descriptors.py
+++ b/tests/setups/descriptors.py
@@ -1,3 +1,4 @@
+import functools
 from dataclasses import dataclass
 from typing import Optional
 
@@ -33,6 +34,17 @@ class DriveHwSetup(Setup):
     config_file: Optional[str]
     fw_file: str
     use_rack_service: bool
+
+    @functools.cache()
+    def get_rack_drive(self, rack_service_client):
+        config = rack_service_client.exposed_get_configuration()
+        for idx, drive in enumerate(config.drives):
+            if self.identifier == drive.identifier:
+                return idx, drive
+
+        raise ValueError(
+            f"The drive {self.identifier} cannot be found on the rack's configuration."
+        )
 
 
 @dataclass

--- a/tests/setups/environment_control.py
+++ b/tests/setups/environment_control.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from virtual_drive.environment import Environment as VirtualDriveEnvironment
 
@@ -48,17 +49,17 @@ class ManualUserEnvironmentController(DriveEnvironmentController):
 class RackServiceEnvironmentController(DriveEnvironmentController):
     """Controller of the environment of Rack Service Setup"""
 
-    def __init__(self, rack_service_client_root):
+    def __init__(self, rack_service_client_root, default_drive_idx: Optional[int] = None):
         self.service = rack_service_client_root
+        self.default_drive_idx = default_drive_idx
 
     def reset(self):
-        self.set_gpi(1, False)
-        self.set_gpi(2, False)
-        self.set_gpi(3, False)
-        self.set_gpi(4, False)
+        pass
 
-    def set_gpi(self, number: int, value: bool):
-        self.service.write_gpio(f"GPI_{number}", int(value))
+    def set_gpi(self, number: int, value: bool, drive_idx: Optional[int] = None):
+        if drive_idx is None:
+            drive_idx = self.default_drive_idx
+        self.service.write_drive_gpio(drive_idx, f"GPI_{number}", int(value))
 
 
 class VirtualDriveEnvironmentController(DriveEnvironmentController):

--- a/tests/setups/environment_control.py
+++ b/tests/setups/environment_control.py
@@ -48,8 +48,8 @@ class ManualUserEnvironmentController(DriveEnvironmentController):
 class RackServiceEnvironmentController(DriveEnvironmentController):
     """Controller of the environment of Rack Service Setup"""
 
-    def __init__(self, rack_service_client):
-        self.service = rack_service_client.root
+    def __init__(self, rack_service_client_root):
+        self.service = rack_service_client_root
 
     def reset(self):
         self.set_gpi(1, False)

--- a/tests/setups/environment_control.py
+++ b/tests/setups/environment_control.py
@@ -48,13 +48,17 @@ class ManualUserEnvironmentController(DriveEnvironmentController):
 class RackServiceEnvironmentController(DriveEnvironmentController):
     """Controller of the environment of Rack Service Setup"""
 
+    def __init__(self, rack_service_client):
+        self.service = rack_service_client.root
+
     def reset(self):
-        pass
+        self.set_gpi(1, False)
+        self.set_gpi(2, False)
+        self.set_gpi(3, False)
+        self.set_gpi(4, False)
 
     def set_gpi(self, number: int, value: bool):
-        # Test gpios in rack with rack service
-        # https://novantamotion.atlassian.net/browse/INGM-514
-        raise NotImplementedError
+        self.service.write_gpio(f"GPI_{number}", int(value))
 
 
 class VirtualDriveEnvironmentController(DriveEnvironmentController):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -42,6 +42,9 @@ def test_set_get_gpi_polarity(motion_controller, gpi_id, polarity):
     assert mc.io.get_gpi_polarity(gpi_id, servo=alias) == polarity
 
 
+@pytest.mark.eoe
+@pytest.mark.soem
+@pytest.mark.canopen
 @pytest.mark.virtual
 @pytest.mark.smoke
 def test_get_gpi_voltage_level(motion_controller):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,6 +2,7 @@ import pytest
 
 from ingeniamotion.enums import GPI, GPO, DigitalVoltageLevel, GPIOPolarity
 from ingeniamotion.exceptions import IMException
+from .setups.rack_setups import CAN_CAP_SETUP, ECAT_CAP_SETUP, ETH_CAP_SETUP
 
 
 @pytest.mark.virtual
@@ -47,8 +48,11 @@ def test_set_get_gpi_polarity(motion_controller, gpi_id, polarity):
 @pytest.mark.canopen
 @pytest.mark.virtual
 @pytest.mark.smoke
-def test_get_gpi_voltage_level(motion_controller):
+def test_get_gpi_voltage_level(motion_controller, tests_setup):
     mc, alias, environment = motion_controller
+
+    if tests_setup in [ETH_CAP_SETUP, ECAT_CAP_SETUP, CAN_CAP_SETUP]:
+        pytest.skip("Capitan rack setups do not have gpio control")
 
     environment.set_gpi(number=1, value=False)
     environment.set_gpi(number=2, value=True)


### PR DESCRIPTION
Added testing of gpi method on the rack to further validate that the structure of the environment and the connection with rack service is practical and scalable.
The rack doesn't have connection to all drives, so the tests skips itself for a some rack setups.

Fixes [# (issue)](https://novantamotion.atlassian.net/browse/INGM-514)

### Type of change

Please add a description and delete options that are not relevant.

- [ ] Connected the environment control with rack service
- [ ] Added markers of hw drives to gpi test

### Tests
Checked the test is being run on all setups and skipped on capitan (they don't have connection to gpios on the rack yet):
![image](https://github.com/user-attachments/assets/0fecbf96-6aa3-4c52-bc86-8ac2a813b7bf)