### PR TITLE
INGM-533 Check sto abnormal fault return a bit should be a boolean or named get sto abnormal fault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Feedback symmetry check calculation.
 - Phasing test when the commutation feedback is a Halls sensor.
 
+### Deprecated 
+- check_sto_abnormal_fault in configuration. Use is_sto_abnormal_fault instead.
+
 ## [0.8.5] - 2024-08-27
 ### Fixed
 - Remove SBC registers that have been removed on FW

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -6,6 +6,7 @@ import ingenialogger
 from ingenialink.canopen.network import CAN_BAUDRATE, CanopenNetwork
 from ingenialink.ethernet.servo import EthernetServo
 from ingenialink.exceptions import ILError
+from ingenialink.utils._utils import deprecated
 
 from ingeniamotion.enums import (
     CommutationMode,
@@ -255,6 +256,7 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
         drive.restore_parameters(axis)
         self.logger.info("Configuration restored", drive=self.mc.servo_name(servo))
 
+    @deprecated(new_func_name="set_max_profile_acceleration or set_profiler")
     def set_max_acceleration(
         self, acceleration: float, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS
     ) -> None:
@@ -273,11 +275,6 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
             TypeError: If acceleration is not a float.
 
         """
-        self.logger.warning(
-            '"set_max_acceleration" is deprecated. '
-            'Please use "set_max_profile_acceleration" or '
-            '"set_profiler".'
-        )
         self.mc.communication.set_register(
             self.PROFILE_MAX_ACCELERATION_REGISTER, acceleration, servo=servo, axis=axis
         )
@@ -750,9 +747,12 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
         else:
             return 0
 
+    @deprecated(new_func_name="is_sto_abnormal_fault")
     def check_sto_abnormal_fault(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> int:
-        """
-        Get abnormal fault bit from STO register
+        """Get abnormal fault bit from STO register.
+
+        .. warning::
+            This function is deprecated. Please use "is_sto_abnormal_fault" instead.
 
         Args:
             servo : servo alias to reference it. ``default`` by default.

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -826,6 +826,19 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
         """
         return self.get_sto_status(servo, axis) == self.STO_LATCHED_STATE
 
+    def is_sto_abnormal_fault(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
+        """Check if the STO of a drive is in abnormal fault.
+
+        Args:
+            servo : servo alias to reference it. ``default`` by default.
+            axis : servo axis. ``1`` by default.
+
+        Returns:
+            ``True`` if STO is in abnormal fault, else ``False``.
+
+        """
+        return bool(self.get_sto_status(servo, axis) & self.STO_ABNORMAL_FAULT_BIT)
+
     def change_tcp_ip_parameters(
         self, ip_address: str, subnet_mask: str, gateway: str, servo: str = DEFAULT_SERVO
     ) -> None:

--- a/ingeniamotion/wizard_tests/sto.py
+++ b/ingeniamotion/wizard_tests/sto.py
@@ -88,10 +88,10 @@ class STOTest(BaseTest[LegacyDictReportType]):
             self.logger.info("STO Power Supply is HIGH")
 
         # Check STO abnormal fault status --> Check bit 3 (0x8 in HEX)
-        sto_abnormal_fault = self.mc.configuration.check_sto_abnormal_fault(
+        sto_abnormal_fault = self.mc.configuration.is_sto_abnormal_fault(
             servo=self.servo, axis=self.axis
         )
-        if sto_abnormal_fault == 0:
+        if not sto_abnormal_fault:
             self.logger.info("STO abnormal fault bit is LOW")
         else:
             self.logger.info("STO abnormal fault bit is HIGH")

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -456,12 +456,19 @@ def test_check_sto_power_supply(mocker, motion_controller, sto_status_value, exp
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value, expected_result",
-    [(0x1BAF, 1), (0xD363, 0), (0xAD9D, 1), (0x8D14, 0), (0x9AEE, 1), (0x94A7, 0)],
+    [
+        (0x1BAF, True),
+        (0xD363, False),
+        (0xAD9D, True),
+        (0x8D14, False),
+        (0x9AEE, True),
+        (0x94A7, False),
+    ],
 )
-def test_check_sto_abnormal_fault(mocker, motion_controller, sto_status_value, expected_result):
+def test_is_sto_abnormal_fault(mocker, motion_controller, sto_status_value, expected_result):
     mc, alias, environment = motion_controller
     patch_get_sto_status(mocker, sto_status_value)
-    value = mc.configuration.check_sto_abnormal_fault(servo=alias)
+    value = mc.configuration.is_sto_abnormal_fault(servo=alias)
     assert value == expected_result
 
 


### PR DESCRIPTION
### Type of change

- Add the is_sto_abnormal_fault method.
- Add deprecation warnings.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.