### PR TITLE
INGM-564 - Update error message

### DIFF
--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -29,7 +29,8 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
 
     result_description = {
         ResultType.SUCCESS: "Feedback test pass successfully",
-        ResultType.RESOLUTION_ERROR: "Feedback has a resolution error",
+        ResultType.RESOLUTION_ERROR: "Feedback has a resolution error."
+        " Detected resolution does not match the one specified on the configuration.",
         ResultType.SYMMETRY_ERROR: "Feedback has a symmetry error",
         ResultType.POS_VEL_RATIO_ERROR: "Position to velocity sensor ratio cannot be different "
         "than 1 when both feedback sensors are the same.",
@@ -393,9 +394,7 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
         # Check the movement displacement
         if position_displacement == 0:
             error_movement_displacement = (
-                "ERROR: No movement detected. "
-                "Please, review your feedback "
-                "configuration & wiring"
+                "ERROR: No movement detected. Please, review your feedback configuration & wiring"
             )
             raise TestError(error_movement_displacement)
 


### PR DESCRIPTION
### Description

The error displayed when a Resolution error occurs during the Feedbacks-Incremental Enc.-Test Incremental Encoder  is not clear enough and can lead to confusion.

Fixes #INGM-564

### Type of change

- [x] Update Error message (Add a more descriptive text to the error message)

### Tests

Steps:
- Launch ML3
- Connect to drive
- Go to Feedbacks-Incremental Enc. and set a wrong Resolution
- Launch the Test Incremental Encoder
- Check new error description.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [x] Set fix version field in the Jira issue.
