### PR TITLE
Ingm 530 always restart drives of rack before test session

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,6 +288,8 @@ def load_firmware(pytestconfig, tests_setup: Setup, request):
     client = request.getfixturevalue("connect_to_rack_service")
     drive_idx, drive = tests_setup.get_rack_drive(client)
 
+    client.exposed_turn_off_ps()
+    time.sleep(5)
     client.exposed_turn_on_ps()
     client.exposed_firmware_load(
         drive_idx, tests_setup.fw_file, drive.product_code, drive.serial_number


### PR DESCRIPTION
Analyzed previous test failure
ID 6: https://novantamotion.atlassian.net/wiki/spaces/LIBS/pages/927203335/Failing+tests+analysis

The drives seemed to be whole ethercat seemed to be powered down, and you could not connect to it, but the tests do power on the setup.
The following build seemed to work.
Apparently the power on that is done before loading firmware does not give enough time for the drive to actually power on. On the next build it is already powered on, so the drive can load the firmware successfully.

I have validated the theory by first by rebooting before loading:
````
client.exposed_turn_off_ps()
time.sleep(5)
client.exposed_turn_on_ps()
client.exposed_firmware_load(
````
And it always failed. So, on this PR I'm adding a the necessary waiting mechanism.
But I'm also leaving the reboot procedure, which will make sure that the sequence is always the same, no matter the previous rack state.