### PR TITLE
INGM-580 Improve the PDO watchdog timeout setting

### DIFF
--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -314,7 +314,7 @@ class PDONetworkManager:
             except AttributeError as e:
                 max_pdo_watchdog = re.findall("wd_time_ms is limited to (.+) ms", e.__str__())
                 max_pdo_watchdog_ms = None
-                if max_pdo_watchdog is not None and "." in max_pdo_watchdog[0]:
+                if max_pdo_watchdog is not None:
                     max_pdo_watchdog_ms = float(max_pdo_watchdog[0])
                 if is_watchdog_timeout_manually_set:
                     error_msg = "The watchdog timeout is too high."

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -312,7 +312,7 @@ class PDONetworkManager:
                 for servo in self._net.servos:
                     servo.set_pdo_watchdog_time(self._watchdog_timeout)
             except AttributeError as e:
-                max_pdo_watchdog = re.findall(r"\d+\.\d+|\d+", e.__str__())
+                max_pdo_watchdog = re.findall("wd_time_ms is limited to (.+) ms", e.__str__())
                 max_pdo_watchdog_ms = None
                 if max_pdo_watchdog is not None and "." in max_pdo_watchdog[0]:
                     max_pdo_watchdog_ms = float(max_pdo_watchdog[0])


### PR DESCRIPTION
### Description

Improve the PDO watchdog timeout setting.

Fixes # INGM-580

### Type of change

- Add a method to set the PDO watchdog timeout.
- Calculate the max watchdog timeout based on whether it was set manually.

### Tests
- Connect to ML3.
- Open a scope and set the mode to PDO poller.
- Set a very high sampling time (>3500 ms)
- Check that the poller is stopped and that an error message showing the max sampling time is shown.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
