### PR TITLE
INGM-549 Add a method to set the MAC address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Method to subscribe to register value updates.
 - Method to subscribe to emergency messages.
 - Method to get a servo's network state.
+- Methods to get/set a servo's MAC address.
 
 ### Changed
 - is_sto1_active and is_sto2_active return booleans instead of integers

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -1,7 +1,7 @@
 import re
 from enum import IntEnum
 from os import path
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, Union, overload
 
 import ingenialogger
 from ingenialink.canopen.network import CAN_BAUDRATE, CanopenNetwork
@@ -928,6 +928,14 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
         if not isinstance(drive, EthernetServo):
             raise IMException("TCP IP parameters can only be restored in ethernet servos.")
         drive.restore_tcp_ip_parameters()
+
+    @overload
+    def get_mac_address(self, *, string_format: Literal[True]) -> str:
+        ...
+
+    @overload
+    def get_mac_address(self, *, string_format: Literal[False]) -> int:
+        ...
 
     def get_mac_address(
         self, servo: str = DEFAULT_SERVO, string_format: bool = False

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -1,3 +1,4 @@
+import re
 from enum import IntEnum
 from os import path
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
@@ -28,6 +29,49 @@ if TYPE_CHECKING:
 class TYPE_SUBNODES(IntEnum):
     COCO = 0
     MOCO = 1
+
+
+class MACAddressConverter:
+    """Class to convert MAC addresses from int to str
+    and vice versa."""
+
+    @staticmethod
+    def int_to_str(mac_address: int) -> str:
+        """Convert a MAC address to the string format
+        XX:XX:XX:XX:XX:XX.
+
+        Args:
+            mac_address: The MAC address as an integer.
+
+        Returns:
+            The MAC address in string format.
+
+        """
+        if not isinstance(mac_address, int):
+            ValueError(
+                f"The MAC address has the wrong type. Expected an int, got {type(mac_address)}."
+            )
+        return ":".join(re.findall("..", "%012x" % mac_address))
+
+    @staticmethod
+    def str_to_int(mac_address: str) -> int:
+        """Convert a MAC address in string format to an int.
+
+        Args:
+            mac_address: The MAC address in string format.
+
+        Returns:
+            The MAC address as an integer.
+
+        Raises:
+            ValueError: If the MAC address has the wrong format.
+
+        """
+        try:
+            mac_address_int = int(mac_address.replace(":", ""), 16)
+        except ValueError:
+            raise ValueError("The MAC address has an incorrect format.")
+        return mac_address_int
 
 
 class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
@@ -836,7 +880,12 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
         return bool(self.get_sto_status(servo, axis) & self.STO_ABNORMAL_FAULT_BIT)
 
     def change_tcp_ip_parameters(
-        self, ip_address: str, subnet_mask: str, gateway: str, servo: str = DEFAULT_SERVO
+        self,
+        ip_address: str,
+        subnet_mask: str,
+        gateway: str,
+        mac_address: Optional[Union[str, int]] = None,
+        servo: str = DEFAULT_SERVO,
     ) -> None:
         """Change TCP IP parameters and store it.
 
@@ -844,13 +893,17 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
             ip_address : IP Address to be changed.
             subnet_mask : Subnet mask to be changed.
             gateway : Gateway to be changed.
+            mac_address: The MAC address to be set. It can be an int or a
+            string with format XX:XX:XX:XX:XX:XX.
             servo : servo alias to reference it. ``default`` by default.
 
         """
         drive = self.mc._get_drive(servo)
         if not isinstance(drive, EthernetServo):
             raise IMException("TCP IP parameters can only be changed in ethernet servos.")
-        drive.change_tcp_ip_parameters(ip_address, subnet_mask, gateway)
+        if isinstance(mac_address, str):
+            mac_address = MACAddressConverter.str_to_int(mac_address)
+        drive.change_tcp_ip_parameters(ip_address, subnet_mask, gateway, mac_address)
 
     def store_tcp_ip_parameters(self, servo: str = DEFAULT_SERVO) -> None:
         """Store TCP IP parameters to non-volatile memory.
@@ -875,6 +928,43 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
         if not isinstance(drive, EthernetServo):
             raise IMException("TCP IP parameters can only be restored in ethernet servos.")
         drive.restore_tcp_ip_parameters()
+
+    def get_mac_address(
+        self, servo: str = DEFAULT_SERVO, string_format: bool = False
+    ) -> Union[int, str]:
+        """Get the MAC address of a servo.
+
+        Args:
+            servo : servo alias to reference it. ``default`` by default.
+            string_format: If True, return the MAC address in string format.
+
+        Returns:
+            The servo's MAC address.
+
+        """
+        drive = self.mc._get_drive(servo)
+        if not isinstance(drive, EthernetServo):
+            raise IMException("The MAC address can only be read from Ethernet servos.")
+        mac_address = drive.get_mac_address()
+        if string_format:
+            return MACAddressConverter.int_to_str(mac_address)
+        return mac_address
+
+    def set_mac_address(self, mac_address: Union[int, str], servo: str = DEFAULT_SERVO) -> None:
+        """Set the MAC address of the servo.
+
+        Args:
+            mac_address: The MAC address to be set. It can be an int or a
+            string with format XX:XX:XX:XX:XX:XX.
+            servo : servo alias to reference it. ``default`` by default.
+
+        """
+        drive = self.mc._get_drive(servo)
+        if not isinstance(drive, EthernetServo):
+            raise IMException("The MAC address can only be set to Ethernet servos.")
+        if isinstance(mac_address, str):
+            mac_address = MACAddressConverter.str_to_int(mac_address)
+        drive.set_mac_address(mac_address)
 
     def get_drive_info_coco_moco(
         self,

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -48,7 +48,7 @@ class MACAddressConverter:
 
         """
         if not isinstance(mac_address, int):
-            ValueError(
+            raise ValueError(
                 f"The MAC address has the wrong type. Expected an int, got {type(mac_address)}."
             )
         return ":".join(re.findall("..", "%012x" % mac_address))

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,7 +4,7 @@ import pytest
 from ingenialink.canopen.network import CAN_BAUDRATE
 from ingenialink.ethercat.servo import EthercatServo
 
-from ingeniamotion.configuration import MACAddressConverter, TYPE_SUBNODES
+from ingeniamotion.configuration import TYPE_SUBNODES, MACAddressConverter
 from ingeniamotion.enums import (
     CommutationMode,
     FilterNumber,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,7 +4,7 @@ import pytest
 from ingenialink.canopen.network import CAN_BAUDRATE
 from ingenialink.ethercat.servo import EthercatServo
 
-from ingeniamotion.configuration import TYPE_SUBNODES
+from ingeniamotion.configuration import MACAddressConverter, TYPE_SUBNODES
 from ingeniamotion.enums import (
     CommutationMode,
     FilterNumber,
@@ -863,3 +863,50 @@ def test_get_subnode_type_exception(motion_controller):
     mc, alias, environment = motion_controller
     with pytest.raises(ValueError):
         mc.configuration.get_subnode_type(-1)
+
+
+@pytest.mark.virtual
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "mac_address_str, mac_address_int",
+    [
+        ("49:4e:47:03:02:01", 80600547656193),
+        ("02:01:05:40:03:e9", 2203406304233),
+    ],
+)
+def test_mac_address_convertion(mac_address_str, mac_address_int):
+    assert MACAddressConverter.str_to_int(mac_address_str) == mac_address_int
+    assert MACAddressConverter.int_to_str(mac_address_int) == mac_address_str
+
+
+@pytest.mark.virtual
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "invalid_mac_address",
+    [
+        "mac_address",
+        "49-4e-47-03-02-01",
+    ],
+)
+def test_mac_address_str_to_int_convertion_exception(invalid_mac_address):
+    with pytest.raises(ValueError) as excinfo:
+        MACAddressConverter.str_to_int(invalid_mac_address)
+    assert str(excinfo.value) == "The MAC address has an incorrect format."
+
+
+@pytest.mark.virtual
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "invalid_mac_address",
+    [
+        125.0,
+        "49:4e:47:03:02:01",
+    ],
+)
+def test_mac_address_int_to_str_convertion_exception(invalid_mac_address):
+    with pytest.raises(ValueError) as excinfo:
+        MACAddressConverter.int_to_str(invalid_mac_address)
+    assert (
+        str(excinfo.value)
+        == f"The MAC address has the wrong type. Expected an int, got {type(invalid_mac_address)}."
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@9becdee
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@707d1d2
 
 
 [testenv]


### PR DESCRIPTION
### Type of change

- Add methods to set/get the MAC address.
- Add a helper class to convert MAC addresses between int and string format.
- Add an optional argument to set the MAC address in the change_tcp_ip_parametes method.

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
