### PR TITLE
INGM-548 Raise IMFirmwareLoadError upon an ensemble check failure

### DIFF
--- a/ingeniamotion/exceptions.py
+++ b/ingeniamotion/exceptions.py
@@ -38,3 +38,9 @@ class IMTimeoutError(IMException):
     """Error raised by IngeniaMotion when a timeout has occurred"""
 
     pass
+
+
+class IMFirmwareLoadError(IMException):
+    """Error raised by IngeniaMotion when a firmware file could not be loaded"""
+
+    pass

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -15,7 +15,11 @@ from ingenialink.servo import SERVO_STATE
 
 import ingeniamotion
 from ingeniamotion import MotionController
-from ingeniamotion.exceptions import IMException, IMRegisterNotExist, IMRegisterWrongAccess
+from ingeniamotion.exceptions import (
+    IMRegisterNotExist,
+    IMRegisterWrongAccess,
+    IMFirmwareLoadError,
+)
 
 from .setups.descriptors import DriveCanOpenSetup, EthernetSetup, Setup
 
@@ -433,9 +437,12 @@ def test__check_ensemble_wrong():
         }
     )
 
-    with pytest.raises(IMException) as exc_info:
+    with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication._Communication__check_ensemble(slaves, 3, mapping)
-    assert str(exc_info.value) == "The selected drive is not part of the ensemble."
+    assert (
+        str(exc_info.value)
+        == "The firmware file could not be loaded correctly. The selected drive is not part of the ensemble."
+    )
 
     slaves = OrderedDict(
         {
@@ -443,11 +450,11 @@ def test__check_ensemble_wrong():
             2: SlaveInfo(654321, 16781876),
         }
     )
-    with pytest.raises(IMException) as exc_info:
+    with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication._Communication__check_ensemble(slaves, 1, mapping)
     assert (
         str(exc_info.value)
-        == "Wrong ensemble. The slave 2 has wrong product code or revision number."
+        == "The firmware file could not be loaded correctly. The slave 2 has wrong product code or revision number."
     )
 
     slaves = OrderedDict(
@@ -456,9 +463,12 @@ def test__check_ensemble_wrong():
             2: SlaveInfo(product_code, 4661),
         }
     )
-    with pytest.raises(IMException) as exc_info:
+    with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication._Communication__check_ensemble(slaves, 2, mapping)
-    assert str(exc_info.value) == "Wrong ensemble. The slave 2 is not detected."
+    assert (
+        str(exc_info.value)
+        == "The firmware file could not be loaded correctly. The slave 2 is not detected."
+    )
 
 
 @pytest.mark.virtual
@@ -488,9 +498,12 @@ def test_check_slave_in_ensemble_drive_not_in_ensemble():
     revision_number = 4660
     slave_info = SlaveInfo(product_code, revision_number)
 
-    with pytest.raises(IMException) as exc_info:
+    with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication._Communication__check_slave_in_ensemble(slave_info, mapping)
-    assert str(exc_info.value) == "The selected drive is not part of the ensemble."
+    assert (
+        str(exc_info.value)
+        == "The firmware file could not be loaded correctly. The selected drive is not part of the ensemble."
+    )
 
 
 @pytest.mark.virtual
@@ -539,9 +552,12 @@ def test_load_ensemble_fw_ecat(mocker):
         assert patch_fw_callback.call_args_list[1][0][1] is False
         assert patch_fw_callback.call_args_list[1][0][2] == 4
 
-    with pytest.raises(IMException) as exc_info:
+    with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication.load_firmware_ecat("", TEST_ENSEMBLE_FW_FILE, slave=5)
-    assert str(exc_info.value) == "The selected drive is not part of the ensemble."
+    assert (
+        str(exc_info.value)
+        == "The firmware file could not be loaded correctly. The selected drive is not part of the ensemble."
+    )
 
 
 @pytest.mark.virtual
@@ -601,9 +617,12 @@ def test_load_ensemble_fw_canopen(mocker):
         assert patch_fw_callback.call_args_list[1][0][0] == 4
         assert patch_fw_callback.call_args_list[1][0][1].endswith("cap-net-2-e_2.4.0.lfu")
 
