### PR TITLE
INGM-557 Retrieve IP-less network adapter information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Method to subscribe to emergency messages.
 - Method to get a servo's network state.
 - Methods to get/set a servo's MAC address.
+- Retrieve IP-less network adapters information (on Windows).
 
 ### Changed
 - is_sto1_active and is_sto2_active return booleans instead of integers

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -485,7 +485,9 @@ class Communication(metaclass=MCMetaClass):
         """
         network_adapters = []
         for adapter in ifaddr.get_adapters():
-            network_adapters.append(NetworkAdapter(adapter.index, adapter.nice_name, adapter.name))
+            network_adapters.append(
+                NetworkAdapter(adapter.index, adapter.nice_name, bytes.decode(adapter.name))
+            )
         if RUNNING_ON_WINDOWS:
             from wmi import WMI
 

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -398,7 +398,7 @@ class Communication(metaclass=MCMetaClass):
                 :func:`get_interface_name_list`.
         """
         adapter_name = cls.get_interface_name_list()[index]
-        adapter_guid = cls.__get_network_adapters()[adapter_name]
+        adapter_guid = cls.get_network_adapters()[adapter_name]
         if RUNNING_ON_WINDOWS:
             return f"\\Device\\NPF_{adapter_guid}"
         return adapter_name
@@ -472,11 +472,11 @@ class Communication(metaclass=MCMetaClass):
             List with interface readable names.
 
         """
-        network_adapters = cls.__get_network_adapters()
+        network_adapters = cls.get_network_adapters()
         return list(network_adapters)
 
     @staticmethod
-    def __get_network_adapters() -> Dict[str, str]:
+    def get_network_adapters() -> Dict[str, str]:
         """Get the detected network adapters.
 
         Returns:

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -490,9 +490,11 @@ class Communication(metaclass=MCMetaClass):
         """
         network_adapters = []
         for adapter in ifaddr.get_adapters():
-            network_adapters.append(
-                NetworkAdapter(adapter.index, adapter.nice_name, bytes.decode(adapter.name))
-            )
+            if isinstance(adapter.name, bytes):
+                adapter_guid = bytes.decode(adapter.name)
+            else:
+                adapter_guid = adapter.name
+            network_adapters.append(NetworkAdapter(adapter.index, adapter.nice_name, adapter_guid))
         if RUNNING_ON_WINDOWS:
             # When using WMI within threads it is required to initialize the COM objects
             # https://stackoverflow.com/a/14428972

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import ifaddr
 import ingenialogger
+import pythoncom
 from ingenialink.canopen.network import CAN_BAUDRATE, CAN_CHANNELS, CAN_DEVICE, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.dictionary import Interface
@@ -37,6 +38,10 @@ if TYPE_CHECKING:
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
 
 RUNNING_ON_WINDOWS = platform.system() == "Windows"
+
+if RUNNING_ON_WINDOWS:
+    from wmi import WMI
+
 FILE_EXT_SFU = ".sfu"
 FILE_EXT_LFU = ".lfu"
 FIRMWARE_FILE_FAIL_MSG = "The firmware file could not be loaded correctly"
@@ -489,7 +494,9 @@ class Communication(metaclass=MCMetaClass):
                 NetworkAdapter(adapter.index, adapter.nice_name, bytes.decode(adapter.name))
             )
         if RUNNING_ON_WINDOWS:
-            from wmi import WMI
+            # When using WMI within threads it is required to initialize the COM objects
+            # https://stackoverflow.com/a/14428972
+            pythoncom.CoInitialize()
 
             for adapter in [
                 NetworkAdapter(o.interfaceindex, o.Name, o.GUID)

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import ifaddr
 import ingenialogger
-import pythoncom
 from ingenialink.canopen.network import CAN_BAUDRATE, CAN_CHANNELS, CAN_DEVICE, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.dictionary import Interface
@@ -40,6 +39,7 @@ from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
 RUNNING_ON_WINDOWS = platform.system() == "Windows"
 
 if RUNNING_ON_WINDOWS:
+    import pythoncom
     from wmi import WMI
 
 FILE_EXT_SFU = ".sfu"

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,3 +16,6 @@ ignore_missing_imports = True
 
 [mypy-ping3]
 ignore_missing_imports = True
+
+[mypy-wmi]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,3 +19,6 @@ ignore_missing_imports = True
 
 [mypy-wmi]
 ignore_missing_imports = True
+
+[mypy-pythoncom]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
     install_requires=[
         "ingenialink>=7.3.5, < 8.0.0",
         "ingenialogger>=0.2.1",
-        "ifaddr==0.1.7",
+        "ifaddr==0.2.0",
         'wmi==1.5.1; platform_system == "Windows"',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
         "ingenialink>=7.3.5, < 8.0.0",
         "ingenialogger>=0.2.1",
         "ifaddr==0.1.7",
+        'wmi==1.5.1; platform_system == "Windows"',
     ],
     extras_require={
         "FSoE": ["fsoe-master==0.1.2"],

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
     install_requires=[
         "ingenialink>=7.3.5, < 8.0.0",
         "ingenialogger>=0.2.1",
-        "ifaddr==0.2.0",
+        "ifaddr==0.1.7",
         'wmi==1.5.1; platform_system == "Windows"',
     ],
     extras_require={

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -3,6 +3,7 @@ import platform
 import tempfile
 import time
 from collections import OrderedDict
+from dataclasses import dataclass
 
 import pytest
 from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
@@ -116,13 +117,24 @@ def test_connect_servo_comkit_no_dictionary_error(coco_dict_path, tests_setup: E
 @pytest.mark.smoke
 @pytest.mark.virtual
 def test_get_ifname_from_interface_ip(mocker):
-    ip = type("IP", (object,), {"ip": "192.168.2.1", "is_IPv4": True})
+    class MockAdapter:
+        @dataclass
+        class IP:
+            ip = "192.168.2.1"
+            is_IPv4 = True
+
+        def __init__(self, interface_name):
+            self.name = interface_name
+            self.nice_name = interface_name
+            self.ips = [self.IP()]
+            self.index = 1
+
     if platform.system() == "Linux":
         name = "eth0"
     else:
-        name = b"{192D1D2F-C684-467D-A637-EC07BD434A63}"
-    adapter = type("Adapter", (object,), {"ips": [ip], "name": name})
-    mocker.patch("ifaddr.get_adapters", return_value=[adapter])
+        name = "{192D1D2F-C684-467D-A637-EC07BD434A63}"
+    mock_adapter = MockAdapter(name)
+    mocker.patch("ifaddr.get_adapters", return_value=[mock_adapter])
     mc = MotionController()
     ifname = mc.communication.get_ifname_from_interface_ip("192.168.2.1")
     if platform.system() == "Windows":

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -132,7 +132,7 @@ def test_get_ifname_from_interface_ip(mocker):
     if platform.system() == "Linux":
         name = "eth0"
     else:
-        name = "{192D1D2F-C684-467D-A637-EC07BD434A63}"
+        name = b"{192D1D2F-C684-467D-A637-EC07BD434A63}"
     mock_adapter = MockAdapter(name)
     mocker.patch("ifaddr.get_adapters", return_value=[mock_adapter])
     mc = MotionController()


### PR DESCRIPTION
### Description

Unconfigured network adapters (IP-less) were not detected by the get_interface_name_list method.

Fixes # INGM-557

### Type of change
- Get network adapter information via WMI (Windows Management Instrumentation)


### Tests
- Remove the IPv4 and IPv6 options from a network adapter options.
- Call the get_interface_name_list method
- Check that the network adapter is listed.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
