### PR TITLE
INGK-1022: adapt ingenialink enum import to follow CapWords convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ _pdf
 
 # Tox
 .tox
+
+# vscode
+.vscode/

--- a/docs/ingeniamotion/enums.rst
+++ b/docs/ingeniamotion/enums.rst
@@ -9,7 +9,7 @@ Enums
    :members:
    :undoc-members:
 
-.. autoclass:: REG_ACCESS
+.. autoclass:: RegAccess
    :members:
    :undoc-members:
 

--- a/docs/ingeniamotion/enums.rst
+++ b/docs/ingeniamotion/enums.rst
@@ -5,7 +5,7 @@ Enums
    :members:
    :undoc-members:
 
-.. autoclass:: REG_DTYPE
+.. autoclass:: RegDtype
    :members:
    :undoc-members:
 

--- a/docs/ingeniamotion/enums.rst
+++ b/docs/ingeniamotion/enums.rst
@@ -17,6 +17,6 @@ Enums
    :members:
    :undoc-members:
 
-.. autoclass:: CAN_DEVICE
+.. autoclass:: CanDevice
    :members:
    :undoc-members:

--- a/docs/ingeniamotion/enums.rst
+++ b/docs/ingeniamotion/enums.rst
@@ -13,7 +13,7 @@ Enums
    :members:
    :undoc-members:
 
-.. autoclass:: CAN_BAUDRATE
+.. autoclass:: CanBaudrate
    :members:
    :undoc-members:
 

--- a/examples/canopen_example.py
+++ b/examples/canopen_example.py
@@ -1,7 +1,7 @@
 import argparse
 
 from ingeniamotion import MotionController
-from ingeniamotion.enums import CAN_DEVICE, CanBaudrate
+from ingeniamotion.enums import CanBaudrate, CanDevice
 
 
 def main(args):
@@ -9,7 +9,7 @@ def main(args):
     mc = MotionController()
 
     # Get list of all node id available
-    can_device = CAN_DEVICE(args.can_transceiver)
+    can_device = CanDevice(args.can_transceiver)
     can_baudrate = CanBaudrate(args.can_baudrate)
     can_channel = args.can_channel
     node_id_list = mc.communication.scan_servos_canopen(can_device, can_baudrate, can_channel)

--- a/examples/canopen_example.py
+++ b/examples/canopen_example.py
@@ -1,7 +1,7 @@
 import argparse
 
 from ingeniamotion import MotionController
-from ingeniamotion.enums import CAN_BAUDRATE, CAN_DEVICE
+from ingeniamotion.enums import CAN_DEVICE, CanBaudrate
 
 
 def main(args):
@@ -10,19 +10,14 @@ def main(args):
 
     # Get list of all node id available
     can_device = CAN_DEVICE(args.can_transceiver)
-    can_baudrate = CAN_BAUDRATE(args.can_baudrate)
+    can_baudrate = CanBaudrate(args.can_baudrate)
     can_channel = args.can_channel
-    node_id_list = mc.communication.scan_servos_canopen(
-        can_device, can_baudrate, can_channel)
+    node_id_list = mc.communication.scan_servos_canopen(can_device, can_baudrate, can_channel)
 
     if len(node_id_list) > 0:
         # Connect to servo with CANOpen
         mc.communication.connect_servo_canopen(
-            can_device,
-            args.dictionary_path,
-            args.node_id,
-            can_baudrate,
-            can_channel
+            can_device, args.dictionary_path, args.node_id, can_baudrate, can_channel
         )
         print("Servo connected!")
         # Disconnect servo, this lines is mandatory
@@ -32,22 +27,26 @@ def main(args):
 
 
 def setup_command():
-    parser = argparse.ArgumentParser(description='Canopen example')
-    parser.add_argument('--dictionary_path', help='Path to drive dictionary', required=True)
-    parser.add_argument('--node_id', default=32, type=int,
-                        help='Node ID')
-    parser.add_argument('--can_transceiver', default='ixxat',
-                        choices=['pcan', 'kvaser', 'ixxat'],
-                        help='CAN transceiver')
-    parser.add_argument('--can_baudrate', default=1000000, type=int,
-                        choices=[50000, 100000, 125000, 250000,
-                                 500000, 1000000],
-                        help='CAN baudrate')
-    parser.add_argument('--can_channel', default=0, type=int,
-                        help='CAN transceiver channel')
+    parser = argparse.ArgumentParser(description="Canopen example")
+    parser.add_argument("--dictionary_path", help="Path to drive dictionary", required=True)
+    parser.add_argument("--node_id", default=32, type=int, help="Node ID")
+    parser.add_argument(
+        "--can_transceiver",
+        default="ixxat",
+        choices=["pcan", "kvaser", "ixxat"],
+        help="CAN transceiver",
+    )
+    parser.add_argument(
+        "--can_baudrate",
+        default=1000000,
+        type=int,
+        choices=[50000, 100000, 125000, 250000, 500000, 1000000],
+        help="CAN baudrate",
+    )
+    parser.add_argument("--can_channel", default=0, type=int, help="CAN transceiver channel")
     return parser.parse_args()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = setup_command()
     main(args)

--- a/examples/change_baudrate.py
+++ b/examples/change_baudrate.py
@@ -1,6 +1,4 @@
-from typing import Optional
-
-from ingenialink import CAN_BAUDRATE, CAN_DEVICE
+from ingenialink import CAN_DEVICE, CanBaudrate
 
 from ingeniamotion.motion_controller import MotionController
 
@@ -9,9 +7,9 @@ def change_baudrate(
     device: CAN_DEVICE,
     channel: int,
     node_id: int,
-    baudrate: CAN_BAUDRATE,
+    baudrate: CanBaudrate,
     dictionary_path: str,
-    new_baudrate: CAN_BAUDRATE,
+    new_baudrate: CanBaudrate,
 ) -> None:
     mc = MotionController()
     mc.communication.connect_servo_canopen(device, dictionary_path, node_id, baudrate, channel)
@@ -37,8 +35,8 @@ if __name__ == "__main__":
     device = CAN_DEVICE.KVASER
     channel = 0
     node_id = 20
-    baudrate = CAN_BAUDRATE.Baudrate_1M
+    baudrate = CanBaudrate.Baudrate_1M
     dictionary_path = "parent_directory/dictionary_file.xdf"
-    new_baudrate = CAN_BAUDRATE.Baudrate_250K
+    new_baudrate = CanBaudrate.Baudrate_250K
 
     change_baudrate(device, channel, node_id, baudrate, dictionary_path, new_baudrate)

