### PR TITLE
INGM-527 Fix number of steps calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Feedback symmetry check calculation.
+- Phasing test when the commutation feedback is a Halls sensor.
 
 ## [0.8.5] - 2024-08-27
 ### Fixed

--- a/ingeniamotion/wizard_tests/phase_calibration.py
+++ b/ingeniamotion/wizard_tests/phase_calibration.py
@@ -256,7 +256,7 @@ class Phasing(BaseTest[LegacyDictReportType]):
         delta = 3 * self.pha_accuracy / 1000
 
         # If reference feedback are Halls
-        if self.ref == SensorType.HALLS:
+        if SensorType.HALLS in [self.comm, self.ref]:
             actual_angle = self.INITIAL_ANGLE_HALLS
         else:
             actual_angle = self.INITIAL_ANGLE

--- a/ingeniamotion/wizard_tests/phase_calibration.py
+++ b/ingeniamotion/wizard_tests/phase_calibration.py
@@ -255,7 +255,7 @@ class Phasing(BaseTest[LegacyDictReportType]):
         # the phasing accuracy
         delta = 3 * self.pha_accuracy / 1000
 
-        # If reference feedback are Halls
+        # If the reference or commutation feedback is a Halls sensor
         if SensorType.HALLS in [self.comm, self.ref]:
             actual_angle = self.INITIAL_ANGLE_HALLS
         else:


### PR DESCRIPTION
### Description

The timeout to check if the commutation feedback is aligned is too small because the number of phasing steps is incorrectly calculated.

Fixes # INGM-527

### Test

- Run the test with a Halls sensor set as the commutation feedback sensor.
- Check that the test is successful.

### Documentation

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
