### PR TITLE
INGM-557 Retrieve IP-less network adapter information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Method to subscribe to emergency messages.
 - Method to get a servo's network state.
 - Methods to get/set a servo's MAC address.
+- Retrieve IP-less network adapters information (on Windows).
 
 ### Changed
 - is_sto1_active and is_sto2_active return booleans instead of integers

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
         "ingenialink>=7.3.5, < 8.0.0",
         "ingenialogger>=0.2.1",
         "ifaddr==0.1.7",
+        'wmi==1.5.1; platform_system == "Windows"',
     ],
     extras_require={
         "FSoE": ["fsoe-master==0.1.2"],


### PR DESCRIPTION
### Description

Unconfigured network adapters (IP-less) were not detected by the get_interface_name_list method.

Fixes # INGM-557

### Type of change

- Retrieve IP-less network adapter information.

### Tests
- Remove the IPv4 and IPv6 options from a network adapter options.
- Call the get_interface_name_list method
- Check that the network adapter is listed.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
