### PR TITLE
Ingm 543 is sto abnormal latched does not work on all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Fixed
 - Feedback symmetry check calculation.
 - Phasing test when the commutation feedback is a Halls sensor.
-- Abnormal STO Latched check. Add missing cases and add exception for uncertain ones.
+- Abnormal STO Latched check. Add missing cases and change return type to enum.
 
 ### Deprecated 
 - check_sto_abnormal_fault in configuration. Use is_sto_abnormal_fault instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 - Feedback symmetry check calculation.
 - Phasing test when the commutation feedback is a Halls sensor.
+- Abnormal STO Latched check. Add missing cases and add exception for uncertain ones.
 
 ### Deprecated 
 - check_sto_abnormal_fault in configuration. Use is_sto_abnormal_fault instead.

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -422,8 +422,7 @@ class Communication(metaclass=MCMetaClass):
             index = self._get_interface_index_by_address(address)
         except IndexError:
             raise ValueError(
-                f"Could not found a adapter configured as {address} "
-                f"to connect as EtherCAT master"
+                f"Could not found a adapter configured as {address} to connect as EtherCAT master"
             )
         return self.__get_adapter_name(index)
 
@@ -888,8 +887,7 @@ class Communication(metaclass=MCMetaClass):
 
         if net is None:
             self.logger.warning(
-                "Could not find any nodes in the network."
-                "Device: %s, channel: %s and baudrate: %s.",
+                "Could not find any nodes in the network.Device: %s, channel: %s and baudrate: %s.",
                 can_device,
                 channel,
                 baudrate,
@@ -924,8 +922,7 @@ class Communication(metaclass=MCMetaClass):
 
         if net is None:
             self.logger.warning(
-                "Could not find any nodes in the network."
-                "Device: %s, channel: %s and baudrate: %s.",
+                "Could not find any nodes in the network.Device: %s, channel: %s and baudrate: %s.",
                 can_device,
                 channel,
                 baudrate,

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1311,7 +1311,7 @@ class Communication(metaclass=MCMetaClass):
             FileNotFoundError: If the firmware file cannot be found.
             ValueError: If the firmware file has the wrong extension.
             ingenialink.exceptions.ILFirmwareLoadError: If no slave is detected.
-            ingenialink.exceptions.ILFirmwareLoadError: If the FoE write operation is not successful.
+            ingenialink.exceptions.ILFirmwareLoadError: If the FoE write operation fails.
 
         """
 

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -828,17 +828,23 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
 
     def is_sto_abnormal_latched(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
         """
-        Check if STO is abnormal latched
+        Check if STO is abnormal latched.
 
         Args:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
 
+        Raises:
+            IMException: For uncertain Abnormal_STO_latched status
+
         Returns:
             ``True`` if STO is abnormal latched, else ``False``.
-
         """
-        return self.get_sto_status(servo, axis) == self.STO_LATCHED_STATE
+        if bool(self.get_sto_status(servo, axis) & self.STO_ABNORMAL_FAULT_BIT) & (
+            self.is_sto1_active(servo, axis) != self.is_sto2_active(servo, axis)
+        ):
+            raise IMException("Abnormal STO might be latched.")
+        return bool(self.get_sto_status(servo, axis) & self.STO_ABNORMAL_FAULT_BIT)
 
     def is_sto_abnormal_fault(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
         """Check if the STO of a drive is in abnormal fault.

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -17,7 +17,7 @@ from ingeniamotion.enums import (
     FilterType,
     GeneratorMode,
     PhasingMode,
-    STOAbnormalStatus,
+    STOAbnormalLatchedStatus,
 )
 from ingeniamotion.exceptions import IMException
 from ingeniamotion.feedbacks import Feedbacks
@@ -829,7 +829,7 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
 
     def is_sto_abnormal_latched(
         self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS
-    ) -> STOAbnormalStatus:
+    ) -> STOAbnormalLatchedStatus:
         """
         Check if STO is abnormal latched.
 
@@ -838,16 +838,16 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
             axis : servo axis. ``1`` by default.
 
         Returns:
-            STOAbnormalStatus: STO Abnormal Latch state.
+            STOAbnormalLatchedStatus: STO Abnormal Latch state.
         """
         sto_status = self.get_sto_status(servo, axis)
         if bool(sto_status & self.STO_ABNORMAL_FAULT_BIT):
             if self.is_sto1_active(servo, axis) != self.is_sto2_active(servo, axis):
-                return STOAbnormalStatus.UNDETERMINATED
+                return STOAbnormalLatchedStatus.UNDETERMINATED
             else:
-                return STOAbnormalStatus.ABNORMAL
+                return STOAbnormalLatchedStatus.LATCHED
         else:
-            return STOAbnormalStatus.NOT
+            return STOAbnormalLatchedStatus.NOT_LATCHED
 
     def is_sto_abnormal_fault(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
         """Check if the STO of a drive is in abnormal fault.

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -129,7 +129,6 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
 
     STO_ACTIVE_STATE = 4
     STO_INACTIVE_STATE = 23
-    STO_LATCHED_STATE = 31
 
     PRODUCT_ID_REGISTERS = {
         TYPE_SUBNODES.COCO: "DRV_ID_PRODUCT_CODE_COCO",
@@ -840,11 +839,12 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
         Returns:
             ``True`` if STO is abnormal latched, else ``False``.
         """
-        if bool(self.get_sto_status(servo, axis) & self.STO_ABNORMAL_FAULT_BIT) & (
+        sto_status = self.get_sto_status(servo, axis)
+        if bool(sto_status & self.STO_ABNORMAL_FAULT_BIT) & (
             self.is_sto1_active(servo, axis) != self.is_sto2_active(servo, axis)
         ):
             raise IMException("Abnormal STO might be latched.")
-        return bool(self.get_sto_status(servo, axis) & self.STO_ABNORMAL_FAULT_BIT)
+        return bool(sto_status & self.STO_ABNORMAL_FAULT_BIT)
 
     def is_sto_abnormal_fault(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
         """Check if the STO of a drive is in abnormal fault.

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -17,7 +17,7 @@ from ingeniamotion.enums import (
     FilterType,
     GeneratorMode,
     PhasingMode,
-    SeverityLevel,
+    STOAbnormalStatus,
 )
 from ingeniamotion.exceptions import IMException
 from ingeniamotion.feedbacks import Feedbacks
@@ -829,25 +829,25 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
 
     def is_sto_abnormal_latched(
         self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS
-    ) -> SeverityLevel:
+    ) -> STOAbnormalStatus:
         """
         Check if STO is abnormal latched.
 
         Args:
-            servo (str, optional): servo alias to reference it. Defaults to DEFAULT_SERVO.
-            axis (int, optional): servo axis. Defaults to DEFAULT_AXIS.
+            servo (str, optional): servo alias to reference it. ``default`` by default.
+            axis (int, optional): servo axis. ``1`` by default.
 
         Returns:
-            SeverityLevel: STO Abnormal Latch state. WARNING if status is unclear.
+            STOAbnormalStatus: STO Abnormal Latch state. WARNING if status is unclear.
         """
         sto_status = self.get_sto_status(servo, axis)
         if bool(sto_status & self.STO_ABNORMAL_FAULT_BIT):
             if self.is_sto1_active(servo, axis) != self.is_sto2_active(servo, axis):
-                return SeverityLevel.WARNING
+                return STOAbnormalStatus.UNDETERMINATED
             else:
-                return SeverityLevel.SUCCESS
+                return STOAbnormalStatus.ABNORMAL
         else:
-            return SeverityLevel.FAIL
+            return STOAbnormalStatus.NOT
 
     def is_sto_abnormal_fault(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
         """Check if the STO of a drive is in abnormal fault.

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -834,11 +834,11 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
         Check if STO is abnormal latched.
 
         Args:
-            servo (str, optional): servo alias to reference it. ``default`` by default.
-            axis (int, optional): servo axis. ``1`` by default.
+            servo : servo alias to reference it. ``default`` by default.
+            axis : servo axis. ``1`` by default.
 
         Returns:
-            STOAbnormalStatus: STO Abnormal Latch state. WARNING if status is unclear.
+            STOAbnormalStatus: STO Abnormal Latch state.
         """
         sto_status = self.get_sto_status(servo, axis)
         if bool(sto_status & self.STO_ABNORMAL_FAULT_BIT):

--- a/ingeniamotion/enums/__init__.py
+++ b/ingeniamotion/enums/__init__.py
@@ -336,7 +336,7 @@ class TemperatureSensor(IntEnum, metaclass=MetaEnum):
 
 @export
 class STOAbnormalLatchedStatus(IntEnum, metaclass=MetaEnum):
-    """STO Abnormal status enum"""
+    """STO Abnormal Latched Status enum."""
 
     NOT_LATCHED = 0
     LATCHED = 1

--- a/ingeniamotion/enums/__init__.py
+++ b/ingeniamotion/enums/__init__.py
@@ -337,9 +337,9 @@ class TemperatureSensor(IntEnum, metaclass=MetaEnum):
 
 
 @export
-class STOAbnormalStatus(IntEnum, metaclass=MetaEnum):
+class STOAbnormalLatchedStatus(IntEnum, metaclass=MetaEnum):
     """STO Abnormal status enum"""
 
-    NOT = 0
-    ABNORMAL = 1
+    NOT_LATCHED = 0
+    LATCHED = 1
     UNDETERMINATED = 2

--- a/ingeniamotion/enums/__init__.py
+++ b/ingeniamotion/enums/__init__.py
@@ -334,3 +334,12 @@ class TemperatureSensor(IntEnum, metaclass=MetaEnum):
     """Temperature Switch"""
     NONE = 6
     """No Temperature sensor"""
+
+
+@export
+class STOAbnormalStatus(IntEnum, metaclass=MetaEnum):
+    """STO Abnormal status enum"""
+
+    NOT = 0
+    ABNORMAL = 1
+    UNDETERMINATED = 2

--- a/ingeniamotion/wizard_tests/sto.py
+++ b/ingeniamotion/wizard_tests/sto.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 import ingenialogger
 
-from ingeniamotion.enums import SeverityLevel
+from ingeniamotion.enums import SeverityLevel, STOAbnormalStatus
 from ingeniamotion.wizard_tests.base_test import BaseTest, LegacyDictReportType
 
 if TYPE_CHECKING:
@@ -115,10 +115,10 @@ class STOTest(BaseTest[LegacyDictReportType]):
         elif not sto_power_supply:
             # STO Supply Fault bit LOW --> STO Supply Fault
             return self.ResultType.STO_ABNORMAL_SUPPLY
-        elif sto_abnormal_fault & (sto_abnormal_latch == SeverityLevel.SUCCESS):
+        elif sto_abnormal_fault & (sto_abnormal_latch == STOAbnormalStatus.ABNORMAL):
             # STO Abnormal Fault bit HIGH & Latch state
             return self.ResultType.STO_ABNORMAL_LATCHED
-        elif sto_abnormal_fault & (sto_abnormal_latch == SeverityLevel.WARNING):
+        elif sto_abnormal_fault & (sto_abnormal_latch == STOAbnormalStatus.UNDETERMINATED):
             # STO Abnormal Fault bit HIGH & Might be Latched state
             return self.ResultType.STO_ABNORMAL
         elif self.mc.configuration.is_sto_inactive(servo=self.servo, axis=self.axis):

--- a/ingeniamotion/wizard_tests/sto.py
+++ b/ingeniamotion/wizard_tests/sto.py
@@ -115,12 +115,12 @@ class STOTest(BaseTest[LegacyDictReportType]):
         elif not sto_power_supply:
             # STO Supply Fault bit LOW --> STO Supply Fault
             return self.ResultType.STO_ABNORMAL_SUPPLY
-        elif sto_abnormal_fault:
-            # STO Abnormal Fault bit HIGH
-            if sto_abnormal_latch == SeverityLevel.SUCCESS:
-                return self.ResultType.STO_ABNORMAL_LATCHED
-            elif sto_abnormal_latch == SeverityLevel.WARNING:
-                return self.ResultType.STO_ABNORMAL
+        elif sto_abnormal_fault & (sto_abnormal_latch == SeverityLevel.SUCCESS):
+            # STO Abnormal Fault bit HIGH & Latch state
+            return self.ResultType.STO_ABNORMAL_LATCHED
+        elif sto_abnormal_fault & (sto_abnormal_latch == SeverityLevel.WARNING):
+            # STO Abnormal Fault bit HIGH & Might be Latched state
+            return self.ResultType.STO_ABNORMAL
         elif self.mc.configuration.is_sto_inactive(servo=self.servo, axis=self.axis):
             # STO Status in Inactive State --> STO Inactive
             return self.ResultType.STO_INACTIVE

--- a/ingeniamotion/wizard_tests/sto.py
+++ b/ingeniamotion/wizard_tests/sto.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 import ingenialogger
 
-from ingeniamotion.enums import SeverityLevel, STOAbnormalStatus
+from ingeniamotion.enums import SeverityLevel, STOAbnormalLatchedStatus
 from ingeniamotion.wizard_tests.base_test import BaseTest, LegacyDictReportType
 
 if TYPE_CHECKING:
@@ -115,10 +115,10 @@ class STOTest(BaseTest[LegacyDictReportType]):
         elif not sto_power_supply:
             # STO Supply Fault bit LOW --> STO Supply Fault
             return self.ResultType.STO_ABNORMAL_SUPPLY
-        elif sto_abnormal_fault & (sto_abnormal_latch == STOAbnormalStatus.ABNORMAL):
+        elif sto_abnormal_fault & (sto_abnormal_latch == STOAbnormalLatchedStatus.LATCHED):
             # STO Abnormal Fault bit HIGH & Latch state
             return self.ResultType.STO_ABNORMAL_LATCHED
-        elif sto_abnormal_fault & (sto_abnormal_latch == STOAbnormalStatus.UNDETERMINATED):
+        elif sto_abnormal_fault & (sto_abnormal_latch == STOAbnormalLatchedStatus.UNDETERMINATED):
             # STO Abnormal Fault bit HIGH & Might be Latched state
             return self.ResultType.STO_ABNORMAL
         elif self.mc.configuration.is_sto_inactive(servo=self.servo, axis=self.axis):

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -197,7 +197,6 @@ def test_sto_test(motion_controller):
     [
         (0x4, "STO Active"),
         (0x1F, "Abnormal STO Latched"),
-        (0x8, "Abnormal STO"),
         (0x73, "Abnormal Supply"),
         (0x5, "STO Inputs Differ"),
     ],

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -197,6 +197,7 @@ def test_sto_test(motion_controller):
     [
         (0x4, "STO Active"),
         (0x1F, "Abnormal STO Latched"),
+        (0xE, "Abnormal STO"),
         (0x73, "Abnormal Supply"),
         (0x5, "STO Inputs Differ"),
     ],

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -509,13 +509,28 @@ def test_is_sto_inactive(mocker, motion_controller, sto_status_value, expected_r
 @pytest.mark.virtual
 @pytest.mark.smoke
 @pytest.mark.parametrize(
-    "sto_status_value, expected_result", [(0x1BF3, False), (0x6B7, False), (0x1F, True)]
+    "sto_status_value, expected_result",
+    [(0x1BF3, False), (0x6B7, False), (0x1D, False), (0x1F, True), (0x1C, True)],
 )
 def test_is_sto_abnormal_latched(mocker, motion_controller, sto_status_value, expected_result):
     mc, alias, environment = motion_controller
     patch_get_sto_status(mocker, sto_status_value)
     value = mc.configuration.is_sto_abnormal_latched(servo=alias)
     assert value == expected_result
+
+
+@pytest.mark.virtual
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "sto_status_value",
+    [(0x1D), (0x1E)],
+)
+def test_is_sto_abnormal_latched_exception(mocker, motion_controller, sto_status_value):
+    mc, alias, environment = motion_controller
+    patch_get_sto_status(mocker, sto_status_value)
+    with pytest.raises(IMException) as excinfo:
+        mc.configuration.is_sto_abnormal_latched(servo=alias)
+    assert str(excinfo.value) == "Abnormal STO might be latched."
 
 
 @pytest.mark.ethernet

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -510,9 +510,21 @@ def test_is_sto_inactive(mocker, motion_controller, sto_status_value, expected_r
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value, expected_result",
-    [(0x1BF3, False), (0x6B7, False), (0x1D, False), (0x1F, True), (0x1C, True)],
+    [
+        # STO Status Inactive, expected output False
+        (0x1BF3, False),
+        # STO Status Supply Fault, expected output False
+        (0x6B7, False),
+        # STO Status Abnormal STO Latched, expected output True
+        (0x1F, True),
+        # STO Status Abnormal STO Latched, expected output True
+        (0x1C, True),
+    ],
 )
 def test_is_sto_abnormal_latched(mocker, motion_controller, sto_status_value, expected_result):
+    """
+    Test checks for Abnormal STO Latched Status
+    """
     mc, alias, environment = motion_controller
     patch_get_sto_status(mocker, sto_status_value)
     value = mc.configuration.is_sto_abnormal_latched(servo=alias)
@@ -523,9 +535,17 @@ def test_is_sto_abnormal_latched(mocker, motion_controller, sto_status_value, ex
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "sto_status_value",
-    [(0x1D), (0x1E)],
+    [
+        # STO Status Abnormal STO Might be Latched, expected output Exception
+        (0x1D),
+        # STO Status Abnormal STO Might be Latched, expected output Exception
+        (0x1E),
+    ],
 )
 def test_is_sto_abnormal_latched_exception(mocker, motion_controller, sto_status_value):
+    """
+    Test checks for Abnormal STO Might be Latched Status that triggers Exception
+    """
     mc, alias, environment = motion_controller
     patch_get_sto_status(mocker, sto_status_value)
     with pytest.raises(IMException) as excinfo:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -10,7 +10,7 @@ from ingeniamotion.enums import (
     FilterNumber,
     FilterSignal,
     FilterType,
-    STOAbnormalStatus,
+    STOAbnormalLatchedStatus,
 )
 from ingeniamotion.exceptions import IMException
 
@@ -512,18 +512,18 @@ def test_is_sto_inactive(mocker, motion_controller, sto_status_value, expected_r
 @pytest.mark.parametrize(
     "sto_status_value, expected_result",
     [
-        # STO Status Inactive, expected output SeverityLevel.FAIL
-        (0x1BF3, STOAbnormalStatus.NOT),
-        # STO Status Supply Fault, expected output SeverityLevel.FAIL
-        (0x6B7, STOAbnormalStatus.NOT),
-        # STO Status Abnormal STO Latched, expected output SeverityLevel.SUCCESS
-        (0x1F, STOAbnormalStatus.ABNORMAL),
-        # STO Status Abnormal STO Latched, expected output SeverityLevel.SUCCESS
-        (0x1C, STOAbnormalStatus.ABNORMAL),
-        # STO Status Abnormal STO Might be Latched, expected output SeverityLevel.WARNING
-        (0x1D, STOAbnormalStatus.UNDETERMINATED),
-        # STO Status Abnormal STO Might be Latched, expected output SeverityLevel.WARNING
-        (0x1E, STOAbnormalStatus.UNDETERMINATED),
+        # STO Status Inactive, expected output NOT STO Abnormal Latched
+        (0x1BF3, STOAbnormalLatchedStatus.NOT_LATCHED),
+        # STO Status Supply Fault, expected output NOT STO Abnormal Latched
+        (0x6B7, STOAbnormalLatchedStatus.NOT_LATCHED),
+        # STO Status Abnormal STO Latched, expected output YES STO Abnormal Latched
+        (0x1F, STOAbnormalLatchedStatus.LATCHED),
+        # STO Status Abnormal STO Latched, expected output YES STO Abnormal Latched
+        (0x1C, STOAbnormalLatchedStatus.LATCHED),
+        # STO Status Abnormal STO Might be Latched, expected outpt UNDETERMIANTED STO Abnormal Latch
+        (0x1D, STOAbnormalLatchedStatus.UNDETERMINATED),
+        # STO Status Abnormal STO Might be Latched, expected outpt UNDETERMIANTED STO Abnormal Latch
+        (0x1E, STOAbnormalLatchedStatus.UNDETERMINATED),
     ],
 )
 def test_is_sto_abnormal_latched(mocker, motion_controller, sto_status_value, expected_result):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -10,7 +10,7 @@ from ingeniamotion.enums import (
     FilterNumber,
     FilterSignal,
     FilterType,
-    SeverityLevel,
+    STOAbnormalStatus,
 )
 from ingeniamotion.exceptions import IMException
 
@@ -513,17 +513,17 @@ def test_is_sto_inactive(mocker, motion_controller, sto_status_value, expected_r
     "sto_status_value, expected_result",
     [
         # STO Status Inactive, expected output SeverityLevel.FAIL
-        (0x1BF3, SeverityLevel.FAIL),
+        (0x1BF3, STOAbnormalStatus.NOT),
         # STO Status Supply Fault, expected output SeverityLevel.FAIL
-        (0x6B7, SeverityLevel.FAIL),
+        (0x6B7, STOAbnormalStatus.NOT),
         # STO Status Abnormal STO Latched, expected output SeverityLevel.SUCCESS
-        (0x1F, SeverityLevel.SUCCESS),
+        (0x1F, STOAbnormalStatus.ABNORMAL),
         # STO Status Abnormal STO Latched, expected output SeverityLevel.SUCCESS
-        (0x1C, SeverityLevel.SUCCESS),
+        (0x1C, STOAbnormalStatus.ABNORMAL),
         # STO Status Abnormal STO Might be Latched, expected output SeverityLevel.WARNING
-        (0x1D, SeverityLevel.WARNING),
+        (0x1D, STOAbnormalStatus.UNDETERMINATED),
         # STO Status Abnormal STO Might be Latched, expected output SeverityLevel.WARNING
-        (0x1E, SeverityLevel.WARNING),
+        (0x1E, STOAbnormalStatus.UNDETERMINATED),
     ],
 )
 def test_is_sto_abnormal_latched(mocker, motion_controller, sto_status_value, expected_result):


### PR DESCRIPTION
### Description

_is_sto_abnormal_latched_ doesn`t work for all cases as it should. New cases need to be added to comply with table:

|STO abnormal fault|STO1=STO2|Is it actually latched|
|---|---|---|
|0|X|No|
|1|1 (STO Active or STO Inactive)|Yes|
|1|0 (STO1!=STO2) Raise exception indicating STO Abnormal might be latched.|No. Impossible to know if it’s latched; latching depends on time and there’s no bit that reports that|

Fixes #INGM-543

### Type of change

- [x] Fix Abnormal STO latched check and add exception (Added missing cases to `configuration.py`, including exception)
- [x] Add Abnormal STO latched test (_test_is_sto_latched_exception_ to `test_configuration.py`). 
- [x] Add new cases for old _test_is_sto_abnormal_latched_ (Add new check cases that include missing scenarios)


### Tests
- [x] Added a new unit test (_test_is_sto_abnormal_latched_exception_).
- [x] Fixed previous test (_test_is_sto_abnormal_latched_).
- [x] Run tests.

### Documentation

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion`.

### Others

- [ ] Set fix version field in the Jira issue.