--- a/examples/change_baudrate.py
+++ b/examples/change_baudrate.py
@@ -1,10 +1,10 @@
-from ingenialink import CAN_DEVICE, CanBaudrate
+from ingenialink import CanBaudrate, CanDevice
 
 from ingeniamotion.motion_controller import MotionController
 
 
 def change_baudrate(
-    device: CAN_DEVICE,
+    device: CanDevice,
     channel: int,
     node_id: int,
     baudrate: CanBaudrate,
@@ -32,7 +32,7 @@ def change_baudrate(
 
 if __name__ == "__main__":
     # Remember to replace all parameters here
-    device = CAN_DEVICE.KVASER
+    device = CanDevice.KVASER
     channel = 0
     node_id = 20
     baudrate = CanBaudrate.Baudrate_1M

--- a/examples/change_node_id.py
+++ b/examples/change_node_id.py
@@ -1,6 +1,4 @@
-from typing import Optional
-
-from ingenialink import CAN_BAUDRATE, CAN_DEVICE
+from ingenialink import CAN_DEVICE, CanBaudrate
 
 from ingeniamotion.motion_controller import MotionController
 
@@ -9,7 +7,7 @@ def change_node_id(
     device: CAN_DEVICE,
     channel: int,
     node_id: int,
-    baudrate: CAN_BAUDRATE,
+    baudrate: CanBaudrate,
     dictionary_path: str,
     new_node_id: int,
 ) -> None:
@@ -60,7 +58,7 @@ if __name__ == "__main__":
     channel = 0
     node_id = 20
     new_node_id = 32
-    baudrate = CAN_BAUDRATE.Baudrate_1M
+    baudrate = CanBaudrate.Baudrate_1M
     dictionary_path = "parent_directory/dictionary_file.xdf"
 
     change_node_id(device, channel, node_id, baudrate, dictionary_path, new_node_id)

--- a/examples/change_node_id.py
+++ b/examples/change_node_id.py
@@ -1,10 +1,10 @@
-from ingenialink import CAN_DEVICE, CanBaudrate
+from ingenialink import CanBaudrate, CanDevice
 
 from ingeniamotion.motion_controller import MotionController
 
 
 def change_node_id(
-    device: CAN_DEVICE,
+    device: CanDevice,
     channel: int,
     node_id: int,
     baudrate: CanBaudrate,
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     # If you want to connect to a node manually, set the node_id parameter as an integer.
     # Instead, set the node_id parameter as a NoneType value to connect the first detected CAN node.
 
-    device = CAN_DEVICE.KVASER
+    device = CanDevice.KVASER
     channel = 0
     node_id = 20
     new_node_id = 32

--- a/examples/load_fw_canopen.py
+++ b/examples/load_fw_canopen.py
@@ -1,4 +1,4 @@
-from ingenialink import CAN_DEVICE, CanBaudrate
+from ingenialink import CanBaudrate, CanDevice
 from ingenialink.exceptions import ILFirmwareLoadError
 
 from ingeniamotion.motion_controller import MotionController
@@ -13,7 +13,7 @@ def progress_log(current_progress: int) -> None:
 
 
 def load_firmware_canopen(
-    device: CAN_DEVICE,
+    device: CanDevice,
     channel: int,
     baudrate: CanBaudrate,
     node_id: int,
@@ -55,7 +55,7 @@ def load_firmware_canopen(
 
 if __name__ == "__main__":
     # Remember to replace all parameters here
-    device = CAN_DEVICE.KVASER
+    device = CanDevice.KVASER
     channel = 0
     baudrate = CanBaudrate.Baudrate_1M
     node_id = 32

--- a/examples/load_fw_canopen.py
+++ b/examples/load_fw_canopen.py
@@ -1,4 +1,4 @@
-from ingenialink import CAN_BAUDRATE, CAN_DEVICE
+from ingenialink import CAN_DEVICE, CanBaudrate
 from ingenialink.exceptions import ILFirmwareLoadError
 
 from ingeniamotion.motion_controller import MotionController
@@ -15,7 +15,7 @@ def progress_log(current_progress: int) -> None:
 def load_firmware_canopen(
     device: CAN_DEVICE,
     channel: int,
-    baudrate: CAN_BAUDRATE,
+    baudrate: CanBaudrate,
     node_id: int,
     dictionary_path: str,
     fw_path: str,
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # Remember to replace all parameters here
     device = CAN_DEVICE.KVASER
     channel = 0
-    baudrate = CAN_BAUDRATE.Baudrate_1M
+    baudrate = CanBaudrate.Baudrate_1M
     node_id = 32
     dictionary_path = "parent_directory/full_dictionary_path.xdf"
     fw_path = "parent_directory/full_firmware_file_path.lfu"

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -12,7 +12,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import ifaddr
 import ingenialogger
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_CHANNELS, CAN_DEVICE, CanopenNetwork
+from ingenialink import CanBaudrate
+from ingenialink.canopen.network import CAN_CHANNELS, CAN_DEVICE, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.dictionary import Interface
 from ingenialink.emcy import EmergencyMessage
@@ -422,8 +423,7 @@ class Communication(metaclass=MCMetaClass):
             index = self._get_interface_index_by_address(address)
         except IndexError:
             raise ValueError(
-                f"Could not found a adapter configured as {address} "
-                f"to connect as EtherCAT master"
+                f"Could not found a adapter configured as {address} to connect as EtherCAT master"
             )
         return self.__get_adapter_name(index)
 
@@ -645,7 +645,7 @@ class Communication(metaclass=MCMetaClass):
         can_device: CAN_DEVICE,
         dict_path: str,
         node_id: int,
-        baudrate: CAN_BAUDRATE = CAN_BAUDRATE.Baudrate_1M,
+        baudrate: CanBaudrate = CanBaudrate.Baudrate_1M,
         channel: int = 0,
         alias: str = DEFAULT_SERVO,
         servo_status_listener: bool = False,
@@ -865,7 +865,7 @@ class Communication(metaclass=MCMetaClass):
     def scan_servos_canopen_with_info(
         self,
         can_device: CAN_DEVICE,
-        baudrate: CAN_BAUDRATE = CAN_BAUDRATE.Baudrate_1M,
+        baudrate: CanBaudrate = CanBaudrate.Baudrate_1M,
         channel: int = 0,
     ) -> OrderedDict[int, SlaveInfo]:
         """Scan CANOpen device network to get all nodes including slave information.
@@ -888,8 +888,7 @@ class Communication(metaclass=MCMetaClass):
 
         if net is None:
             self.logger.warning(
-                "Could not find any nodes in the network."
-                "Device: %s, channel: %s and baudrate: %s.",
+                "Could not find any nodes in the network.Device: %s, channel: %s and baudrate: %s.",
                 can_device,
                 channel,
                 baudrate,
@@ -901,7 +900,7 @@ class Communication(metaclass=MCMetaClass):
     def scan_servos_canopen(
         self,
         can_device: CAN_DEVICE,
-        baudrate: CAN_BAUDRATE = CAN_BAUDRATE.Baudrate_1M,
+        baudrate: CanBaudrate = CanBaudrate.Baudrate_1M,
         channel: int = 0,
     ) -> List[int]:
         """Scan CANOpen device network to get all nodes.
@@ -924,8 +923,7 @@ class Communication(metaclass=MCMetaClass):
 
         if net is None:
             self.logger.warning(
-                "Could not find any nodes in the network."
-                "Device: %s, channel: %s and baudrate: %s.",
+                "Could not find any nodes in the network.Device: %s, channel: %s and baudrate: %s.",
                 can_device,
                 channel,
                 baudrate,

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -18,7 +18,7 @@ from ingenialink.canopen.servo import CanopenServo
 from ingenialink.dictionary import Interface
 from ingenialink.emcy import EmergencyMessage
 from ingenialink.enums.register import RegAccess, RegDtype
-from ingenialink.enums.servo import SERVO_STATE
+from ingenialink.enums.servo import ServoState
 from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
@@ -1067,7 +1067,7 @@ class Communication(metaclass=MCMetaClass):
         network.unsubscribe_from_status(drive.target, callback)
 
     def subscribe_servo_status(
-        self, callback: Callable[[SERVO_STATE, int], Any], servo: str = DEFAULT_SERVO
+        self, callback: Callable[[ServoState, int], Any], servo: str = DEFAULT_SERVO
     ) -> None:
         """Add a callback to servo status change event.
 
@@ -1080,7 +1080,7 @@ class Communication(metaclass=MCMetaClass):
         drive.subscribe_to_status(callback)
 
     def unsubscribe_servo_status(
-        self, callback: Callable[[SERVO_STATE, int], Any], servo: str = DEFAULT_SERVO
+        self, callback: Callable[[ServoState, int], Any], servo: str = DEFAULT_SERVO
     ) -> None:
         """Remove servo status change event callback.
 

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import ifaddr
 import ingenialogger
-from ingenialink import CanBaudrate, CanDevice, NetState
+from ingenialink import CanBaudrate, CanDevice, NetDevEvt, NetState
 from ingenialink.canopen.network import CAN_CHANNELS, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.dictionary import Interface
@@ -23,7 +23,7 @@ from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.exceptions import ILError
-from ingenialink.network import NET_DEV_EVT, SlaveInfo
+from ingenialink.network import SlaveInfo
 from ingenialink.register import Register
 from ingenialink.servo import DictionaryFactory, Servo
 from ingenialink.virtual.network import VirtualNetwork
@@ -1039,7 +1039,7 @@ class Communication(metaclass=MCMetaClass):
         drive.write(register, value, subnode=axis)
 
     def subscribe_net_status(
-        self, callback: Callable[[NET_DEV_EVT], None], servo: str = DEFAULT_SERVO
+        self, callback: Callable[[NetDevEvt], None], servo: str = DEFAULT_SERVO
     ) -> None:
         """Add a callback to net status change event.
 
@@ -1053,7 +1053,7 @@ class Communication(metaclass=MCMetaClass):
         network.subscribe_to_status(drive.target, callback)
 
     def unsubscribe_net_status(
-        self, callback: Callable[[NET_DEV_EVT], None], servo: str = DEFAULT_SERVO
+        self, callback: Callable[[NetDevEvt], None], servo: str = DEFAULT_SERVO
     ) -> None:
         """Remove net status change event callback.
 

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -12,8 +12,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import ifaddr
 import ingenialogger
-from ingenialink import CanBaudrate
-from ingenialink.canopen.network import CAN_CHANNELS, CAN_DEVICE, CanopenNetwork
+from ingenialink import CanBaudrate, CanDevice
+from ingenialink.canopen.network import CAN_CHANNELS, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.dictionary import Interface
 from ingenialink.emcy import EmergencyMessage
@@ -528,17 +528,17 @@ class Communication(metaclass=MCMetaClass):
                     )
         return {adapter.interface_name: adapter.interface_guid for adapter in network_adapters}
 
-    def get_available_canopen_devices(self) -> dict[CAN_DEVICE, list[int]]:
+    def get_available_canopen_devices(self) -> dict[CanDevice, list[int]]:
         """Return the list of available CAN devices (those connected and with drivers installed).
 
         Returns:
             Dict of available CAN devices and channels. For example:
             {
-                CAN_DEVICE.KVASER: [0, 1]
-                CAN_DEVICE.PCAN: [0]
+                CanDevice.KVASER: [0, 1]
+                CanDevice.PCAN: [0]
             }
         """
-        available_devices: dict[CAN_DEVICE, list[int]] = {}
+        available_devices: dict[CanDevice, list[int]] = {}
         can_net = None
         for net_key in self.mc.net:
             net = self.mc.net[net_key]
@@ -546,9 +546,9 @@ class Communication(metaclass=MCMetaClass):
                 can_net = net
                 break
         if can_net is None:
-            can_net = CanopenNetwork(CAN_DEVICE.KVASER)
+            can_net = CanopenNetwork(CanDevice.KVASER)
         for device, channel in can_net.get_available_devices():
-            can_device = CAN_DEVICE(device)
+            can_device = CanDevice(device)
             can_channel = CAN_CHANNELS[device].index(channel)
             if can_device not in available_devices:
                 available_devices[can_device] = [can_channel]
@@ -642,7 +642,7 @@ class Communication(metaclass=MCMetaClass):
 
     def connect_servo_canopen(
         self,
-        can_device: CAN_DEVICE,
+        can_device: CanDevice,
         dict_path: str,
         node_id: int,
         baudrate: CanBaudrate = CanBaudrate.Baudrate_1M,
@@ -864,7 +864,7 @@ class Communication(metaclass=MCMetaClass):
 
     def scan_servos_canopen_with_info(
         self,
-        can_device: CAN_DEVICE,
+        can_device: CanDevice,
         baudrate: CanBaudrate = CanBaudrate.Baudrate_1M,
         channel: int = 0,
     ) -> OrderedDict[int, SlaveInfo]:
@@ -899,7 +899,7 @@ class Communication(metaclass=MCMetaClass):
 
     def scan_servos_canopen(
         self,
-        can_device: CAN_DEVICE,
+        can_device: CanDevice,
         baudrate: CanBaudrate = CanBaudrate.Baudrate_1M,
         channel: int = 0,
     ) -> List[int]:

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -17,7 +17,7 @@ from ingenialink.canopen.network import CAN_CHANNELS, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.dictionary import Interface
 from ingenialink.emcy import EmergencyMessage
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
+from ingenialink.enums.register import REG_ACCESS, RegDtype
 from ingenialink.enums.servo import SERVO_STATE
 from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethercat.network import EthercatNetwork
@@ -992,7 +992,7 @@ class Communication(metaclass=MCMetaClass):
         drive = self.mc.servos[servo]
         register_dtype = self.mc.info.register_type(register, axis, servo=servo)
         value = drive.read(register, subnode=axis)
-        if register_dtype.value <= REG_DTYPE.S64.value and isinstance(value, int):
+        if register_dtype.value <= RegDtype.S64.value and isinstance(value, int):
             return int(value)
         if not isinstance(value, (int, float, str)):
             raise TypeError("Register value is not a correct type of value.")
@@ -1022,11 +1022,11 @@ class Communication(metaclass=MCMetaClass):
         drive = self.mc.servos[servo]
         register_dtype_value = self.mc.info.register_type(register, axis, servo=servo)
         register_access_type = self.mc.info.register_info(register, axis, servo=servo).access
-        signed_int = [REG_DTYPE.S8, REG_DTYPE.S16, REG_DTYPE.S32, REG_DTYPE.S64]
-        unsigned_int = [REG_DTYPE.U8, REG_DTYPE.U16, REG_DTYPE.U32, REG_DTYPE.U64]
-        if register_dtype_value == REG_DTYPE.FLOAT and not isinstance(value, (int, float)):
+        signed_int = [RegDtype.S8, RegDtype.S16, RegDtype.S32, RegDtype.S64]
+        unsigned_int = [RegDtype.U8, RegDtype.U16, RegDtype.U32, RegDtype.U64]
+        if register_dtype_value == RegDtype.FLOAT and not isinstance(value, (int, float)):
             raise TypeError("Value must be a float")
-        if register_dtype_value == REG_DTYPE.STR and not isinstance(value, str):
+        if register_dtype_value == RegDtype.STR and not isinstance(value, str):
             raise TypeError("Value must be a string")
         if register_dtype_value in signed_int and not isinstance(value, int):
             raise TypeError("Value must be an int")

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import ifaddr
 import ingenialogger
-from ingenialink import CanBaudrate, CanDevice
+from ingenialink import CanBaudrate, CanDevice, NetState
 from ingenialink.canopen.network import CAN_CHANNELS, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.dictionary import Interface
@@ -23,7 +23,7 @@ from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.exceptions import ILError
-from ingenialink.network import NET_DEV_EVT, NET_STATE, SlaveInfo
+from ingenialink.network import NET_DEV_EVT, SlaveInfo
 from ingenialink.register import Register
 from ingenialink.servo import DictionaryFactory, Servo
 from ingenialink.virtual.network import VirtualNetwork
@@ -953,7 +953,7 @@ class Communication(metaclass=MCMetaClass):
         if servo_count == 0:
             del self.mc.net[net_name]
 
-    def get_servo_state(self, servo: str = DEFAULT_SERVO) -> NET_STATE:
+    def get_servo_state(self, servo: str = DEFAULT_SERVO) -> NetState:
         """Get the network state of a servo (connected/disconnected).
 
         The net_status_listener should be enabled for the servo in order

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -17,7 +17,7 @@ from ingenialink.canopen.network import CAN_CHANNELS, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.dictionary import Interface
 from ingenialink.emcy import EmergencyMessage
-from ingenialink.enums.register import REG_ACCESS, RegDtype
+from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.enums.servo import SERVO_STATE
 from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethercat.network import EthercatNetwork
@@ -1032,7 +1032,7 @@ class Communication(metaclass=MCMetaClass):
             raise TypeError("Value must be an int")
         if register_dtype_value in unsigned_int and (not isinstance(value, int) or value < 0):
             raise TypeError("Value must be an unsigned int")
-        if register_access_type == REG_ACCESS.RO:
+        if register_access_type == RegAccess.RO:
             raise IMRegisterWrongAccess(
                 f"Register: {register} cannot write to a read-only register"
             )

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -4,7 +4,8 @@ from os import path
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import ingenialogger
-from ingenialink.canopen.network import CAN_BAUDRATE, CanopenNetwork
+from ingenialink import CanBaudrate
+from ingenialink.canopen.network import CanopenNetwork
 from ingenialink.ethernet.servo import EthernetServo
 from ingenialink.exceptions import ILError
 from ingenialink.utils._utils import deprecated
@@ -1130,7 +1131,7 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
             )
         return vendor_id
 
-    def change_baudrate(self, baud_rate: CAN_BAUDRATE, servo: str = DEFAULT_SERVO) -> None:
+    def change_baudrate(self, baud_rate: CanBaudrate, servo: str = DEFAULT_SERVO) -> None:
         """Change a CANopen device's baudrate.
 
         Args:

--- a/ingeniamotion/disturbance.py
+++ b/ingeniamotion/disturbance.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import ingenialogger
 import numpy as np
-from ingenialink.enums.register import REG_DTYPE, RegCyclicType
+from ingenialink.enums.register import RegCyclicType, RegDtype
 from ingenialink.exceptions import ILValueError
 from numpy import ndarray
 from numpy.typing import NDArray
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 # Constants for typing
 # TODO: INGM-327
 TYPE_MAPPED_REGISTERS_ALL = Dict[str, Union[str, int, List[float]]]
-TYPE_MAPPED_REGISTERS_NAME_AXIS = Dict[str, Union[str, int, REG_DTYPE]]
+TYPE_MAPPED_REGISTERS_NAME_AXIS = Dict[str, Union[str, int, RegDtype]]
 TYPE_MAPPED_REGISTERS_DATA = Dict[str, List[Union[int, float]]]
 TYPE_MAPPED_REGISTERS_DATA_NO_KEY = List[Union[int, float]]
 
@@ -55,15 +55,15 @@ class Disturbance:
     REGISTER_MAP_OFFSET = 0x800
 
     __data_type_size = {
-        REG_DTYPE.U8: 1,
-        REG_DTYPE.S8: 1,
-        REG_DTYPE.U16: 2,
-        REG_DTYPE.S16: 2,
-        REG_DTYPE.U32: 4,
-        REG_DTYPE.S32: 4,
-        REG_DTYPE.U64: 8,
-        REG_DTYPE.S64: 8,
-        REG_DTYPE.FLOAT: 4,
+        RegDtype.U8: 1,
+        RegDtype.S8: 1,
+        RegDtype.U16: 2,
+        RegDtype.S16: 2,
+        RegDtype.U32: 4,
+        RegDtype.S32: 4,
+        RegDtype.U64: 8,
+        RegDtype.S64: 8,
+        RegDtype.FLOAT: 4,
     }
 
     def __init__(self, mc: "MotionController", servo: str = DEFAULT_SERVO) -> None:
@@ -247,7 +247,7 @@ class Disturbance:
         drive = self.mc.servos[self.servo]
         self.__check_buffer_size_is_enough(adapted_registers_data)
         idx_list = list(range(len(adapted_registers_data)))
-        dtype_list = [REG_DTYPE(x["dtype"]) for x in self.mapped_registers]
+        dtype_list = [RegDtype(x["dtype"]) for x in self.mapped_registers]
         if self._version >= MonitoringVersion.MONITORING_V3:
             drive.disturbance_remove_data()
         try:
@@ -297,7 +297,7 @@ class Disturbance:
         total_buffer_size = 0
         for ch_idx, data in enumerate(registers):
             dtype = self.mapped_registers[ch_idx]["dtype"]
-            if not isinstance(dtype, REG_DTYPE):
+            if not isinstance(dtype, RegDtype):
                 continue
             total_buffer_size += self.__data_type_size[dtype] * len(data)
         if total_buffer_size > self.max_sample_number:

--- a/ingeniamotion/enums/__init__.py
+++ b/ingeniamotion/enums/__init__.py
@@ -1,12 +1,29 @@
 from enum import Enum, IntEnum
 from typing import Type, TypeVar
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
+from ingenialink import (
+    CAN_BAUDRATE,
+    CAN_DEVICE,
+    REG_ACCESS,
+    REG_DTYPE,
+    CanBaudrate,
+    CanDevice,
+    RegAccess,
+    RegDtype,
+)
 
 T = TypeVar("T", bound=Type[Enum])
 
-__all__ = ["CAN_BAUDRATE", "CAN_DEVICE", "REG_ACCESS", "REG_DTYPE"]
+__all__ = [
+    "CAN_BAUDRATE",
+    "CanBaudrate",
+    "CAN_DEVICE",
+    "CanDevice",
+    "REG_ACCESS",
+    "RegAccess",
+    "REG_DTYPE",
+    "RegDtype",
+]
 
 
 def export(obj: T) -> T:

--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -24,7 +24,7 @@ except ImportError:
 else:
     FSOE_MASTER_INSTALLED = True
 
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
+from ingenialink.enums.register import REG_ACCESS, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
 from ingenialink.utils._utils import dtype_value
@@ -349,20 +349,20 @@ class FSoEMaster:
     DEFAULT_WATCHDOG_TIMEOUT_S = 1
 
     SAFETY_ADDRESS_REGISTER = EthercatRegister(
-        idx=0x4193, subidx=0x00, dtype=REG_DTYPE.U16, access=REG_ACCESS.RW
+        idx=0x4193, subidx=0x00, dtype=RegDtype.U16, access=REG_ACCESS.RW
     )
     SAFE_INPUTS_MAP_REGISTER = EthercatRegister(
         identifier="SAFE_INPUTS_MAP",
         idx=0x46D2,
         subidx=0x00,
-        dtype=REG_DTYPE.U16,
+        dtype=RegDtype.U16,
         access=REG_ACCESS.RW,
     )
     SS1_TIME_TO_STO_REGISTER = EthercatRegister(
         identifier="SS1_TIME_TO_STO",
         idx=0x6651,
         subidx=0x01,
-        dtype=REG_DTYPE.U16,
+        dtype=RegDtype.U16,
         access=REG_ACCESS.RW,
     )
 

--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -24,7 +24,7 @@ except ImportError:
 else:
     FSOE_MASTER_INSTALLED = True
 
-from ingenialink.enums.register import REG_ACCESS, RegDtype
+from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
 from ingenialink.utils._utils import dtype_value
@@ -349,21 +349,21 @@ class FSoEMaster:
     DEFAULT_WATCHDOG_TIMEOUT_S = 1
 
     SAFETY_ADDRESS_REGISTER = EthercatRegister(
-        idx=0x4193, subidx=0x00, dtype=RegDtype.U16, access=REG_ACCESS.RW
+        idx=0x4193, subidx=0x00, dtype=RegDtype.U16, access=RegAccess.RW
     )
     SAFE_INPUTS_MAP_REGISTER = EthercatRegister(
         identifier="SAFE_INPUTS_MAP",
         idx=0x46D2,
         subidx=0x00,
         dtype=RegDtype.U16,
-        access=REG_ACCESS.RW,
+        access=RegAccess.RW,
     )
     SS1_TIME_TO_STO_REGISTER = EthercatRegister(
         identifier="SS1_TIME_TO_STO",
         idx=0x6651,
         subidx=0x01,
         dtype=RegDtype.U16,
-        access=REG_ACCESS.RW,
+        access=RegAccess.RW,
     )
 
     def __init__(self, motion_controller: "MotionController") -> None:

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -5,7 +5,7 @@ import ingenialogger
 from ingenialink import CanBaudrate
 from ingenialink.canopen.network import CanopenNetwork
 from ingenialink.dictionary import SubnodeType
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
+from ingenialink.enums.register import REG_ACCESS, RegDtype
 from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
@@ -63,7 +63,7 @@ class Information(metaclass=MCMetaClass):
         register: str,
         axis: int = DEFAULT_AXIS,
         servo: str = DEFAULT_SERVO,
-    ) -> REG_DTYPE:
+    ) -> RegDtype:
         """Return register dtype.
 
         Args:

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -2,7 +2,7 @@ import os
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 
 import ingenialogger
-from ingenialink import CAN_BAUDRATE
+from ingenialink import CanBaudrate
 from ingenialink.canopen.network import CanopenNetwork
 from ingenialink.dictionary import SubnodeType
 from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
@@ -178,7 +178,7 @@ class Information(metaclass=MCMetaClass):
         else:
             raise IMException("You need a CANopen communication to use this function")
 
-    def get_baudrate(self, servo: str = DEFAULT_SERVO) -> CAN_BAUDRATE:
+    def get_baudrate(self, servo: str = DEFAULT_SERVO) -> CanBaudrate:
         """Get the baudrate of target servo
 
         Args:
@@ -189,7 +189,7 @@ class Information(metaclass=MCMetaClass):
         """
         net = self.mc._get_network(servo)
         if isinstance(net, CanopenNetwork):
-            return CAN_BAUDRATE(net.baudrate)
+            return CanBaudrate(net.baudrate)
         raise IMException(f"The servo {servo} is not a CANopen device.")
 
     def get_ip(self, servo: str = DEFAULT_SERVO) -> str:

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -5,7 +5,7 @@ import ingenialogger
 from ingenialink import CanBaudrate
 from ingenialink.canopen.network import CanopenNetwork
 from ingenialink.dictionary import SubnodeType
-from ingenialink.enums.register import REG_ACCESS, RegDtype
+from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
@@ -86,7 +86,7 @@ class Information(metaclass=MCMetaClass):
         register: str,
         axis: int = DEFAULT_AXIS,
         servo: str = DEFAULT_SERVO,
-    ) -> REG_ACCESS:
+    ) -> RegAccess:
         """Return register access.
 
         Args:

--- a/ingeniamotion/monitoring/monitoring_v1.py
+++ b/ingeniamotion/monitoring/monitoring_v1.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import ingenialogger
-from ingenialink.enums.register import REG_DTYPE
+from ingenialink.enums.register import RegDtype
 
 from ingeniamotion.enums import MonitoringSoCConfig, MonitoringSoCType, MonitoringVersion
 from ingeniamotion.exceptions import IMStatusWordError
@@ -147,7 +147,7 @@ class MonitoringV1(Monitoring):
         self,
         total_samples: int,
         trigger_delay_samples: int,
-        registers: List[Dict[str, Union[int, str, REG_DTYPE]]],
+        registers: List[Dict[str, Union[int, str, RegDtype]]],
     ) -> None:
         n_sample = max(total_samples - trigger_delay_samples, trigger_delay_samples)
         max_size = self.max_sample_number // 2

--- a/ingeniamotion/monitoring/monitoring_v3.py
+++ b/ingeniamotion/monitoring/monitoring_v3.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
 import ingenialogger
-from ingenialink.enums.register import REG_DTYPE
+from ingenialink.enums.register import RegDtype
 
 from ingeniamotion.enums import (
     MonitoringProcessStage,
@@ -133,7 +133,7 @@ class MonitoringV3(Monitoring):
         self,
         total_samples: int,
         trigger_delay_samples: int,
-        registers: List[Dict[str, Union[int, str, REG_DTYPE]]],
+        registers: List[Dict[str, Union[int, str, RegDtype]]],
     ) -> None:
         n_sample = total_samples
         max_size = self.max_sample_number

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -9,7 +9,7 @@ from ingenialink.enums.register import RegCyclicType
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethercat.servo import EthercatServo
-from ingenialink.exceptions import ILError, ILWrongWorkingCount
+from ingenialink.exceptions import ILError, ILWrongWorkingCountError
 from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
 
 from ingeniamotion.enums import COMMUNICATION_TYPE
@@ -252,7 +252,7 @@ class PDONetworkManager:
                         first_iteration = False
                     else:
                         self._net.send_receive_processdata(self._refresh_rate)
-                except ILWrongWorkingCount as il_error:
+                except ILWrongWorkingCountError as il_error:
                     self._pd_thread_stop_event.set()
                     self._net.stop_pdos()
                     duration_error = ""

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -48,7 +48,7 @@ class PDOPoller:
         self.__refresh_time = refresh_time
         self.__watchdog_timeout = watchdog_timeout
         self.__buffer_size = buffer_size
-        self.__buffer: Deque[tuple[float, List[Union[int, float]]]] = deque(
+        self.__buffer: Deque[tuple[float, List[Union[int, float, bytes]]]] = deque(
             maxlen=self.__buffer_size
         )
         self.__start_time: Optional[float] = None
@@ -80,7 +80,7 @@ class PDOPoller:
         self.__mc.capture.pdo.remove_tpdo_map(self.__servo, self.__tpdo_map)
 
     @property
-    def data(self) -> Tuple[List[float], List[List[Union[int, float]]]]:
+    def data(self) -> Tuple[List[float], List[List[Union[int, float, bytes]]]]:
         """
         Get the poller data. After the data is retrieved, the data buffers are cleared.
 
@@ -90,7 +90,7 @@ class PDOPoller:
 
         """
         time_stamps = []
-        data: List[List[Union[int, float]]] = [[] for _ in range(len(self.__tpdo_map.items))]
+        data: List[List[Union[int, float, bytes]]] = [[] for _ in range(len(self.__tpdo_map.items))]
         for _ in range(len(self.__buffer)):
             time_stamp, data_sample = self.__buffer.popleft()
             time_stamps.append(time_stamp)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,8 @@ from typing import Dict
 import numpy as np
 import pytest
 import rpyc
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE
+from ingenialink import CanBaudrate
+from ingenialink.canopen.network import CAN_DEVICE
 from ping3 import ping
 from virtual_drive.core import VirtualDrive
 
@@ -74,7 +75,7 @@ def connect_soem(mc, config: DriveEcatSetup, alias):
 
 def connect_canopen(mc, config: DriveCanOpenSetup, alias):
     device = CAN_DEVICE(config.device)
-    baudrate = CAN_BAUDRATE(config.baudrate)
+    baudrate = CanBaudrate(config.baudrate)
     mc.communication.connect_servo_canopen(
         device,
         config.dictionary,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,7 @@ from typing import Dict
 import numpy as np
 import pytest
 import rpyc
-from ingenialink import CanBaudrate
-from ingenialink.canopen.network import CAN_DEVICE
+from ingenialink import CanBaudrate, CanDevice
 from ping3 import ping
 from virtual_drive.core import VirtualDrive
 
@@ -74,7 +73,7 @@ def connect_soem(mc, config: DriveEcatSetup, alias):
 
 
 def connect_canopen(mc, config: DriveCanOpenSetup, alias):
-    device = CAN_DEVICE(config.device)
+    device = CanDevice(config.device)
     baudrate = CanBaudrate(config.baudrate)
     mc.communication.connect_servo_canopen(
         device,

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -13,7 +13,7 @@ from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.exceptions import ILError
 from ingenialink.network import SlaveInfo
-from ingenialink.servo import SERVO_STATE
+from ingenialink.servo import ServoState
 
 import ingeniamotion
 from ingeniamotion import MotionController
@@ -307,7 +307,7 @@ def test_subscribe_servo_status(mocker, motion_controller):
     time.sleep(0.5)
     mc.motion.motor_disable(alias, axis)
     time.sleep(0.5)
-    expected_status = [SERVO_STATE.RDY, SERVO_STATE.ENABLED, SERVO_STATE.DISABLED]
+    expected_status = [ServoState.RDY, ServoState.ENABLED, ServoState.DISABLED]
     for index, call in enumerate(patch_callback.call_args_list):
         assert call[0][0] == expected_status[index]
         assert call[0][2] == axis

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -6,7 +6,8 @@ from collections import OrderedDict
 from dataclasses import dataclass
 
 import pytest
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink import CanBaudrate
+from ingenialink.canopen.network import CAN_DEVICE, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
@@ -164,7 +165,7 @@ def test_connect_servo_canopen(tests_setup: DriveCanOpenSetup):
     assert "canopen_test" not in mc.servos
     assert "canopen_test" not in mc.net
     device = CAN_DEVICE(tests_setup.device)
-    baudrate = CAN_BAUDRATE(tests_setup.baudrate)
+    baudrate = CanBaudrate(tests_setup.baudrate)
     mc.communication.connect_servo_canopen(
         device,
         tests_setup.dictionary,
@@ -189,7 +190,7 @@ def test_connect_servo_canopen_busy_drive_error(motion_controller, tests_setup: 
     assert alias in mc.servo_net
     assert mc.servo_net[alias] in mc.net
     device = CAN_DEVICE(tests_setup.device)
-    baudrate = CAN_BAUDRATE(tests_setup.baudrate)
+    baudrate = CanBaudrate(tests_setup.baudrate)
     with pytest.raises(ILError):
         mc.communication.connect_servo_canopen(
             device,

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -6,8 +6,8 @@ from collections import OrderedDict
 from dataclasses import dataclass
 
 import pytest
-from ingenialink import CanBaudrate
-from ingenialink.canopen.network import CAN_DEVICE, CanopenNetwork
+from ingenialink import CanBaudrate, CanDevice
+from ingenialink.canopen.network import CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
@@ -164,7 +164,7 @@ def test_connect_servo_canopen(tests_setup: DriveCanOpenSetup):
     mc = MotionController()
     assert "canopen_test" not in mc.servos
     assert "canopen_test" not in mc.net
-    device = CAN_DEVICE(tests_setup.device)
+    device = CanDevice(tests_setup.device)
     baudrate = CanBaudrate(tests_setup.baudrate)
     mc.communication.connect_servo_canopen(
         device,
@@ -189,7 +189,7 @@ def test_connect_servo_canopen_busy_drive_error(motion_controller, tests_setup: 
     assert alias in mc.servos
     assert alias in mc.servo_net
     assert mc.servo_net[alias] in mc.net
-    device = CAN_DEVICE(tests_setup.device)
+    device = CanDevice(tests_setup.device)
     baudrate = CanBaudrate(tests_setup.baudrate)
     with pytest.raises(ILError):
         mc.communication.connect_servo_canopen(
@@ -362,7 +362,7 @@ def test_scan_servos_canopen_with_info(mocker):
     mocker.patch(
         "ingenialink.canopen.network.CanopenNetwork.scan_slaves_info", return_value=detected_slaves
     )
-    assert mc.communication.scan_servos_canopen_with_info(CAN_DEVICE.KVASER) == detected_slaves
+    assert mc.communication.scan_servos_canopen_with_info(CanDevice.KVASER) == detected_slaves
 
 
 @pytest.mark.virtual
@@ -372,7 +372,7 @@ def test_scan_servos_canopen(mocker):
     mocker.patch(
         "ingenialink.canopen.network.CanopenNetwork.scan_slaves", return_value=detected_slaves
     )
-    assert mc.communication.scan_servos_canopen(CAN_DEVICE.KVASER) == detected_slaves
+    assert mc.communication.scan_servos_canopen(CanDevice.KVASER) == detected_slaves
 
 
 @pytest.mark.virtual
@@ -593,7 +593,7 @@ def test_load_ensemble_fw_canopen(mocker):
         servos[str(node_id)] = MockCanopenServo(node_id)
 
     mc = MotionController()
-    net = CanopenNetwork(CAN_DEVICE.KVASER)
+    net = CanopenNetwork(CanDevice.KVASER)
     net.servos = list(servos.values())
     mocker.patch("ingeniamotion.motion_controller.MotionController._get_network", return_value=net)
     mocker.patch("ingenialink.canopen.network.CanopenNetwork.connect_to_slave")
@@ -682,7 +682,7 @@ def test_get_available_canopen_devices(mocker):
         ],
     )
     test_output = mc.communication.get_available_canopen_devices()
-    expected_ouput = {CAN_DEVICE.KVASER: [0, 1], CAN_DEVICE.PCAN: [0, 1], CAN_DEVICE.IXXAT: [0, 1]}
+    expected_ouput = {CanDevice.KVASER: [0, 1], CanDevice.PCAN: [0, 1], CanDevice.IXXAT: [0, 1]}
     assert test_output == expected_ouput
 
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from ingenialink.canopen.network import CAN_BAUDRATE
+from ingenialink import CanBaudrate
 from ingenialink.ethercat.servo import EthercatServo
 
 from ingeniamotion.configuration import TYPE_SUBNODES, MACAddressConverter
@@ -608,7 +608,7 @@ def test_get_fw_version(motion_controller):
 def test_change_baudrate_exception(motion_controller):
     mc, alias, environment = motion_controller
     with pytest.raises(ValueError):
-        mc.configuration.change_baudrate(CAN_BAUDRATE.Baudrate_1M, alias)
+        mc.configuration.change_baudrate(CanBaudrate.Baudrate_1M, alias)
 
 
 @pytest.mark.virtual

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -3,4 +3,4 @@ import pytest
 
 @pytest.mark.virtual
 def test_import_ingenialink_enums():
-    from ingeniamotion.enums import REG_ACCESS, REG_DTYPE, CanBaudrate, CanDevice  # noqa: F401
+    from ingeniamotion.enums import REG_ACCESS, CanBaudrate, CanDevice, RegDtype  # noqa: F401

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -3,4 +3,4 @@ import pytest
 
 @pytest.mark.virtual
 def test_import_ingenialink_enums():
-    from ingeniamotion.enums import CAN_BAUDRATE, CAN_DEVICE, REG_ACCESS, REG_DTYPE  # noqa: F401
+    from ingeniamotion.enums import CAN_DEVICE, REG_ACCESS, REG_DTYPE, CanBaudrate  # noqa: F401

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -3,4 +3,4 @@ import pytest
 
 @pytest.mark.virtual
 def test_import_ingenialink_enums():
-    from ingeniamotion.enums import REG_ACCESS, CanBaudrate, CanDevice, RegDtype  # noqa: F401
+    from ingeniamotion.enums import CanBaudrate, CanDevice, RegAccess, RegDtype  # noqa: F401

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -3,4 +3,4 @@ import pytest
 
 @pytest.mark.virtual
 def test_import_ingenialink_enums():
-    from ingeniamotion.enums import CAN_DEVICE, REG_ACCESS, REG_DTYPE, CanBaudrate  # noqa: F401
+    from ingeniamotion.enums import REG_ACCESS, REG_DTYPE, CanBaudrate, CanDevice  # noqa: F401

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,7 +3,7 @@ from typing import Dict
 from unittest.mock import Mock
 
 import pytest
-from ingenialink import CAN_DEVICE, CanBaudrate
+from ingenialink import CanBaudrate, CanDevice
 from ingenialink.exceptions import ILFirmwareLoadError
 from ingenialink.pdo import RPDOMap, TPDOMap
 
@@ -276,7 +276,7 @@ def test_brake_config_example(tests_setup: DriveEthernetSetup, script_runner, mo
 
 @pytest.mark.virtual
 def test_can_bootloader_example_success(mocker, capsys):
-    device = CAN_DEVICE.PCAN
+    device = CanDevice.PCAN
     channel = 0
     baudrate = CanBaudrate.Baudrate_1M
     node_id = 32
@@ -321,7 +321,7 @@ def test_can_bootloader_example_success(mocker, capsys):
 
 @pytest.mark.virtual
 def test_can_bootloader_example_failed(mocker, capsys):
-    device = CAN_DEVICE.PCAN
+    device = CanDevice.PCAN
     channel = 0
     baudrate = CanBaudrate.Baudrate_1M
     node_id = 32
@@ -362,7 +362,7 @@ def test_can_bootloader_example_failed(mocker, capsys):
 
 @pytest.mark.virtual
 def test_change_node_id_success(mocker, capsys):
-    device = CAN_DEVICE.PCAN
+    device = CanDevice.PCAN
     channel = 0
     baudrate = CanBaudrate.Baudrate_1M
     dictionary_path = "test_dictionary.xdf"
@@ -385,7 +385,7 @@ def test_change_node_id_success(mocker, capsys):
 
 @pytest.mark.virtual
 def test_change_node_id_failed(mocker, capsys):
-    device = CAN_DEVICE.PCAN
+    device = CanDevice.PCAN
     channel = 0
     baudrate = CanBaudrate.Baudrate_1M
     dictionary_path = "test_dictionary.xdf"
@@ -407,7 +407,7 @@ def test_change_node_id_failed(mocker, capsys):
 
 @pytest.mark.virtual
 def test_change_baudrate_success(mocker, capsys):
-    device = CAN_DEVICE.PCAN
+    device = CanDevice.PCAN
     channel = 0
     baudrate = CanBaudrate.Baudrate_1M
     node_id = 32
@@ -432,7 +432,7 @@ def test_change_baudrate_success(mocker, capsys):
 
 @pytest.mark.virtual
 def test_change_baudrate_failed(mocker, capsys):
-    device = CAN_DEVICE.PCAN
+    device = CanDevice.PCAN
     channel = 0
     baudrate = CanBaudrate.Baudrate_1M
     node_id = 32

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,7 +3,7 @@ from typing import Dict
 from unittest.mock import Mock
 
 import pytest
-from ingenialink import CAN_BAUDRATE, CAN_DEVICE
+from ingenialink import CAN_DEVICE, CanBaudrate
 from ingenialink.exceptions import ILFirmwareLoadError
 from ingenialink.pdo import RPDOMap, TPDOMap
 
@@ -278,7 +278,7 @@ def test_brake_config_example(tests_setup: DriveEthernetSetup, script_runner, mo
 def test_can_bootloader_example_success(mocker, capsys):
     device = CAN_DEVICE.PCAN
     channel = 0
-    baudrate = CAN_BAUDRATE.Baudrate_1M
+    baudrate = CanBaudrate.Baudrate_1M
     node_id = 32
     dictionary_path = "test_dictionary.xdf"
     fw_path = "test_fw.lfu"
@@ -323,7 +323,7 @@ def test_can_bootloader_example_success(mocker, capsys):
 def test_can_bootloader_example_failed(mocker, capsys):
     device = CAN_DEVICE.PCAN
     channel = 0
-    baudrate = CAN_BAUDRATE.Baudrate_1M
+    baudrate = CanBaudrate.Baudrate_1M
     node_id = 32
     dictionary_path = "test_dictionary.xdf"
     fw_path = "test_fw.lfu"
@@ -364,7 +364,7 @@ def test_can_bootloader_example_failed(mocker, capsys):
 def test_change_node_id_success(mocker, capsys):
     device = CAN_DEVICE.PCAN
     channel = 0
-    baudrate = CAN_BAUDRATE.Baudrate_1M
+    baudrate = CanBaudrate.Baudrate_1M
     dictionary_path = "test_dictionary.xdf"
 
     node_id = 20
@@ -387,7 +387,7 @@ def test_change_node_id_success(mocker, capsys):
 def test_change_node_id_failed(mocker, capsys):
     device = CAN_DEVICE.PCAN
     channel = 0
-    baudrate = CAN_BAUDRATE.Baudrate_1M
+    baudrate = CanBaudrate.Baudrate_1M
     dictionary_path = "test_dictionary.xdf"
 
     node_id = 20
@@ -409,10 +409,10 @@ def test_change_node_id_failed(mocker, capsys):
 def test_change_baudrate_success(mocker, capsys):
     device = CAN_DEVICE.PCAN
     channel = 0
-    baudrate = CAN_BAUDRATE.Baudrate_1M
+    baudrate = CanBaudrate.Baudrate_1M
     node_id = 32
     dictionary_path = "test_dictionary.xdf"
-    test_new_baudrate = CAN_BAUDRATE.Baudrate_125K
+    test_new_baudrate = CanBaudrate.Baudrate_125K
 
     mocker.patch.object(Communication, "connect_servo_canopen")
     mocker.patch.object(Communication, "disconnect")
@@ -434,7 +434,7 @@ def test_change_baudrate_success(mocker, capsys):
 def test_change_baudrate_failed(mocker, capsys):
     device = CAN_DEVICE.PCAN
     channel = 0
-    baudrate = CAN_BAUDRATE.Baudrate_1M
+    baudrate = CanBaudrate.Baudrate_1M
     node_id = 32
     dictionary_path = "test_dictionary.xdf"
     test_new_baudrate = baudrate

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -4,7 +4,7 @@ from ingenialink.canopen.network import CanopenNetwork
 from ingenialink.dictionary import SubnodeType
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
-from ingenialink.register import REG_ACCESS, REG_DTYPE
+from ingenialink.register import REG_ACCESS, RegDtype
 
 from ingeniamotion.exceptions import IMException, IMRegisterNotExist
 from ingeniamotion.information import COMMUNICATION_TYPE
@@ -23,7 +23,7 @@ from ingeniamotion.information import COMMUNICATION_TYPE
 def test_register_info(motion_controller, uid, axis):
     mc, alias, environment = motion_controller
     register = mc.info.register_info(uid, axis, alias)
-    assert isinstance(register.dtype, REG_DTYPE)
+    assert isinstance(register.dtype, RegDtype)
     assert isinstance(register.access, REG_ACCESS)
     assert isinstance(register.range, tuple)
 
@@ -32,10 +32,10 @@ def test_register_info(motion_controller, uid, axis):
 @pytest.mark.parametrize(
     "uid, axis, dtype",
     [
-        ("CL_POS_FBK_VALUE", 1, REG_DTYPE.S32),
-        ("CL_VEL_SET_POINT_VALUE", 1, REG_DTYPE.FLOAT),
-        ("PROF_POS_OPTION_CODE", 1, REG_DTYPE.U16),
-        ("PROF_IP_CLEAR_DATA", 1, REG_DTYPE.U16),
+        ("CL_POS_FBK_VALUE", 1, RegDtype.S32),
+        ("CL_VEL_SET_POINT_VALUE", 1, RegDtype.FLOAT),
+        ("PROF_POS_OPTION_CODE", 1, RegDtype.U16),
+        ("PROF_IP_CLEAR_DATA", 1, RegDtype.U16),
     ],
 )
 def test_register_type(motion_controller, uid, axis, dtype):

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -4,7 +4,7 @@ from ingenialink.canopen.network import CanopenNetwork
 from ingenialink.dictionary import SubnodeType
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
-from ingenialink.register import REG_ACCESS, RegDtype
+from ingenialink.register import RegAccess, RegDtype
 
 from ingeniamotion.exceptions import IMException, IMRegisterNotExist
 from ingeniamotion.information import COMMUNICATION_TYPE
@@ -24,7 +24,7 @@ def test_register_info(motion_controller, uid, axis):
     mc, alias, environment = motion_controller
     register = mc.info.register_info(uid, axis, alias)
     assert isinstance(register.dtype, RegDtype)
-    assert isinstance(register.access, REG_ACCESS)
+    assert isinstance(register.access, RegAccess)
     assert isinstance(register.range, tuple)
 
 
@@ -48,10 +48,10 @@ def test_register_type(motion_controller, uid, axis, dtype):
 @pytest.mark.parametrize(
     "uid, axis, access",
     [
-        ("CL_POS_FBK_VALUE", 1, REG_ACCESS.RO),
-        ("CL_VEL_SET_POINT_VALUE", 1, REG_ACCESS.RW),
-        ("PROF_POS_OPTION_CODE", 1, REG_ACCESS.RW),
-        ("PROF_IP_CLEAR_DATA", 1, REG_ACCESS.WO),
+        ("CL_POS_FBK_VALUE", 1, RegAccess.RO),
+        ("CL_VEL_SET_POINT_VALUE", 1, RegAccess.RW),
+        ("PROF_POS_OPTION_CODE", 1, RegAccess.RW),
+        ("PROF_IP_CLEAR_DATA", 1, RegAccess.WO),
     ],
 )
 def test_register_access(motion_controller, uid, axis, access):

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -1,5 +1,6 @@
 import pytest
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink import CanBaudrate
+from ingenialink.canopen.network import CAN_DEVICE, CanopenNetwork
 from ingenialink.dictionary import SubnodeType
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
@@ -254,7 +255,7 @@ def test_get_baudrate_success(motion_controller, mocker):
 
     fake_device = CAN_DEVICE.PCAN
     fake_channel = 0
-    fake_baudrate = CAN_BAUDRATE.Baudrate_1M
+    fake_baudrate = CanBaudrate.Baudrate_1M
     fake_network = CanopenNetwork(fake_device, fake_channel, fake_baudrate)
     mocker.patch.object(mc, "_get_network", return_value=fake_network)
 

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -1,6 +1,6 @@
 import pytest
-from ingenialink import CanBaudrate
-from ingenialink.canopen.network import CAN_DEVICE, CanopenNetwork
+from ingenialink import CanBaudrate, CanDevice
+from ingenialink.canopen.network import CanopenNetwork
 from ingenialink.dictionary import SubnodeType
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
@@ -131,7 +131,7 @@ def test_get_name(motion_controller):
     [
         (EthernetNetwork, COMMUNICATION_TYPE.Ethernet, None),
         (EthercatNetwork, COMMUNICATION_TYPE.Ethercat, "fake_interface_name"),
-        (CanopenNetwork, COMMUNICATION_TYPE.Canopen, CAN_DEVICE.PCAN),
+        (CanopenNetwork, COMMUNICATION_TYPE.Canopen, CanDevice.PCAN),
     ],
 )
 @pytest.mark.virtual
@@ -153,7 +153,7 @@ def test_get_communication_type(mocker, motion_controller, communication, expect
     [
         (EthernetNetwork, "VIRTUAL-DRIVE - Drive (127.0.0.1)", None),
         (EthercatNetwork, "VIRTUAL-DRIVE - Drive", "fake_interface_name"),
-        (CanopenNetwork, "VIRTUAL-DRIVE - Drive", CAN_DEVICE.PCAN),
+        (CanopenNetwork, "VIRTUAL-DRIVE - Drive", CanDevice.PCAN),
     ],
 )
 @pytest.mark.virtual
@@ -253,7 +253,7 @@ def test_get_slave_id_exception(motion_controller):
 def test_get_baudrate_success(motion_controller, mocker):
     mc, alias, environment = motion_controller
 
-    fake_device = CAN_DEVICE.PCAN
+    fake_device = CanDevice.PCAN
     fake_channel = 0
     fake_baudrate = CanBaudrate.Baudrate_1M
     fake_network = CanopenNetwork(fake_device, fake_channel, fake_baudrate)

--- a/tests/test_pdo.py
+++ b/tests/test_pdo.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 from ingenialink.ethercat.network import EthercatNetwork
-from ingenialink.exceptions import ILWrongWorkingCount
+from ingenialink.exceptions import ILWrongWorkingCountError
 from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
 from packaging import version
 
@@ -310,7 +310,7 @@ def test_subscribe_exceptions(motion_controller, mocker):
     error_msg = "Test error"
 
     def start_pdos(self, *args):
-        raise ILWrongWorkingCount(error_msg)
+        raise ILWrongWorkingCountError(error_msg)
 
     mocker.patch("ingenialink.ethercat.network.EthercatNetwork.stop_pdos")
     mocker.patch(

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@707d1d2
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@6c1dd7b
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@1f2630d
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@e3c3d60
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@dc92cf3
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@7b40b16
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@6c1dd7b
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@1f2630d
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@e3c3d60
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@dc92cf3
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # For instance, to install ingenialink from a custom branch.
 # It should be empty in production.
 [develop]
-    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@7b40b16
+    ingenialink = git+https://github.com/ingeniamc/ingenialink-python@a7a1ec3
 
 
 [testenv]


### PR DESCRIPTION
### Description

Adapt `ingenialink` `Enums` imports: https://github.com/ingeniamc/ingenialink-python/pull/516

### Type of change

Please add a description and delete options that are not relevant.

- [ ] Change imports

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion`.

