### PR TITLE
restore configuration only if configuration file is specified

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,8 +107,8 @@ def motion_controller(tests_setup: Setup, pytestconfig, request):
         else:
             raise NotImplementedError
 
-        mc.configuration.restore_configuration(servo=alias)
         if tests_setup.config_file is not None:
+            mc.configuration.restore_configuration(servo=alias)
             mc.configuration.load_configuration(tests_setup.config_file, servo=alias)
         yield mc, alias, environment
         environment.reset()


### PR DESCRIPTION
### Description
When the configuration file is not specified tests are supposed to assume that the drive is correctly configured.
It was doing a restore configuration instead

### Type of change

- [ ] Fix restore-load configuration on conftest

### Tests
- [ ] Run with a local setup without the config_file specified