-    with pytest.raises(IMException) as exc_info:
+    with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication.load_firmware_canopen(TEST_ENSEMBLE_FW_FILE, servo="5")
-    assert str(exc_info.value) == "The selected drive is not part of the ensemble."
+    assert (
+        str(exc_info.value)
+        == "The firmware file could not be loaded correctly. The selected drive is not part of the ensemble."
+    )
 
 
 @pytest.mark.virtual

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -16,9 +16,9 @@ from ingenialink.servo import SERVO_STATE
 import ingeniamotion
 from ingeniamotion import MotionController
 from ingeniamotion.exceptions import (
+    IMFirmwareLoadError,
     IMRegisterNotExist,
     IMRegisterWrongAccess,
-    IMFirmwareLoadError,
 )
 
 from .setups.descriptors import DriveCanOpenSetup, EthernetSetup, Setup
@@ -440,8 +440,8 @@ def test__check_ensemble_wrong():
     with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication._Communication__check_ensemble(slaves, 3, mapping)
     assert (
-        str(exc_info.value)
-        == "The firmware file could not be loaded correctly. The selected drive is not part of the ensemble."
+        str(exc_info.value) == "The firmware file could not be loaded correctly. "
+        "The selected drive is not part of the ensemble."
     )
 
     slaves = OrderedDict(
@@ -453,8 +453,8 @@ def test__check_ensemble_wrong():
     with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication._Communication__check_ensemble(slaves, 1, mapping)
     assert (
-        str(exc_info.value)
-        == "The firmware file could not be loaded correctly. The slave 2 has wrong product code or revision number."
+        str(exc_info.value) == "The firmware file could not be loaded correctly. "
+        "The slave 2 has wrong product code or revision number."
     )
 
     slaves = OrderedDict(
@@ -466,8 +466,8 @@ def test__check_ensemble_wrong():
     with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication._Communication__check_ensemble(slaves, 2, mapping)
     assert (
-        str(exc_info.value)
-        == "The firmware file could not be loaded correctly. The slave 2 is not detected."
+        str(exc_info.value) == "The firmware file could not be loaded correctly. "
+        "The slave 2 is not detected."
     )
 
 
@@ -501,8 +501,8 @@ def test_check_slave_in_ensemble_drive_not_in_ensemble():
     with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication._Communication__check_slave_in_ensemble(slave_info, mapping)
     assert (
-        str(exc_info.value)
-        == "The firmware file could not be loaded correctly. The selected drive is not part of the ensemble."
+        str(exc_info.value) == "The firmware file could not be loaded correctly. "
+        "The selected drive is not part of the ensemble."
     )
 
 
@@ -555,8 +555,8 @@ def test_load_ensemble_fw_ecat(mocker):
     with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication.load_firmware_ecat("", TEST_ENSEMBLE_FW_FILE, slave=5)
     assert (
-        str(exc_info.value)
-        == "The firmware file could not be loaded correctly. The selected drive is not part of the ensemble."
+        str(exc_info.value) == "The firmware file could not be loaded correctly. "
+        "The selected drive is not part of the ensemble."
     )
 
 
@@ -620,8 +620,8 @@ def test_load_ensemble_fw_canopen(mocker):
     with pytest.raises(IMFirmwareLoadError) as exc_info:
         mc.communication.load_firmware_canopen(TEST_ENSEMBLE_FW_FILE, servo="5")
     assert (
-        str(exc_info.value)
-        == "The firmware file could not be loaded correctly. The selected drive is not part of the ensemble."
+        str(exc_info.value) == "The firmware file could not be loaded correctly. "
+        "The selected drive is not part of the ensemble."
     )
 
 


### PR DESCRIPTION
### Type of change

Please add a description and delete options that are not relevant.

- Create the IMFirmwareLoadError exception.
- Raise the exception upon an ensemble check failure.
- Add extra checks (no slaves detected, slave not in scanned slaves).

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
