### PR TITLE
INGM-538 Use the correct marker for EtherCAT

### DIFF
--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -684,7 +684,7 @@ def test_subscribe_register_updates(motion_controller):
 
 
 @pytest.mark.canopen
-@pytest.mark.ethercat
+@pytest.mark.soem
 @pytest.mark.smoke
 def test_emcy_callback(motion_controller):
     mc, alias, _ = motion_controller


### PR DESCRIPTION
### Type of change

Please add a description and delete options that are not relevant.

- Use the correct marker for EtherCAT

### Tests
- [x] Run tests.

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
