### PR TITLE
INGM-535 Allow users to subscribe to register updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Method to subscribe to register value updates.
+
 ### Fixed
 - Feedback symmetry check calculation.
 - Phasing test when the commutation feedback is a Halls sensor.

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1020,7 +1020,7 @@ class Communication(metaclass=MCMetaClass):
             # Servo that has not been subscribed yet
             self.register_update_observers[drive] = []
             # Subscribe to ingenialink
-            drive.register_update_subscribe(self._il_callback)
+            drive.register_update_subscribe(self._il_register_subscribe_callback)
 
         self.register_update_observers[drive].append(IMObserver(callback, alias=servo))
 
@@ -1045,12 +1045,12 @@ class Communication(metaclass=MCMetaClass):
         if len(self.register_update_observers[drive]) == 0:
             del self.register_update_observers[drive]
             # No observers, unsubscribe from ingenialink
-            drive.register_update_unsubscribe(self._il_callback)
+            drive.register_update_unsubscribe(self._il_register_subscribe_callback)
 
-    def _il_callback(
+    def _il_register_subscribe_callback(
         self, servo_instance: Servo, register: Register, value: Union[int, float, str, bytes]
     ) -> None:
-        """This method will be the one subscribed ingenialink.
+        """This method will be the one subscribed to ingenialink.
         When called, the servo alias will be added to the received information.
 
         Args:

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1010,8 +1010,8 @@ class Communication(metaclass=MCMetaClass):
         The callback will be called when a read/write operation occurs.
 
         Args:
-            callback: Callable that takes a servo alias, Servo and Register instance and the register value
-            as arguments.
+            callback: Callable that takes a servo alias, Servo and Register instances
+            and the register value as arguments.
             servo : servo alias to reference it. ``default`` by default.
 
         """

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -48,17 +48,22 @@ class RegisterUpdateCallbackModifier:
 
     """
 
-    instances: Dict[str, "RegisterUpdateCallbackModifier"] = {}
+    instances: Dict[
+        str, Dict[Callable[[str, Servo, Register], None], "RegisterUpdateCallbackModifier"]
+    ] = {}
 
     def __new__(
         cls, alias: str, callback: Callable[[str, Servo, Register], None]
     ) -> "RegisterUpdateCallbackModifier":
         if alias in cls.instances:
-            return cls.instances[alias]
+            if callback in cls.instances[alias]:
+                return cls.instances[alias][callback]
+        else:
+            cls.instances[alias] = {}
 
         obj = super().__new__(cls)
 
-        cls.instances[alias] = obj
+        cls.instances[alias][callback] = obj
 
         return obj
 

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -49,11 +49,17 @@ class RegisterUpdateCallbackModifier:
     """
 
     instances: Dict[
-        str, Dict[Callable[[str, Servo, Register], None], "RegisterUpdateCallbackModifier"]
+        str,
+        Dict[
+            Callable[[str, Servo, Register, Union[int, float, str, bytes]], None],
+            "RegisterUpdateCallbackModifier",
+        ],
     ] = {}
 
     def __new__(
-        cls, alias: str, callback: Callable[[str, Servo, Register], None]
+        cls,
+        alias: str,
+        callback: Callable[[str, Servo, Register, Union[int, float, str, bytes]], None],
     ) -> "RegisterUpdateCallbackModifier":
         if alias in cls.instances:
             if callback in cls.instances[alias]:
@@ -67,11 +73,17 @@ class RegisterUpdateCallbackModifier:
 
         return obj
 
-    def __init__(self, alias: str, callback: Callable[[str, Servo, Register], None]) -> None:
+    def __init__(
+        self,
+        alias: str,
+        callback: Callable[[str, Servo, Register, Union[int, float, str, bytes]], None],
+    ) -> None:
         self.alias = alias
         self.callback = callback
 
-    def modified_callback(self, servo: Servo, register: Register) -> None:
+    def modified_callback(
+        self, servo: Servo, register: Register, value: Union[int, float, str, bytes]
+    ) -> None:
         """This method will be the one subscribed to the register updates.
         When called, the servo alias will be added to the information passed to
         the register update callback.
@@ -81,7 +93,7 @@ class RegisterUpdateCallbackModifier:
             register: The register object.
 
         """
-        return self.callback(self.alias, servo, register)
+        return self.callback(self.alias, servo, register, value)
 
 
 class Communication(metaclass=MCMetaClass):
@@ -1039,7 +1051,7 @@ class Communication(metaclass=MCMetaClass):
 
     def subscribe_register_update(
         self,
-        callback: Callable[[str, Servo, Register], None],
+        callback: Callable[[str, Servo, Register, Union[int, float, str, bytes]], None],
         servo: str = DEFAULT_SERVO,
     ) -> None:
         """Subscribe to register updates.
@@ -1055,7 +1067,7 @@ class Communication(metaclass=MCMetaClass):
 
     def unsubscribe_register_update(
         self,
-        callback: Callable[[str, Servo, Register], None],
+        callback: Callable[[str, Servo, Register, Union[int, float, str, bytes]], None],
         servo: str = DEFAULT_SERVO,
     ) -> None:
         """Unsubscribe from register updates.
@@ -1070,8 +1082,8 @@ class Communication(metaclass=MCMetaClass):
 
     @staticmethod
     def _modify_register_update_callback(
-        servo: str, callback: Callable[[str, Servo, Register], None]
-    ) -> Callable[[Servo, Register], None]:
+        servo: str, callback: Callable[[str, Servo, Register, Union[int, float, str, bytes]], None]
+    ) -> Callable[[Servo, Register, Union[int, float, str, bytes]], None]:
         return RegisterUpdateCallbackModifier(servo, callback).modified_callback
 
     def load_firmware_canopen(

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -670,3 +670,6 @@ def test_subscribe_register_updates(motion_controller):
     )
 
     mc.communication.set_register(user_over_voltage_uid, value=previous_reg_value, servo=alias)
+
+    # The old value has not been propagated after unsubscribing
+    assert register_update_callback.value == new_reg_value

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -27,12 +27,14 @@ class RegisterUpdateTest:
         self.alias = None
         self.servo = None
         self.register = None
+        self.value = None
 
-    def register_update_test(self, alias, servo, register):
+    def register_update_test(self, alias, servo, register, value):
         self.call_count += 1
         self.alias = alias
         self.servo = servo
         self.register = register
+        self.value = value
 
 
 @pytest.mark.virtual
@@ -654,14 +656,14 @@ def test_subscribe_register_updates(motion_controller):
     assert register_update_callback.call_count == 1
     assert register_update_callback.alias == alias
     assert register_update_callback.register.identifier == user_over_voltage_uid
-    assert register_update_callback.register.storage == previous_reg_value
+    assert register_update_callback.value == previous_reg_value
 
     new_reg_value = 100
     mc.communication.set_register(user_over_voltage_uid, value=new_reg_value, servo=alias)
     assert register_update_callback.call_count == 2
     assert register_update_callback.alias == alias
     assert register_update_callback.register.identifier == user_over_voltage_uid
-    assert register_update_callback.register.storage == new_reg_value
+    assert register_update_callback.value == new_reg_value
 
     mc.communication.unsubscribe_register_update(
         register_update_callback.register_update_test, servo=alias

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -646,7 +646,9 @@ def test_subscribe_register_updates(motion_controller):
     register_update_callback = RegisterUpdateTest()
 
     mc, alias, environment = motion_controller
-    mc.communication.subscribe_register_update(register_update_callback.register_update_test, servo=alias)
+    mc.communication.subscribe_register_update(
+        register_update_callback.register_update_test, servo=alias
+    )
 
     previous_reg_value = mc.communication.get_register(user_over_voltage_uid, servo=alias)
     assert register_update_callback.call_count == 1
@@ -661,7 +663,8 @@ def test_subscribe_register_updates(motion_controller):
     assert register_update_callback.register.identifier == user_over_voltage_uid
     assert register_update_callback.register.storage == new_reg_value
 
-    mc.communication.unsubscribe_register_update(register_update_callback.register_update_test, servo=alias)
+    mc.communication.unsubscribe_register_update(
+        register_update_callback.register_update_test, servo=alias
+    )
 
     mc.communication.set_register(user_over_voltage_uid, value=previous_reg_value, servo=alias)
-

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -21,6 +21,20 @@ from .setups.descriptors import VirtualDriveSetup, EthernetSetup, DriveCanOpenSe
 TEST_ENSEMBLE_FW_FILE = "tests/resources/example_ensemble_fw.zfu"
 
 
+class RegisterUpdateTest:
+    def __init__(self):
+        self.call_count = 0
+        self.alias = None
+        self.servo = None
+        self.register = None
+
+    def register_update_test(self, alias, servo, register):
+        self.call_count += 1
+        self.alias = alias
+        self.servo = servo
+        self.register = register
+
+
 @pytest.mark.virtual
 def test_connect_servo_eoe(tests_setup: EthernetSetup):
     mc = MotionController()
@@ -623,3 +637,31 @@ def test_get_available_canopen_devices(mocker):
     test_output = mc.communication.get_available_canopen_devices()
     expected_ouput = {CAN_DEVICE.KVASER: [0, 1], CAN_DEVICE.PCAN: [0, 1], CAN_DEVICE.IXXAT: [0, 1]}
     assert test_output == expected_ouput
+
+
+@pytest.mark.virtual
+@pytest.mark.smoke
+def test_subscribe_register_updates(motion_controller):
+    user_over_voltage_uid = "DRV_PROT_USER_OVER_VOLT"
+    register_update_callback = RegisterUpdateTest()
+
+    mc, alias, environment = motion_controller
+    mc.communication.subscribe_register_update(register_update_callback.register_update_test, servo=alias)
+
+    previous_reg_value = mc.communication.get_register(user_over_voltage_uid, servo=alias)
+    assert register_update_callback.call_count == 1
+    assert register_update_callback.alias == alias
+    assert register_update_callback.register.identifier == user_over_voltage_uid
+    assert register_update_callback.register.storage == previous_reg_value
+
+    new_reg_value = 100
+    mc.communication.set_register(user_over_voltage_uid, value=new_reg_value, servo=alias)
+    assert register_update_callback.call_count == 2
+    assert register_update_callback.alias == alias
+    assert register_update_callback.register.identifier == user_over_voltage_uid
+    assert register_update_callback.register.storage == new_reg_value
+
+    mc.communication.unsubscribe_register_update(register_update_callback.register_update_test, servo=alias)
+
+    mc.communication.set_register(user_over_voltage_uid, value=previous_reg_value, servo=alias)
+

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@368bcda
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@8c54688
+
 
 [testenv]
 description = run unit tests

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@8c54688
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@5edf0f7
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@fed2e39
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@368bcda
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
### Description

Add methods to subscribe/unsubscribe to register value updates.

Fixes # INGM-535

### Type of change

- Add the subscribe_register_update method.
- Add the unsubscribe_register_update method.
- Append the servo alias to the information received by ingenialink.


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
