### PR TITLE
change is_sto1_active and is_sto2_active to booleans instead of ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Method to subscribe to register value updates.
 - Method to subscribe to emergency messages.
 
+### Changed
+- is_sto1_active and is_sto2_active return booleans instead of integers
+
 ### Fixed
 - Feedback symmetry check calculation.
 - Phasing test when the commutation feedback is a Halls sensor.

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -699,7 +699,7 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
             raise TypeError("STO status value has to be an integer")
         return sto_status
 
-    def is_sto1_active(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> int:
+    def is_sto1_active(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
         """
         Get STO1 bit from STO register
 
@@ -708,15 +708,13 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
             axis : servo axis. ``1`` by default.
 
         Returns:
-            return value of STO1 bit.
+            returns True when the STO 1 input is active (bit is 0)
+            returns False when the STO 1 input is inactive (bit is 1)
 
         """
-        if self.get_sto_status(servo, axis) & self.STO1_ACTIVE_BIT:
-            return 1
-        else:
-            return 0
+        return not bool(self.get_sto_status(servo, axis) & self.STO1_ACTIVE_BIT)
 
-    def is_sto2_active(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> int:
+    def is_sto2_active(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
         """
         Get STO2 bit from STO register
 
@@ -725,13 +723,11 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
             axis : servo axis. ``1`` by default.
 
         Returns:
-            return value of STO2 bit.
+            returns True when the STO 2 input is active (bit is 0)
+            returns False when the STO 2 input is inactive (bit is 1)
 
         """
-        if self.get_sto_status(servo, axis) & self.STO2_ACTIVE_BIT:
-            return 1
-        else:
-            return 0
+        return not bool(self.get_sto_status(servo, axis) & self.STO2_ACTIVE_BIT)
 
     def check_sto_power_supply(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> int:
         """

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -708,8 +708,8 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
             axis : servo axis. ``1`` by default.
 
         Returns:
-            returns True when the STO 1 input is active (bit is 0)
-            returns False when the STO 1 input is inactive (bit is 1)
+            True when the STO 1 input is active (bit is 0).
+            False when the STO 1 input is inactive (bit is 1)
 
         """
         return not bool(self.get_sto_status(servo, axis) & self.STO1_ACTIVE_BIT)
@@ -723,8 +723,8 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
             axis : servo axis. ``1`` by default.
 
         Returns:
-            returns True when the STO 2 input is active (bit is 0)
-            returns False when the STO 2 input is inactive (bit is 1)
+            True when the STO 2 input is active (bit is 0).
+            False when the STO 2 input is inactive (bit is 1)
 
         """
         return not bool(self.get_sto_status(servo, axis) & self.STO2_ACTIVE_BIT)

--- a/ingeniamotion/wizard_tests/sto.py
+++ b/ingeniamotion/wizard_tests/sto.py
@@ -66,13 +66,13 @@ class STOTest(BaseTest[LegacyDictReportType]):
         pass
 
     def loop(self) -> ResultType:
-        if self.mc.configuration.is_sto1_active(servo=self.servo, axis=self.axis) == 0:
+        if self.mc.configuration.is_sto1_active(servo=self.servo, axis=self.axis):
             self.logger.info("STO1 bit is LOW")
         # Check STO1 status --> Check bit 0 (0x1 in HEX)
         else:
             self.logger.info("STO1 bit is HIGH")
 
-        if self.mc.configuration.is_sto2_active(servo=self.servo, axis=self.axis) == 0:
+        if self.mc.configuration.is_sto2_active(servo=self.servo, axis=self.axis):
             self.logger.info("STO2 bit is LOW")
         # Check STO2 status --> Check bit 1 (0x2 in HEX)
         else:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -409,32 +409,39 @@ def patch_get_sto_status(mocker, value):
 @pytest.mark.parametrize(
     "sto_status_value, expected_result",
     [
-        (0x4843, 1),
-        (0xF567, 1),
-        (0xFFFF, 1),
-        (0x0000, 0),
-        (0x4766, 0),
-        (0xF6A4, 0),
+        (0x4843, False),
+        (0xF567, False),
+        (0xFFFF, False),
+        (0x0000, True),
+        (0x4766, True),
+        (0xF6A4, True),
     ],
 )
 def test_is_sto1_active(mocker, motion_controller, sto_status_value, expected_result):
     mc, alias, environment = motion_controller
     patch_get_sto_status(mocker, sto_status_value)
     value = mc.configuration.is_sto1_active(servo=alias)
-    assert value == expected_result
+    assert value is expected_result
 
 
 @pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value, expected_result",
-    [(0xA187, 1), (0x31BA, 1), (0xD7DD, 0), (0xFB8, 0), (0xA8DE, 1), (0x99A5, 0)],
+    [
+        (0xA187, False),
+        (0x31BA, False),
+        (0xD7DD, True),
+        (0xFB8, True),
+        (0xA8DE, False),
+        (0x99A5, True),
+    ],
 )
 def test_is_sto2_active(mocker, motion_controller, sto_status_value, expected_result):
     mc, alias, environment = motion_controller
     patch_get_sto_status(mocker, sto_status_value)
     value = mc.configuration.is_sto2_active(servo=alias)
-    assert value == expected_result
+    assert value is expected_result
 
 
 @pytest.mark.virtual


### PR DESCRIPTION
Fixes INGM-532

### Type of change

Please add a description and delete options that are not relevant.

- [x] change return type
- [x] adapt tests
- [x] Check wizard usage -> Not used
- [x] Check motionlab usage -> Not used

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
