### PR TITLE
INGM-579 Replace the check_servo decorator

### DIFF
--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -152,7 +152,6 @@ class Capture:
             NotImplementedError: If an wrong monitoring version is requested.
 
         """
-        self.mc._get_drive(servo)
         version = self._check_version(servo)
         if version == MonitoringVersion.MONITORING_V3:
             return MonitoringV3(self.mc, servo)

--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -18,7 +18,7 @@ from ingeniamotion.exceptions import (
     IMRegisterNotExist,
     IMStatusWordError,
 )
-from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
+from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 from ingeniamotion.monitoring.base_monitoring import Monitoring
 from ingeniamotion.monitoring.monitoring_v1 import MonitoringV1
 from ingeniamotion.monitoring.monitoring_v3 import MonitoringV3
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
 
 
-class Capture(metaclass=MCMetaClass):
+class Capture:
     """Capture."""
 
     DISTURBANCE_STATUS_REGISTER = "DIST_STATUS"

--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -228,7 +228,6 @@ class Capture:
              trigger_signal or trigger_value are None.
 
         """
-        self.mc._get_drive(servo)
         self.clean_monitoring(servo=servo)
         monitoring = self.create_empty_monitoring(servo)
         monitoring.set_frequency(prescaler)
@@ -277,7 +276,6 @@ class Capture:
                 registers and samples.
 
         """
-        self.mc._get_drive(servo)
         self.clean_disturbance(servo=servo)
         disturbance = Disturbance(self.mc, servo)
         disturbance.set_frequency_divider(freq_divider)
@@ -333,7 +331,6 @@ class Capture:
             IMMonitoringError: If monitoring can't be enabled.
 
         """
-        self.mc._get_drive(servo)
         self.enable_monitoring(servo=servo)
         self.enable_disturbance(servo=servo)
 
@@ -384,7 +381,6 @@ class Capture:
             servo : servo alias to reference it. ``default`` by default.
 
         """
-        self.mc._get_drive(servo)
         self.disable_monitoring(servo=servo)
         self.disable_disturbance(servo=servo)
 
@@ -443,7 +439,6 @@ class Capture:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         monitoring_disturbance_status = self.mc.communication.get_register(
             self.MONITORING_STATUS_REGISTER, servo=servo, axis=0
         )
@@ -465,7 +460,6 @@ class Capture:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         monitoring_status = self.mc.communication.get_register(
             self.MONITORING_STATUS_REGISTER, servo=servo, axis=0
         )
@@ -491,7 +485,6 @@ class Capture:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         if version is None:
             version = self._check_version(servo)
         if version < MonitoringVersion.MONITORING_V3:
@@ -519,7 +512,6 @@ class Capture:
             IMRegisterNotExist: If the register doesn't exist.
 
         """
-        self.mc._get_drive(servo)
         monitor_status = self.get_monitoring_status(servo)
         return (monitor_status & self.MONITORING_STATUS_ENABLED_BIT) == 1
 
@@ -540,7 +532,6 @@ class Capture:
             IMRegisterNotExist: If the register doesn't exist.
 
         """
-        self.mc._get_drive(servo)
         monitor_status = self.get_disturbance_status(servo, version=version)
         return (monitor_status & self.DISTURBANCE_STATUS_ENABLED_BIT) == 1
 
@@ -561,7 +552,6 @@ class Capture:
             IMRegisterNotExist: If the register doesn't exist.
 
         """
-        self.mc._get_drive(servo)
         if version is None:
             version = self._check_version(servo=servo)
         monitor_status = self.mc.capture.get_monitoring_status(servo=servo)
@@ -586,7 +576,6 @@ class Capture:
             IMRegisterNotExist: If the register doesn't exist.
 
         """
-        self.mc._get_drive(servo)
         if version is None:
             version = self._check_version(servo=servo)
         monitor_status = self.mc.capture.get_monitoring_status(servo=servo)
@@ -633,7 +622,6 @@ class Capture:
             servo : servo alias to reference it. ``default`` by default.
 
         """
-        self.mc._get_drive(servo)
         self.clean_monitoring(servo=servo)
         self.clean_disturbance(servo=servo)
 
@@ -649,7 +637,6 @@ class Capture:
             IMStatusWordError: If motor is enabled.
 
         """
-        self.mc._get_drive(servo)
         for subnode in [
             subnode
             for subnode, subnode_type in self.mc.info.get_subnodes(servo).items()
@@ -673,7 +660,6 @@ class Capture:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         try:
             max_sample_size = self.mc.communication.get_register(
                 self.DISTURBANCE_MAXIMUM_SAMPLE_SIZE_REGISTER, servo=servo, axis=0
@@ -697,7 +683,6 @@ class Capture:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         try:
             max_sample_size = self.mc.communication.get_register(
                 self.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER, servo=servo, axis=0
@@ -722,7 +707,6 @@ class Capture:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         position_velocity_loop_rate = self.mc.configuration.get_position_and_velocity_loop_rate(
             servo=servo, axis=axis
         )

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1029,7 +1029,7 @@ class Communication:
             TypeError: If some parameter has a wrong type.
 
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         register_dtype = self.mc.info.register_type(register, axis, servo=servo)
         value = drive.read(register, subnode=axis)
         if register_dtype.value <= RegDtype.S64.value and isinstance(value, int):
@@ -1059,7 +1059,7 @@ class Communication:
             IMRegisterWrongAccess: If the register access is read-only.
 
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         register_dtype_value = self.mc.info.register_type(register, axis, servo=servo)
         register_access_type = self.mc.info.register_info(register, axis, servo=servo).access
         signed_int = [RegDtype.S8, RegDtype.S16, RegDtype.S32, RegDtype.S64]

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 import contextlib
 
-from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
+from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 RUNNING_ON_WINDOWS = platform.system() == "Windows"
 
@@ -71,7 +71,7 @@ class NetworkAdapter:
     interface_guid: str
 
 
-class Communication(metaclass=MCMetaClass):
+class Communication:
     """Communication."""
 
     FORCE_SYSTEM_BOOT_COCO_REGISTER = "DRV_BOOT_COCO_FORCE"

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -170,6 +170,7 @@ class Configuration(Homing, Feedbacks):
             axis : axis that will run the test. 1 by default.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.BRAKE_OVERRIDE_REGISTER, self.BrakeOverride.RELEASE_BRAKE, servo=servo, axis=axis
         )
@@ -182,6 +183,7 @@ class Configuration(Homing, Feedbacks):
             axis : axis that will run the test. 1 by default.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.BRAKE_OVERRIDE_REGISTER, self.BrakeOverride.ENABLE_BRAKE, servo=servo, axis=axis
         )
@@ -194,6 +196,7 @@ class Configuration(Homing, Feedbacks):
             axis : axis that will run the test. 1 by default.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.BRAKE_OVERRIDE_REGISTER,
             self.BrakeOverride.OVERRIDE_DISABLED,
@@ -212,6 +215,7 @@ class Configuration(Homing, Feedbacks):
             axis : axis that will run the test. 1 by default.
 
         """
+        self.mc._get_drive(servo)
         self.disable_brake_override(servo, axis)
 
     def check_configuration(
@@ -236,10 +240,10 @@ class Configuration(Homing, Feedbacks):
             ILConfigurationError: If the configuration file differs from the drive state.
 
         """
+        drive = self.mc._get_drive(servo)
         if not path.isfile(config_path):
             raise FileNotFoundError(f"{config_path} file does not exist!")
-        servo_inst = self.mc.servos[servo]
-        servo_inst.check_configuration(config_path, subnode=axis)
+        drive.check_configuration(config_path, subnode=axis)
         self.logger.info(
             "Configuration check successfull %s", config_path, drive=self.mc.servo_name(servo)
         )
@@ -259,10 +263,10 @@ class Configuration(Homing, Feedbacks):
             FileNotFoundError: If configuration file does not exist.
 
         """
+        drive = self.mc._get_drive(servo)
         if not path.isfile(config_path):
             raise FileNotFoundError(f"{config_path} file does not exist!")
-        servo_inst = self.mc.servos[servo]
-        servo_inst.load_configuration(config_path, subnode=axis)
+        drive.load_configuration(config_path, subnode=axis)
         self.logger.info(
             "Configuration loaded from %s", config_path, drive=self.mc.servo_name(servo)
         )
@@ -279,8 +283,8 @@ class Configuration(Homing, Feedbacks):
             servo : servo alias to reference it. ``default`` by default.
 
         """
-        servo_inst = self.mc.servos[servo]
-        servo_inst.save_configuration(output_file, subnode=axis)
+        drive = self.mc._get_drive(servo)
+        drive.save_configuration(output_file, subnode=axis)
         self.logger.info("Configuration saved to %s", output_file, drive=self.mc.servo_name(servo))
 
     def store_configuration(self, axis: Optional[int] = None, servo: str = DEFAULT_SERVO) -> None:
@@ -319,6 +323,7 @@ class Configuration(Homing, Feedbacks):
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.PROFILE_MAX_ACCELERATION_REGISTER, acceleration, servo=servo, axis=axis
         )
@@ -339,6 +344,7 @@ class Configuration(Homing, Feedbacks):
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.PROFILE_MAX_DECELERATION_REGISTER, deceleration, servo=servo, axis=axis
         )
@@ -374,6 +380,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: Missing arguments. All the arguments given were None.
 
         """
+        self.mc._get_drive(servo)
         if acceleration is None and deceleration is None and velocity is None:
             raise TypeError("Missing arguments. At least one argument is required.")
 
@@ -400,6 +407,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If the read value has the wrong type.
 
         """
+        self.mc._get_drive(servo)
         max_velocity = self.mc.communication.get_register(
             self.MAX_VELOCITY_REGISTER, servo=servo, axis=axis
         )
@@ -421,6 +429,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If velocity is not a float.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.MAX_VELOCITY_REGISTER, velocity, servo=servo, axis=axis
         )
@@ -438,6 +447,7 @@ class Configuration(Homing, Feedbacks):
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.PROFILE_MAX_VELOCITY_REGISTER, velocity, servo=servo, axis=axis
         )
@@ -461,6 +471,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         pos_vel_loop_rate = self.mc.communication.get_register(
             self.POSITION_AND_VELOCITY_LOOP_RATE_REGISTER, servo=servo, axis=axis
         )
@@ -482,6 +493,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         current_loop = self.mc.communication.get_register(
             self.CURRENT_LOOP_RATE_REGISTER, servo=servo, axis=axis
         )
@@ -509,6 +521,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         pow_stg_freq = self.mc.communication.get_register(
             self.POWER_STAGE_FREQUENCY_SELECTION_REGISTER, servo=servo, axis=axis
         )
@@ -538,6 +551,7 @@ class Configuration(Homing, Feedbacks):
             IntEnum: Enum with power stage frequency available values.
 
         """
+        self.mc._get_drive(servo)
         return self.mc.get_register_enum(self.POWER_STAGE_FREQUENCY_SELECTION_REGISTER, servo, axis)
 
     @MCMetaClass.check_motor_disabled
@@ -575,6 +589,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         status_word = self.mc.communication.get_register(self.STATUS_WORD_REGISTER, servo, axis)
         if not isinstance(status_word, int):
             raise TypeError("Power stage frequency value has to be an integer")
@@ -591,6 +606,7 @@ class Configuration(Homing, Feedbacks):
             ``True`` if motor is enabled, else ``False``.
 
         """
+        self.mc._get_drive(servo)
         status_word = self.mc.configuration.get_status_word(servo=servo, axis=axis)
         return bool(status_word & self.STATUS_WORD_OPERATION_ENABLED_BIT)
 
@@ -607,6 +623,7 @@ class Configuration(Homing, Feedbacks):
             ``True`` if commutation feedback is aligned, else ``False``.
 
         """
+        self.mc._get_drive(servo)
         status_word = self.mc.configuration.get_status_word(servo=servo, axis=axis)
         return bool(status_word & self.STATUS_WORD_COMMUTATION_FEEDBACK_ALIGNED_BIT)
 
@@ -621,6 +638,7 @@ class Configuration(Homing, Feedbacks):
             axis : servo axis. ``1`` by default.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(self.PHASING_MODE_REGISTER, phasing_mode, servo, axis)
 
     def get_phasing_mode(
@@ -639,6 +657,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         phasing_mode = self.mc.communication.get_register(self.PHASING_MODE_REGISTER, servo, axis)
         if not isinstance(phasing_mode, int):
             raise TypeError("Phasing mode value has to be an integer")
@@ -658,6 +677,7 @@ class Configuration(Homing, Feedbacks):
             axis : servo axis. ``1`` by default.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(self.GENERATOR_MODE_REGISTER, mode, servo, axis)
 
     def set_motor_pair_poles(
@@ -675,6 +695,7 @@ class Configuration(Homing, Feedbacks):
             ingenialink.exceptions.ILValueError: If pair poles is less than 0.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.MOTOR_POLE_PAIRS_REGISTER, pair_poles, servo=servo, axis=axis
         )
@@ -692,6 +713,7 @@ class Configuration(Homing, Feedbacks):
         Raises:
             TypeError: If some read value has a wrong type.
         """
+        self.mc._get_drive(servo)
         pair_poles = self.mc.communication.get_register(
             self.MOTOR_POLE_PAIRS_REGISTER, servo=servo, axis=axis
         )
@@ -713,6 +735,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         sto_status = self.mc.communication.get_register(
             self.STO_STATUS_REGISTER, servo=servo, axis=axis
         )
@@ -732,6 +755,7 @@ class Configuration(Homing, Feedbacks):
             False when the STO 1 input is inactive (bit is 1)
 
         """
+        self.mc._get_drive(servo)
         return not bool(self.get_sto_status(servo, axis) & self.STO1_ACTIVE_BIT)
 
     def is_sto2_active(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
@@ -746,6 +770,7 @@ class Configuration(Homing, Feedbacks):
             False when the STO 2 input is inactive (bit is 1)
 
         """
+        self.mc._get_drive(servo)
         return not bool(self.get_sto_status(servo, axis) & self.STO2_ACTIVE_BIT)
 
     def check_sto_power_supply(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> int:
@@ -759,6 +784,7 @@ class Configuration(Homing, Feedbacks):
             return value of power supply bit.
 
         """
+        self.mc._get_drive(servo)
         if self.get_sto_status(servo, axis) & self.STO_SUPPLY_FAULT_BIT:
             return 1
         else:
@@ -779,6 +805,7 @@ class Configuration(Homing, Feedbacks):
             return value of abnormal fault bit.
 
         """
+        self.mc._get_drive(servo)
         if self.get_sto_status(servo, axis) & self.STO_ABNORMAL_FAULT_BIT:
             return 1
         else:
@@ -795,6 +822,7 @@ class Configuration(Homing, Feedbacks):
             return value of report bit.
 
         """
+        self.mc._get_drive(servo)
         if self.get_sto_status(servo, axis) & self.STO_REPORT_BIT:
             return 1
         else:
@@ -811,6 +839,7 @@ class Configuration(Homing, Feedbacks):
             ``True`` if STO is active, else ``False``.
 
         """
+        self.mc._get_drive(servo)
         return self.get_sto_status(servo, axis) == self.STO_ACTIVE_STATE
 
     def is_sto_inactive(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
@@ -824,6 +853,7 @@ class Configuration(Homing, Feedbacks):
             ``True`` if STO is inactive, else ``False``.
 
         """
+        self.mc._get_drive(servo)
         return self.get_sto_status(servo, axis) == self.STO_INACTIVE_STATE
 
     def is_sto_abnormal_latched(
@@ -838,6 +868,7 @@ class Configuration(Homing, Feedbacks):
         Returns:
             STOAbnormalLatchedStatus: STO Abnormal Latch state.
         """
+        self.mc._get_drive(servo)
         sto_status = self.get_sto_status(servo, axis)
         if bool(sto_status & self.STO_ABNORMAL_FAULT_BIT):
             if self.is_sto1_active(servo, axis) != self.is_sto2_active(servo, axis):
@@ -858,6 +889,7 @@ class Configuration(Homing, Feedbacks):
             ``True`` if STO is in abnormal fault, else ``False``.
 
         """
+        self.mc._get_drive(servo)
         return bool(self.get_sto_status(servo, axis) & self.STO_ABNORMAL_FAULT_BIT)
 
     def change_tcp_ip_parameters(
@@ -983,6 +1015,7 @@ class Configuration(Homing, Feedbacks):
             Serial numbers (COCO, MOCO).
 
         """
+        self.mc._get_drive(servo)
         prod_codes: list[Optional[int]] = [None, None]
         rev_numbers: list[Optional[int]] = [None, None]
         fw_versions: list[Optional[str]] = [None, None]
@@ -1045,6 +1078,7 @@ class Configuration(Homing, Feedbacks):
         Raises:
             TypeError: If some read value has a wrong type.
         """
+        self.mc._get_drive(servo)
         product_code_register = self.PRODUCT_ID_REGISTERS[self.get_subnode_type(axis)]
         product_code_value = self.mc.communication.get_register(
             product_code_register, servo, axis=axis
@@ -1066,6 +1100,7 @@ class Configuration(Homing, Feedbacks):
         Raises:
             TypeError: If some read value has a wrong type.
         """
+        self.mc._get_drive(servo)
         revision_number_register = self.REVISION_NUMBER_REGISTERS[self.get_subnode_type(axis)]
         revision_number_value = self.mc.communication.get_register(
             revision_number_register, servo, axis=axis
@@ -1087,6 +1122,7 @@ class Configuration(Homing, Feedbacks):
         Raises:
             TypeError: If some read value has a wrong type.
         """
+        self.mc._get_drive(servo)
         serial_number_register = self.SERIAL_NUMBER_REGISTERS[self.get_subnode_type(axis)]
         serial_number_value = self.mc.communication.get_register(
             serial_number_register, servo, axis=axis
@@ -1108,6 +1144,7 @@ class Configuration(Homing, Feedbacks):
         Raises:
             TypeError: If some read value has a wrong type.
         """
+        self.mc._get_drive(servo)
         fw_register = self.SOFTWARE_VERSION_REGISTERS[self.get_subnode_type(axis)]
         fw_value = self.mc.communication.get_register(fw_register, servo, axis=axis)
         if not isinstance(fw_value, str):
@@ -1128,6 +1165,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If the read vendor ID has the wrong type.
 
         """
+        self.mc._get_drive(servo)
         register = self.VENDOR_ID_COCO_REGISTER if axis == 0 else self.VENDOR_ID_REGISTER
         vendor_id = self.mc.communication.get_register(register, servo, axis)
         if not isinstance(vendor_id, int):
@@ -1200,6 +1238,7 @@ class Configuration(Homing, Feedbacks):
             axis: servo axis. ``1`` by default.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.VELOCITY_LOOP_KP_REGISTER, kp, servo=servo, axis=axis
         )
@@ -1228,6 +1267,7 @@ class Configuration(Homing, Feedbacks):
             axis: servo axis. ``1`` by default.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.POSITION_LOOP_KP_REGISTER, kp, servo=servo, axis=axis
         )
@@ -1252,6 +1292,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         rated_current = self.mc.communication.get_register(
             self.RATED_CURRENT_REGISTER, servo=servo, axis=axis
         )
@@ -1273,6 +1314,7 @@ class Configuration(Homing, Feedbacks):
             axis: servo axis. ``1`` by default.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.RATED_CURRENT_REGISTER, rated_current, servo=servo, axis=axis
         )
@@ -1291,6 +1333,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         max_current = self.mc.communication.get_register(
             self.MAX_CURRENT_REGISTER, servo=servo, axis=axis
         )
@@ -1317,6 +1360,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         commutation_mode = self.mc.communication.get_register(
             self.COMMUTATION_MODE_REGISTER, servo, axis
         )
@@ -1339,6 +1383,7 @@ class Configuration(Homing, Feedbacks):
             axis: servo axis. ``1`` by default.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.COMMUTATION_MODE_REGISTER, commutation_mode, servo, axis
         )
@@ -1357,6 +1402,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         bus_voltage = self.mc.communication.get_register(self.BUS_VOLTAGE_REGISTER, servo, axis)
         if not isinstance(bus_voltage, float):
             raise TypeError("Bus voltage value has to be a float")
@@ -1377,6 +1423,7 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         pos_to_vel_ratio = self.mc.communication.get_register(
             self.POSITION_TO_VELOCITY_RATIO_REGISTER, servo, axis
         )
@@ -1396,6 +1443,7 @@ class Configuration(Homing, Feedbacks):
             axis: servo axis. ``1`` by default.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.POSITION_TO_VELOCITY_RATIO_REGISTER, pos_to_vel_ratio, servo, axis
         )
@@ -1423,6 +1471,7 @@ class Configuration(Homing, Feedbacks):
             servo: servo alias to reference it. ``default`` by default.
             axis: servo axis. ``1`` by default.
         """
+        self.mc._get_drive(servo)
         arguments = [filter_type, frequency, q_factor, gain]
         registers = [
             self.FILTER_TYPE_REGISTER,

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -170,7 +170,6 @@ class Configuration(Homing, Feedbacks):
             axis : axis that will run the test. 1 by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.BRAKE_OVERRIDE_REGISTER, self.BrakeOverride.RELEASE_BRAKE, servo=servo, axis=axis
         )
@@ -183,7 +182,6 @@ class Configuration(Homing, Feedbacks):
             axis : axis that will run the test. 1 by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.BRAKE_OVERRIDE_REGISTER, self.BrakeOverride.ENABLE_BRAKE, servo=servo, axis=axis
         )
@@ -196,7 +194,6 @@ class Configuration(Homing, Feedbacks):
             axis : axis that will run the test. 1 by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.BRAKE_OVERRIDE_REGISTER,
             self.BrakeOverride.OVERRIDE_DISABLED,
@@ -215,7 +212,6 @@ class Configuration(Homing, Feedbacks):
             axis : axis that will run the test. 1 by default.
 
         """
-        self.mc._get_drive(servo)
         self.disable_brake_override(servo, axis)
 
     def check_configuration(
@@ -323,7 +319,6 @@ class Configuration(Homing, Feedbacks):
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.PROFILE_MAX_ACCELERATION_REGISTER, acceleration, servo=servo, axis=axis
         )
@@ -344,7 +339,6 @@ class Configuration(Homing, Feedbacks):
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.PROFILE_MAX_DECELERATION_REGISTER, deceleration, servo=servo, axis=axis
         )
@@ -380,7 +374,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: Missing arguments. All the arguments given were None.
 
         """
-        self.mc._get_drive(servo)
         if acceleration is None and deceleration is None and velocity is None:
             raise TypeError("Missing arguments. At least one argument is required.")
 
@@ -407,7 +400,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If the read value has the wrong type.
 
         """
-        self.mc._get_drive(servo)
         max_velocity = self.mc.communication.get_register(
             self.MAX_VELOCITY_REGISTER, servo=servo, axis=axis
         )
@@ -429,7 +421,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If velocity is not a float.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.MAX_VELOCITY_REGISTER, velocity, servo=servo, axis=axis
         )
@@ -447,7 +438,6 @@ class Configuration(Homing, Feedbacks):
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.PROFILE_MAX_VELOCITY_REGISTER, velocity, servo=servo, axis=axis
         )
@@ -471,7 +461,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         pos_vel_loop_rate = self.mc.communication.get_register(
             self.POSITION_AND_VELOCITY_LOOP_RATE_REGISTER, servo=servo, axis=axis
         )
@@ -493,7 +482,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         current_loop = self.mc.communication.get_register(
             self.CURRENT_LOOP_RATE_REGISTER, servo=servo, axis=axis
         )
@@ -521,7 +509,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         pow_stg_freq = self.mc.communication.get_register(
             self.POWER_STAGE_FREQUENCY_SELECTION_REGISTER, servo=servo, axis=axis
         )
@@ -551,7 +538,6 @@ class Configuration(Homing, Feedbacks):
             IntEnum: Enum with power stage frequency available values.
 
         """
-        self.mc._get_drive(servo)
         return self.mc.get_register_enum(self.POWER_STAGE_FREQUENCY_SELECTION_REGISTER, servo, axis)
 
     @MCMetaClass.check_motor_disabled
@@ -589,7 +575,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         status_word = self.mc.communication.get_register(self.STATUS_WORD_REGISTER, servo, axis)
         if not isinstance(status_word, int):
             raise TypeError("Power stage frequency value has to be an integer")
@@ -606,7 +591,6 @@ class Configuration(Homing, Feedbacks):
             ``True`` if motor is enabled, else ``False``.
 
         """
-        self.mc._get_drive(servo)
         status_word = self.mc.configuration.get_status_word(servo=servo, axis=axis)
         return bool(status_word & self.STATUS_WORD_OPERATION_ENABLED_BIT)
 
@@ -623,7 +607,6 @@ class Configuration(Homing, Feedbacks):
             ``True`` if commutation feedback is aligned, else ``False``.
 
         """
-        self.mc._get_drive(servo)
         status_word = self.mc.configuration.get_status_word(servo=servo, axis=axis)
         return bool(status_word & self.STATUS_WORD_COMMUTATION_FEEDBACK_ALIGNED_BIT)
 
@@ -638,7 +621,6 @@ class Configuration(Homing, Feedbacks):
             axis : servo axis. ``1`` by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(self.PHASING_MODE_REGISTER, phasing_mode, servo, axis)
 
     def get_phasing_mode(
@@ -657,7 +639,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         phasing_mode = self.mc.communication.get_register(self.PHASING_MODE_REGISTER, servo, axis)
         if not isinstance(phasing_mode, int):
             raise TypeError("Phasing mode value has to be an integer")
@@ -677,7 +658,6 @@ class Configuration(Homing, Feedbacks):
             axis : servo axis. ``1`` by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(self.GENERATOR_MODE_REGISTER, mode, servo, axis)
 
     def set_motor_pair_poles(
@@ -695,7 +675,6 @@ class Configuration(Homing, Feedbacks):
             ingenialink.exceptions.ILValueError: If pair poles is less than 0.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.MOTOR_POLE_PAIRS_REGISTER, pair_poles, servo=servo, axis=axis
         )
@@ -713,7 +692,6 @@ class Configuration(Homing, Feedbacks):
         Raises:
             TypeError: If some read value has a wrong type.
         """
-        self.mc._get_drive(servo)
         pair_poles = self.mc.communication.get_register(
             self.MOTOR_POLE_PAIRS_REGISTER, servo=servo, axis=axis
         )
@@ -735,7 +713,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         sto_status = self.mc.communication.get_register(
             self.STO_STATUS_REGISTER, servo=servo, axis=axis
         )
@@ -755,7 +732,6 @@ class Configuration(Homing, Feedbacks):
             False when the STO 1 input is inactive (bit is 1)
 
         """
-        self.mc._get_drive(servo)
         return not bool(self.get_sto_status(servo, axis) & self.STO1_ACTIVE_BIT)
 
     def is_sto2_active(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
@@ -770,7 +746,6 @@ class Configuration(Homing, Feedbacks):
             False when the STO 2 input is inactive (bit is 1)
 
         """
-        self.mc._get_drive(servo)
         return not bool(self.get_sto_status(servo, axis) & self.STO2_ACTIVE_BIT)
 
     def check_sto_power_supply(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> int:
@@ -784,7 +759,6 @@ class Configuration(Homing, Feedbacks):
             return value of power supply bit.
 
         """
-        self.mc._get_drive(servo)
         if self.get_sto_status(servo, axis) & self.STO_SUPPLY_FAULT_BIT:
             return 1
         else:
@@ -805,7 +779,6 @@ class Configuration(Homing, Feedbacks):
             return value of abnormal fault bit.
 
         """
-        self.mc._get_drive(servo)
         if self.get_sto_status(servo, axis) & self.STO_ABNORMAL_FAULT_BIT:
             return 1
         else:
@@ -822,7 +795,6 @@ class Configuration(Homing, Feedbacks):
             return value of report bit.
 
         """
-        self.mc._get_drive(servo)
         if self.get_sto_status(servo, axis) & self.STO_REPORT_BIT:
             return 1
         else:
@@ -839,7 +811,6 @@ class Configuration(Homing, Feedbacks):
             ``True`` if STO is active, else ``False``.
 
         """
-        self.mc._get_drive(servo)
         return self.get_sto_status(servo, axis) == self.STO_ACTIVE_STATE
 
     def is_sto_inactive(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:
@@ -853,7 +824,6 @@ class Configuration(Homing, Feedbacks):
             ``True`` if STO is inactive, else ``False``.
 
         """
-        self.mc._get_drive(servo)
         return self.get_sto_status(servo, axis) == self.STO_INACTIVE_STATE
 
     def is_sto_abnormal_latched(
@@ -868,7 +838,6 @@ class Configuration(Homing, Feedbacks):
         Returns:
             STOAbnormalLatchedStatus: STO Abnormal Latch state.
         """
-        self.mc._get_drive(servo)
         sto_status = self.get_sto_status(servo, axis)
         if bool(sto_status & self.STO_ABNORMAL_FAULT_BIT):
             if self.is_sto1_active(servo, axis) != self.is_sto2_active(servo, axis):
@@ -889,7 +858,6 @@ class Configuration(Homing, Feedbacks):
             ``True`` if STO is in abnormal fault, else ``False``.
 
         """
-        self.mc._get_drive(servo)
         return bool(self.get_sto_status(servo, axis) & self.STO_ABNORMAL_FAULT_BIT)
 
     def change_tcp_ip_parameters(
@@ -1015,7 +983,6 @@ class Configuration(Homing, Feedbacks):
             Serial numbers (COCO, MOCO).
 
         """
-        self.mc._get_drive(servo)
         prod_codes: list[Optional[int]] = [None, None]
         rev_numbers: list[Optional[int]] = [None, None]
         fw_versions: list[Optional[str]] = [None, None]
@@ -1078,7 +1045,6 @@ class Configuration(Homing, Feedbacks):
         Raises:
             TypeError: If some read value has a wrong type.
         """
-        self.mc._get_drive(servo)
         product_code_register = self.PRODUCT_ID_REGISTERS[self.get_subnode_type(axis)]
         product_code_value = self.mc.communication.get_register(
             product_code_register, servo, axis=axis
@@ -1100,7 +1066,6 @@ class Configuration(Homing, Feedbacks):
         Raises:
             TypeError: If some read value has a wrong type.
         """
-        self.mc._get_drive(servo)
         revision_number_register = self.REVISION_NUMBER_REGISTERS[self.get_subnode_type(axis)]
         revision_number_value = self.mc.communication.get_register(
             revision_number_register, servo, axis=axis
@@ -1122,7 +1087,6 @@ class Configuration(Homing, Feedbacks):
         Raises:
             TypeError: If some read value has a wrong type.
         """
-        self.mc._get_drive(servo)
         serial_number_register = self.SERIAL_NUMBER_REGISTERS[self.get_subnode_type(axis)]
         serial_number_value = self.mc.communication.get_register(
             serial_number_register, servo, axis=axis
@@ -1144,7 +1108,6 @@ class Configuration(Homing, Feedbacks):
         Raises:
             TypeError: If some read value has a wrong type.
         """
-        self.mc._get_drive(servo)
         fw_register = self.SOFTWARE_VERSION_REGISTERS[self.get_subnode_type(axis)]
         fw_value = self.mc.communication.get_register(fw_register, servo, axis=axis)
         if not isinstance(fw_value, str):
@@ -1165,7 +1128,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If the read vendor ID has the wrong type.
 
         """
-        self.mc._get_drive(servo)
         register = self.VENDOR_ID_COCO_REGISTER if axis == 0 else self.VENDOR_ID_REGISTER
         vendor_id = self.mc.communication.get_register(register, servo, axis)
         if not isinstance(vendor_id, int):
@@ -1238,7 +1200,6 @@ class Configuration(Homing, Feedbacks):
             axis: servo axis. ``1`` by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.VELOCITY_LOOP_KP_REGISTER, kp, servo=servo, axis=axis
         )
@@ -1267,7 +1228,6 @@ class Configuration(Homing, Feedbacks):
             axis: servo axis. ``1`` by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.POSITION_LOOP_KP_REGISTER, kp, servo=servo, axis=axis
         )
@@ -1292,7 +1252,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         rated_current = self.mc.communication.get_register(
             self.RATED_CURRENT_REGISTER, servo=servo, axis=axis
         )
@@ -1314,7 +1273,6 @@ class Configuration(Homing, Feedbacks):
             axis: servo axis. ``1`` by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.RATED_CURRENT_REGISTER, rated_current, servo=servo, axis=axis
         )
@@ -1333,7 +1291,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         max_current = self.mc.communication.get_register(
             self.MAX_CURRENT_REGISTER, servo=servo, axis=axis
         )
@@ -1360,7 +1317,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         commutation_mode = self.mc.communication.get_register(
             self.COMMUTATION_MODE_REGISTER, servo, axis
         )
@@ -1383,7 +1339,6 @@ class Configuration(Homing, Feedbacks):
             axis: servo axis. ``1`` by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.COMMUTATION_MODE_REGISTER, commutation_mode, servo, axis
         )
@@ -1402,7 +1357,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         bus_voltage = self.mc.communication.get_register(self.BUS_VOLTAGE_REGISTER, servo, axis)
         if not isinstance(bus_voltage, float):
             raise TypeError("Bus voltage value has to be a float")
@@ -1423,7 +1377,6 @@ class Configuration(Homing, Feedbacks):
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         pos_to_vel_ratio = self.mc.communication.get_register(
             self.POSITION_TO_VELOCITY_RATIO_REGISTER, servo, axis
         )
@@ -1443,7 +1396,6 @@ class Configuration(Homing, Feedbacks):
             axis: servo axis. ``1`` by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.POSITION_TO_VELOCITY_RATIO_REGISTER, pos_to_vel_ratio, servo, axis
         )
@@ -1471,7 +1423,6 @@ class Configuration(Homing, Feedbacks):
             servo: servo alias to reference it. ``default`` by default.
             axis: servo axis. ``1`` by default.
         """
-        self.mc._get_drive(servo)
         arguments = [filter_type, frequency, q_factor, gain]
         registers = [
             self.FILTER_TYPE_REGISTER,

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -81,7 +81,7 @@ class MACAddressConverter:
         return mac_address_int
 
 
-class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
+class Configuration(Homing, Feedbacks):
     """Configuration."""
 
     class BrakeOverride(IntEnum):

--- a/ingeniamotion/drive_tests.py
+++ b/ingeniamotion/drive_tests.py
@@ -79,7 +79,6 @@ class DriveTests:
             TestError: In case the servo or setup configuration makes
                 impossible fulfilling the test
         """
-        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.HALLS, servo, axis, apply_changes)
 
     def incremental_encoder_1_test(
@@ -115,7 +114,6 @@ class DriveTests:
             TestError: In case the servo or setup configuration makes
                 impossible fulfilling the test
         """
-        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.QEI, servo, axis, apply_changes)
 
     def incremental_encoder_2_test(
@@ -150,7 +148,6 @@ class DriveTests:
             TestError: In case the servo or setup configuration makes
                 impossible fulfilling the test
         """
-        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.QEI2, servo, axis, apply_changes)
 
     def absolute_encoder_1_test(
@@ -160,7 +157,6 @@ class DriveTests:
 
         To know more about it see :func:`digital_halls_test`.
         """
-        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.ABS1, servo, axis, apply_changes)
 
     def absolute_encoder_2_test(
@@ -170,7 +166,6 @@ class DriveTests:
 
         To know more about it see :func:`digital_halls_test`.
         """
-        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.BISSC2, servo, axis, apply_changes)
 
     def secondary_ssi_test(
@@ -180,13 +175,11 @@ class DriveTests:
 
         To know more about it see :func:`digital_halls_test`.
         """
-        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.SSI2, servo, axis, apply_changes)
 
     def __get_feedback_test(
         self, feedback: SensorType, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS
     ) -> Feedbacks:
-        self.mc._get_drive(servo)
         return self.__sensors[feedback](self.mc, servo, axis)
 
     def __feedback_test(
@@ -245,7 +238,6 @@ class DriveTests:
                 complete the calibration.
             TypeError: If some parameter has a wrong type.
         """
-        self.mc._get_drive(servo)
         commutation = Phasing(self.mc, servo, axis)
         output = commutation.run()
         if (
@@ -283,7 +275,6 @@ class DriveTests:
                     "result_message": "Phasing process finished successfully"
                 }
         """
-        self.mc._get_drive(servo)
         phasing_check = PhasingCheck(self.mc, servo, axis)
         return phasing_check.run()
 
@@ -308,7 +299,6 @@ class DriveTests:
                     "result_message": "Phasing process finished successfully"
                 }
         """
-        self.mc._get_drive(servo)
         sto_test = STOTest(self.mc, servo, axis)
         return sto_test.run()
 
@@ -322,7 +312,6 @@ class DriveTests:
         Returns:
             Instance of Brake test. Call ``Brake.finish()`` to end the test.
         """
-        self.mc._get_drive(servo)
         brake_test = Brake(self.mc, servo, axis)
         brake_test.run()
         return brake_test
@@ -365,7 +354,6 @@ class DriveTests:
                 impossible fulfilling the test
             TypeError: If some parameter has a wrong type.
         """
-        self.mc._get_drive(servo)
         dc_feedback_polarity_test = DCFeedbacksPolarityTest(self.mc, feedback, servo, axis)
         output = dc_feedback_polarity_test.run()
         if (
@@ -428,7 +416,6 @@ class DriveTests:
             TestError: In case the servo or setup configuration makes
                 impossible fulfilling the test
         """
-        self.mc._get_drive(servo)
         dc_feedback_resolution_test = DCFeedbacksResolutionTest(
             self.mc, feedback, servo, axis, kp=kp, ki=ki, kd=kd
         )

--- a/ingeniamotion/drive_tests.py
+++ b/ingeniamotion/drive_tests.py
@@ -79,6 +79,7 @@ class DriveTests:
             TestError: In case the servo or setup configuration makes
                 impossible fulfilling the test
         """
+        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.HALLS, servo, axis, apply_changes)
 
     def incremental_encoder_1_test(
@@ -114,6 +115,7 @@ class DriveTests:
             TestError: In case the servo or setup configuration makes
                 impossible fulfilling the test
         """
+        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.QEI, servo, axis, apply_changes)
 
     def incremental_encoder_2_test(
@@ -148,6 +150,7 @@ class DriveTests:
             TestError: In case the servo or setup configuration makes
                 impossible fulfilling the test
         """
+        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.QEI2, servo, axis, apply_changes)
 
     def absolute_encoder_1_test(
@@ -157,6 +160,7 @@ class DriveTests:
 
         To know more about it see :func:`digital_halls_test`.
         """
+        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.ABS1, servo, axis, apply_changes)
 
     def absolute_encoder_2_test(
@@ -166,6 +170,7 @@ class DriveTests:
 
         To know more about it see :func:`digital_halls_test`.
         """
+        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.BISSC2, servo, axis, apply_changes)
 
     def secondary_ssi_test(
@@ -175,11 +180,13 @@ class DriveTests:
 
         To know more about it see :func:`digital_halls_test`.
         """
+        self.mc._get_drive(servo)
         return self.__feedback_test(SensorType.SSI2, servo, axis, apply_changes)
 
     def __get_feedback_test(
         self, feedback: SensorType, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS
     ) -> Feedbacks:
+        self.mc._get_drive(servo)
         return self.__sensors[feedback](self.mc, servo, axis)
 
     def __feedback_test(
@@ -238,6 +245,7 @@ class DriveTests:
                 complete the calibration.
             TypeError: If some parameter has a wrong type.
         """
+        self.mc._get_drive(servo)
         commutation = Phasing(self.mc, servo, axis)
         output = commutation.run()
         if (
@@ -275,6 +283,7 @@ class DriveTests:
                     "result_message": "Phasing process finished successfully"
                 }
         """
+        self.mc._get_drive(servo)
         phasing_check = PhasingCheck(self.mc, servo, axis)
         return phasing_check.run()
 
@@ -299,6 +308,7 @@ class DriveTests:
                     "result_message": "Phasing process finished successfully"
                 }
         """
+        self.mc._get_drive(servo)
         sto_test = STOTest(self.mc, servo, axis)
         return sto_test.run()
 
@@ -312,6 +322,7 @@ class DriveTests:
         Returns:
             Instance of Brake test. Call ``Brake.finish()`` to end the test.
         """
+        self.mc._get_drive(servo)
         brake_test = Brake(self.mc, servo, axis)
         brake_test.run()
         return brake_test
@@ -354,6 +365,7 @@ class DriveTests:
                 impossible fulfilling the test
             TypeError: If some parameter has a wrong type.
         """
+        self.mc._get_drive(servo)
         dc_feedback_polarity_test = DCFeedbacksPolarityTest(self.mc, feedback, servo, axis)
         output = dc_feedback_polarity_test.run()
         if (
@@ -416,6 +428,7 @@ class DriveTests:
             TestError: In case the servo or setup configuration makes
                 impossible fulfilling the test
         """
+        self.mc._get_drive(servo)
         dc_feedback_resolution_test = DCFeedbacksResolutionTest(
             self.mc, feedback, servo, axis, kp=kp, ki=ki, kd=kd
         )

--- a/ingeniamotion/drive_tests.py
+++ b/ingeniamotion/drive_tests.py
@@ -6,7 +6,7 @@ from ingeniamotion.enums import SensorType, SeverityLevel
 
 if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
-from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
+from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 from ingeniamotion.wizard_tests.brake import Brake
 from ingeniamotion.wizard_tests.feedbacks_tests.absolute_encoder1_test import AbsoluteEncoder1Test
 from ingeniamotion.wizard_tests.feedbacks_tests.absolute_encoder2_test import AbsoluteEncoder2Test
@@ -30,7 +30,7 @@ from ingeniamotion.wizard_tests.phasing_check import PhasingCheck
 from ingeniamotion.wizard_tests.sto import STOTest
 
 
-class DriveTests(metaclass=MCMetaClass):
+class DriveTests:
     """Class that contain the tests that can be performed on a drive."""
 
     __sensors = {

--- a/ingeniamotion/errors.py
+++ b/ingeniamotion/errors.py
@@ -126,7 +126,6 @@ class Errors:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         error_version = self.__get_error_location(servo)
         subnode, error_location = self.__get_error_subnode(error_version, axis)
         error = self.mc.communication.get_register(
@@ -184,7 +183,6 @@ class Errors:
             ValueError: Index must be less than 32
             TypeError: If some read value has a wrong type.
         """
-        self.mc._get_drive(servo)
         if index >= self.MAXIMUM_ERROR_INDEX:
             raise ValueError("index must be less than 32")
         error_version = self.__get_error_location(servo)
@@ -215,7 +213,6 @@ class Errors:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         error_version = self.__get_error_location(servo)
         subnode, error_location = self.__get_error_subnode(error_version, axis)
         total_number_errors = self.mc.communication.get_register(
@@ -237,7 +234,6 @@ class Errors:
         Returns:
             List of all errors.
         """
-        self.mc._get_drive(servo)
         err_list = []
         err_num = self.get_number_total_errors(servo, axis)
         err_num = min(err_num, self.MAXIMUM_ERROR_INDEX)
@@ -256,7 +252,6 @@ class Errors:
         Returns:
             ``True`` if fault is active, else ``False``.
         """
-        self.mc._get_drive(servo)
         status_word = self.mc.configuration.get_status_word(servo=servo, axis=axis)
         return bool(status_word & self.STATUS_WORD_FAULT_BIT)
 
@@ -270,7 +265,6 @@ class Errors:
         Returns:
             ``True`` if warning is active, else ``False``.
         """
-        self.mc._get_drive(servo)
         status_word = self.mc.configuration.get_status_word(servo=servo, axis=axis)
         return bool(status_word & self.STATUS_WORD_WARNING_BIT)
 

--- a/ingeniamotion/errors.py
+++ b/ingeniamotion/errors.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING, Optional
 if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
 
-from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
+from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 
-class Errors(metaclass=MCMetaClass):
+class Errors:
     """Errors."""
 
     class ErrorLocation(IntEnum):

--- a/ingeniamotion/errors.py
+++ b/ingeniamotion/errors.py
@@ -126,6 +126,7 @@ class Errors:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         error_version = self.__get_error_location(servo)
         subnode, error_location = self.__get_error_subnode(error_version, axis)
         error = self.mc.communication.get_register(
@@ -183,6 +184,7 @@ class Errors:
             ValueError: Index must be less than 32
             TypeError: If some read value has a wrong type.
         """
+        self.mc._get_drive(servo)
         if index >= self.MAXIMUM_ERROR_INDEX:
             raise ValueError("index must be less than 32")
         error_version = self.__get_error_location(servo)
@@ -213,6 +215,7 @@ class Errors:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         error_version = self.__get_error_location(servo)
         subnode, error_location = self.__get_error_subnode(error_version, axis)
         total_number_errors = self.mc.communication.get_register(
@@ -234,6 +237,7 @@ class Errors:
         Returns:
             List of all errors.
         """
+        self.mc._get_drive(servo)
         err_list = []
         err_num = self.get_number_total_errors(servo, axis)
         err_num = min(err_num, self.MAXIMUM_ERROR_INDEX)
@@ -252,6 +256,7 @@ class Errors:
         Returns:
             ``True`` if fault is active, else ``False``.
         """
+        self.mc._get_drive(servo)
         status_word = self.mc.configuration.get_status_word(servo=servo, axis=axis)
         return bool(status_word & self.STATUS_WORD_FAULT_BIT)
 
@@ -265,6 +270,7 @@ class Errors:
         Returns:
             ``True`` if warning is active, else ``False``.
         """
+        self.mc._get_drive(servo)
         status_word = self.mc.configuration.get_status_word(servo=servo, axis=axis)
         return bool(status_word & self.STATUS_WORD_WARNING_BIT)
 
@@ -292,6 +298,6 @@ class Errors:
             KeyError: The error codes does not exist in the error's dictionary.
 
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         dictionary_errors = drive.errors[error_code & self.ERROR_CODE_BITS]
         return tuple(dictionary_errors)  # type: ignore[return-value]

--- a/ingeniamotion/feedbacks.py
+++ b/ingeniamotion/feedbacks.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
 
 
-class Feedbacks(metaclass=MCMetaClass):
+class Feedbacks:
     """Feedbacks Wizard Class description."""
 
     __feedback_type_dict = {

--- a/ingeniamotion/feedbacks.py
+++ b/ingeniamotion/feedbacks.py
@@ -67,7 +67,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         commutation_feedback = self.mc.communication.get_register(
             self.COMMUTATION_FEEDBACK_REGISTER, servo=servo, axis=axis
         )
@@ -108,7 +107,6 @@ class Feedbacks:
         Returns:
             Category {ABSOLUTE, INCREMENTAL} of the selected feedback.
         """
-        self.mc._get_drive(servo)
         commutation_feedback = self.get_commutation_feedback(servo, axis)
         return self.__feedback_type_dict[commutation_feedback]
 
@@ -124,7 +122,6 @@ class Feedbacks:
         Returns:
             Resolution of the selected feedback.
         """
-        self.mc._get_drive(servo)
         sensor_type = self.get_commutation_feedback(servo, axis)
         return self.feedback_resolution_functions[sensor_type](servo, axis)
 
@@ -145,7 +142,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         reference_feedback = self.mc.communication.get_register(
             self.REFERENCE_FEEDBACK_REGISTER, servo=servo, axis=axis
         )
@@ -186,7 +182,6 @@ class Feedbacks:
         Returns:
             Category {ABSOLUTE, INCREMENTAL} of the selected feedback.
         """
-        self.mc._get_drive(servo)
         reference_feedback = self.get_reference_feedback(servo, axis)
         return self.__feedback_type_dict[reference_feedback]
 
@@ -202,7 +197,6 @@ class Feedbacks:
         Returns:
             Resolution of the selected feedback.
         """
-        self.mc._get_drive(servo)
         sensor_type = self.get_reference_feedback(servo, axis)
         return self.feedback_resolution_functions[sensor_type](servo, axis)
 
@@ -223,7 +217,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         velocity_feedback = self.mc.communication.get_register(
             self.VELOCITY_FEEDBACK_REGISTER, servo=servo, axis=axis
         )
@@ -245,7 +238,6 @@ class Feedbacks:
         Raises:
             IMStatusWordError: If motor is enabled.
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.VELOCITY_FEEDBACK_REGISTER, feedback, servo=servo, axis=axis
         )
@@ -265,7 +257,6 @@ class Feedbacks:
         Returns:
             Category {ABSOLUTE, INCREMENTAL} of the selected feedback.
         """
-        self.mc._get_drive(servo)
         velocity_feedback = self.get_velocity_feedback(servo, axis)
         return self.__feedback_type_dict[velocity_feedback]
 
@@ -281,7 +272,6 @@ class Feedbacks:
         Returns:
             Resolution of the selected feedback.
         """
-        self.mc._get_drive(servo)
         sensor_type = self.get_velocity_feedback(servo, axis)
         return self.feedback_resolution_functions[sensor_type](servo, axis)
 
@@ -302,7 +292,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         position_feedback = self.mc.communication.get_register(
             self.POSITION_FEEDBACK_REGISTER, servo=servo, axis=axis
         )
@@ -343,7 +332,6 @@ class Feedbacks:
         Returns:
             Category {ABSOLUTE, INCREMENTAL} of the selected feedback.
         """
-        self.mc._get_drive(servo)
         position_feedback = self.get_position_feedback(servo, axis)
         return self.__feedback_type_dict[position_feedback]
 
@@ -359,7 +347,6 @@ class Feedbacks:
         Returns:
             Resolution of the selected feedback.
         """
-        self.mc._get_drive(servo)
         sensor_type = self.get_position_feedback(servo, axis)
         return self.feedback_resolution_functions[sensor_type](servo, axis)
 
@@ -380,7 +367,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         auxiliar_feedback = self.mc.communication.get_register(
             self.AUXILIAR_FEEDBACK_REGISTER, servo=servo, axis=axis
         )
@@ -421,7 +407,6 @@ class Feedbacks:
         Returns:
             Category {ABSOLUTE, INCREMENTAL} of the selected feedback.
         """
-        self.mc._get_drive(servo)
         auxiliar_feedback = self.get_auxiliar_feedback(servo, axis)
         return self.__feedback_type_dict[auxiliar_feedback]
 
@@ -437,7 +422,6 @@ class Feedbacks:
         Returns:
             Resolution of the selected feedback.
         """
-        self.mc._get_drive(servo)
         sensor_type = self.get_auxiliar_feedback(servo, axis)
         return self.feedback_resolution_functions[sensor_type](servo, axis)
 
@@ -457,7 +441,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         single_turn_bits = self.mc.communication.get_register(
             "FBK_BISS1_SSI1_POS_ST_BITS", servo=servo, axis=axis
         )
@@ -484,7 +467,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         resolution = self.mc.communication.get_register(
             "FBK_DIGENC1_RESOLUTION", servo=servo, axis=axis
         )
@@ -508,7 +490,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         pair_poles = self.mc.communication.get_register(
             "FBK_DIGHALL_PAIRPOLES", servo=servo, axis=axis
         )
@@ -533,7 +514,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         secondary_single_turn_bits = self.mc.communication.get_register(
             "FBK_SSI2_POS_ST_BITS", servo=servo, axis=axis
         )
@@ -558,7 +538,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         serial_slave_1_single_turn_bits = self.mc.communication.get_register(
             "FBK_BISS2_POS_ST_BITS", servo=servo, axis=axis
         )
@@ -583,7 +562,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         resolution = self.mc.communication.get_register(
             "FBK_DIGENC2_RESOLUTION", servo=servo, axis=axis
         )
@@ -625,7 +603,6 @@ class Feedbacks:
         Returns:
             Resolution of target feedback.
         """
-        self.mc._get_drive(servo)
         return self.feedback_resolution_functions[feedback](servo, axis)
 
     def get_feedback_polarity_register_uid(self, feedback: SensorType) -> str:
@@ -659,7 +636,6 @@ class Feedbacks:
             axis: axis that will run the test. ``1`` by default.
 
         """
-        self.mc._get_drive(servo)
         polarity_register = self.get_feedback_polarity_register_uid(feedback)
         self.mc.communication.set_register(polarity_register, polarity, servo=servo, axis=axis)
         self.logger.debug(
@@ -688,7 +664,6 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         polarity_register = self.get_feedback_polarity_register_uid(feedback)
         raw_polarity = self.mc.communication.get_register(polarity_register, servo=servo, axis=axis)
         if not isinstance(raw_polarity, int):

--- a/ingeniamotion/feedbacks.py
+++ b/ingeniamotion/feedbacks.py
@@ -67,6 +67,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         commutation_feedback = self.mc.communication.get_register(
             self.COMMUTATION_FEEDBACK_REGISTER, servo=servo, axis=axis
         )
@@ -107,6 +108,7 @@ class Feedbacks:
         Returns:
             Category {ABSOLUTE, INCREMENTAL} of the selected feedback.
         """
+        self.mc._get_drive(servo)
         commutation_feedback = self.get_commutation_feedback(servo, axis)
         return self.__feedback_type_dict[commutation_feedback]
 
@@ -122,6 +124,7 @@ class Feedbacks:
         Returns:
             Resolution of the selected feedback.
         """
+        self.mc._get_drive(servo)
         sensor_type = self.get_commutation_feedback(servo, axis)
         return self.feedback_resolution_functions[sensor_type](servo, axis)
 
@@ -142,6 +145,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         reference_feedback = self.mc.communication.get_register(
             self.REFERENCE_FEEDBACK_REGISTER, servo=servo, axis=axis
         )
@@ -182,6 +186,7 @@ class Feedbacks:
         Returns:
             Category {ABSOLUTE, INCREMENTAL} of the selected feedback.
         """
+        self.mc._get_drive(servo)
         reference_feedback = self.get_reference_feedback(servo, axis)
         return self.__feedback_type_dict[reference_feedback]
 
@@ -197,6 +202,7 @@ class Feedbacks:
         Returns:
             Resolution of the selected feedback.
         """
+        self.mc._get_drive(servo)
         sensor_type = self.get_reference_feedback(servo, axis)
         return self.feedback_resolution_functions[sensor_type](servo, axis)
 
@@ -217,6 +223,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         velocity_feedback = self.mc.communication.get_register(
             self.VELOCITY_FEEDBACK_REGISTER, servo=servo, axis=axis
         )
@@ -238,6 +245,7 @@ class Feedbacks:
         Raises:
             IMStatusWordError: If motor is enabled.
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.VELOCITY_FEEDBACK_REGISTER, feedback, servo=servo, axis=axis
         )
@@ -257,6 +265,7 @@ class Feedbacks:
         Returns:
             Category {ABSOLUTE, INCREMENTAL} of the selected feedback.
         """
+        self.mc._get_drive(servo)
         velocity_feedback = self.get_velocity_feedback(servo, axis)
         return self.__feedback_type_dict[velocity_feedback]
 
@@ -272,6 +281,7 @@ class Feedbacks:
         Returns:
             Resolution of the selected feedback.
         """
+        self.mc._get_drive(servo)
         sensor_type = self.get_velocity_feedback(servo, axis)
         return self.feedback_resolution_functions[sensor_type](servo, axis)
 
@@ -292,6 +302,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         position_feedback = self.mc.communication.get_register(
             self.POSITION_FEEDBACK_REGISTER, servo=servo, axis=axis
         )
@@ -332,6 +343,7 @@ class Feedbacks:
         Returns:
             Category {ABSOLUTE, INCREMENTAL} of the selected feedback.
         """
+        self.mc._get_drive(servo)
         position_feedback = self.get_position_feedback(servo, axis)
         return self.__feedback_type_dict[position_feedback]
 
@@ -347,6 +359,7 @@ class Feedbacks:
         Returns:
             Resolution of the selected feedback.
         """
+        self.mc._get_drive(servo)
         sensor_type = self.get_position_feedback(servo, axis)
         return self.feedback_resolution_functions[sensor_type](servo, axis)
 
@@ -367,6 +380,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         auxiliar_feedback = self.mc.communication.get_register(
             self.AUXILIAR_FEEDBACK_REGISTER, servo=servo, axis=axis
         )
@@ -407,6 +421,7 @@ class Feedbacks:
         Returns:
             Category {ABSOLUTE, INCREMENTAL} of the selected feedback.
         """
+        self.mc._get_drive(servo)
         auxiliar_feedback = self.get_auxiliar_feedback(servo, axis)
         return self.__feedback_type_dict[auxiliar_feedback]
 
@@ -422,6 +437,7 @@ class Feedbacks:
         Returns:
             Resolution of the selected feedback.
         """
+        self.mc._get_drive(servo)
         sensor_type = self.get_auxiliar_feedback(servo, axis)
         return self.feedback_resolution_functions[sensor_type](servo, axis)
 
@@ -441,6 +457,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         single_turn_bits = self.mc.communication.get_register(
             "FBK_BISS1_SSI1_POS_ST_BITS", servo=servo, axis=axis
         )
@@ -467,6 +484,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         resolution = self.mc.communication.get_register(
             "FBK_DIGENC1_RESOLUTION", servo=servo, axis=axis
         )
@@ -490,6 +508,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         pair_poles = self.mc.communication.get_register(
             "FBK_DIGHALL_PAIRPOLES", servo=servo, axis=axis
         )
@@ -514,6 +533,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         secondary_single_turn_bits = self.mc.communication.get_register(
             "FBK_SSI2_POS_ST_BITS", servo=servo, axis=axis
         )
@@ -538,6 +558,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         serial_slave_1_single_turn_bits = self.mc.communication.get_register(
             "FBK_BISS2_POS_ST_BITS", servo=servo, axis=axis
         )
@@ -562,6 +583,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         resolution = self.mc.communication.get_register(
             "FBK_DIGENC2_RESOLUTION", servo=servo, axis=axis
         )
@@ -603,6 +625,7 @@ class Feedbacks:
         Returns:
             Resolution of target feedback.
         """
+        self.mc._get_drive(servo)
         return self.feedback_resolution_functions[feedback](servo, axis)
 
     def get_feedback_polarity_register_uid(self, feedback: SensorType) -> str:
@@ -636,6 +659,7 @@ class Feedbacks:
             axis: axis that will run the test. ``1`` by default.
 
         """
+        self.mc._get_drive(servo)
         polarity_register = self.get_feedback_polarity_register_uid(feedback)
         self.mc.communication.set_register(polarity_register, polarity, servo=servo, axis=axis)
         self.logger.debug(
@@ -664,6 +688,7 @@ class Feedbacks:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         polarity_register = self.get_feedback_polarity_register_uid(feedback)
         raw_polarity = self.mc.communication.get_register(polarity_register, servo=servo, axis=axis)
         if not isinstance(raw_polarity, int):

--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -388,6 +388,7 @@ class FSoEMaster:
             fsoe_master_watchdog_timeout: The FSoE master watchdog timeout in seconds.
 
         """
+        self.__mc._get_drive(servo)
         slave_address = self.get_safety_address(servo)
         application_parameters = self._get_application_parameters(servo)
         master_handler = FSoEMasterHandler(
@@ -440,6 +441,7 @@ class FSoEMaster:
             servo: servo alias to reference it. ``default`` by default.
 
         """
+        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         master_handler.sto_deactivate()
 
@@ -450,6 +452,7 @@ class FSoEMaster:
             servo: servo alias to reference it. ``default`` by default.
 
         """
+        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         master_handler.sto_activate()
 
@@ -460,6 +463,7 @@ class FSoEMaster:
             servo: servo alias to reference it. ``default`` by default.
 
         """
+        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         master_handler.ss1_deactivate()
 
@@ -470,6 +474,7 @@ class FSoEMaster:
             servo: servo alias to reference it. ``default`` by default.
 
         """
+        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         master_handler.ss1_activate()
 
@@ -483,6 +488,7 @@ class FSoEMaster:
            The safe inputs value.
 
         """
+        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         return master_handler.safe_inputs_value()
 
@@ -496,7 +502,7 @@ class FSoEMaster:
             The FSoE slave address.
 
         """
-        drive = self.__mc.servos[servo]
+        drive = self.__mc._get_drive(servo)
         value = drive.read(self.SAFETY_ADDRESS_REGISTER)
         if not isinstance(value, int):
             raise ValueError(f"Wrong safety address value type. Expected int, got {type(value)}")
@@ -510,7 +516,7 @@ class FSoEMaster:
             servo: servo alias to reference it. ``default`` by default.
 
         """
-        drive = self.__mc.servos[servo]
+        drive = self.__mc._get_drive(servo)
         drive.write(self.SAFETY_ADDRESS_REGISTER, data=address)
 
     def check_sto_active(self, servo: str = DEFAULT_SERVO) -> bool:
@@ -523,6 +529,7 @@ class FSoEMaster:
             True if the STO is active. False otherwise.
 
         """
+        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         return master_handler.is_sto_active()
 
@@ -538,6 +545,7 @@ class FSoEMaster:
                 ``None`` by default.
 
         """
+        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         master_handler.wait_for_data_state(timeout)
 
@@ -551,6 +559,7 @@ class FSoEMaster:
             The servo's FSoE master handler state.
 
         """
+        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         return master_handler.state
 

--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -388,7 +388,6 @@ class FSoEMaster:
             fsoe_master_watchdog_timeout: The FSoE master watchdog timeout in seconds.
 
         """
-        self.__mc._get_drive(servo)
         slave_address = self.get_safety_address(servo)
         application_parameters = self._get_application_parameters(servo)
         master_handler = FSoEMasterHandler(
@@ -441,7 +440,6 @@ class FSoEMaster:
             servo: servo alias to reference it. ``default`` by default.
 
         """
-        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         master_handler.sto_deactivate()
 
@@ -452,7 +450,6 @@ class FSoEMaster:
             servo: servo alias to reference it. ``default`` by default.
 
         """
-        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         master_handler.sto_activate()
 
@@ -463,7 +460,6 @@ class FSoEMaster:
             servo: servo alias to reference it. ``default`` by default.
 
         """
-        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         master_handler.ss1_deactivate()
 
@@ -474,7 +470,6 @@ class FSoEMaster:
             servo: servo alias to reference it. ``default`` by default.
 
         """
-        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         master_handler.ss1_activate()
 
@@ -488,7 +483,6 @@ class FSoEMaster:
            The safe inputs value.
 
         """
-        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         return master_handler.safe_inputs_value()
 
@@ -529,7 +523,6 @@ class FSoEMaster:
             True if the STO is active. False otherwise.
 
         """
-        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         return master_handler.is_sto_active()
 
@@ -545,7 +538,6 @@ class FSoEMaster:
                 ``None`` by default.
 
         """
-        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         master_handler.wait_for_data_state(timeout)
 
@@ -559,7 +551,6 @@ class FSoEMaster:
             The servo's FSoE master handler state.
 
         """
-        self.__mc._get_drive(servo)
         master_handler = self.__handlers[servo]
         return master_handler.state
 

--- a/ingeniamotion/homing.py
+++ b/ingeniamotion/homing.py
@@ -35,7 +35,7 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
-        self.__mc._get_drive(servo)
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(self.HOMING_MODE_REGISTER, homing_mode, servo, axis)
 
     def set_homing_offset(
@@ -48,7 +48,7 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
-        self.__mc._get_drive(servo)
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(self.HOMING_OFFSET_REGISTER, homing_offset, servo, axis)
 
     def set_homing_timeout(
@@ -61,7 +61,7 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
-        self.__mc._get_drive(servo)
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(self.HOMING_TIMEOUT_REGISTER, timeout_ms, servo, axis)
 
     def __check_motor_phasing(self, servo: str, axis: int) -> None:
@@ -82,7 +82,7 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
-        self.__mc._get_drive(servo)
+        self.mc._get_drive(servo)
         # Save previous mode
         prev_op_mode = self.mc.motion.get_operation_mode(servo, axis)
 
@@ -126,7 +126,7 @@ class Homing:
             motor_enable : if ``True`` do motor enable. ``True`` by default.
 
         """
-        self.__mc._get_drive(servo)
+        self.mc._get_drive(servo)
         self.mc.motion.set_operation_mode(OperationMode.HOMING, servo, axis)
         if direction > 0:
             # Positive direction
@@ -181,7 +181,7 @@ class Homing:
             axis : servo axis. ``1`` by default.
             motor_enable : if ``True`` do motor enable. ``True`` by default.
         """
-        self.__mc._get_drive(servo)
+        self.mc._get_drive(servo)
         self.mc.motion.set_operation_mode(OperationMode.HOMING, servo, axis)
         if direction > 0:
             # Positive direction
@@ -234,7 +234,7 @@ class Homing:
             axis : servo axis. ``1`` by default.
             motor_enable : if ``True`` do motor enable. ``True`` by default.
         """
-        self.__mc._get_drive(servo)
+        self.mc._get_drive(servo)
         self.mc.motion.set_operation_mode(OperationMode.HOMING, servo, axis)
         if direction > 0:
             # Positive direction

--- a/ingeniamotion/homing.py
+++ b/ingeniamotion/homing.py
@@ -35,7 +35,6 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(self.HOMING_MODE_REGISTER, homing_mode, servo, axis)
 
     def set_homing_offset(
@@ -48,7 +47,6 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(self.HOMING_OFFSET_REGISTER, homing_offset, servo, axis)
 
     def set_homing_timeout(
@@ -61,7 +59,6 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(self.HOMING_TIMEOUT_REGISTER, timeout_ms, servo, axis)
 
     def __check_motor_phasing(self, servo: str, axis: int) -> None:
@@ -82,7 +79,6 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
-        self.mc._get_drive(servo)
         # Save previous mode
         prev_op_mode = self.mc.motion.get_operation_mode(servo, axis)
 
@@ -126,7 +122,6 @@ class Homing:
             motor_enable : if ``True`` do motor enable. ``True`` by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.motion.set_operation_mode(OperationMode.HOMING, servo, axis)
         if direction > 0:
             # Positive direction
@@ -181,7 +176,6 @@ class Homing:
             axis : servo axis. ``1`` by default.
             motor_enable : if ``True`` do motor enable. ``True`` by default.
         """
-        self.mc._get_drive(servo)
         self.mc.motion.set_operation_mode(OperationMode.HOMING, servo, axis)
         if direction > 0:
             # Positive direction
@@ -234,7 +228,6 @@ class Homing:
             axis : servo axis. ``1`` by default.
             motor_enable : if ``True`` do motor enable. ``True`` by default.
         """
-        self.mc._get_drive(servo)
         self.mc.motion.set_operation_mode(OperationMode.HOMING, servo, axis)
         if direction > 0:
             # Positive direction

--- a/ingeniamotion/homing.py
+++ b/ingeniamotion/homing.py
@@ -6,10 +6,10 @@ from ingeniamotion.enums import HomingMode, OperationMode
 
 if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
-from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
+from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 
-class Homing(metaclass=MCMetaClass):
+class Homing:
     """Class that contains the homing functionalities."""
 
     HOMING_MODE_REGISTER = "HOM_MODE"

--- a/ingeniamotion/homing.py
+++ b/ingeniamotion/homing.py
@@ -35,6 +35,7 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
+        self.__mc._get_drive(servo)
         self.mc.communication.set_register(self.HOMING_MODE_REGISTER, homing_mode, servo, axis)
 
     def set_homing_offset(
@@ -47,6 +48,7 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
+        self.__mc._get_drive(servo)
         self.mc.communication.set_register(self.HOMING_OFFSET_REGISTER, homing_offset, servo, axis)
 
     def set_homing_timeout(
@@ -59,6 +61,7 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
+        self.__mc._get_drive(servo)
         self.mc.communication.set_register(self.HOMING_TIMEOUT_REGISTER, timeout_ms, servo, axis)
 
     def __check_motor_phasing(self, servo: str, axis: int) -> None:
@@ -79,6 +82,7 @@ class Homing:
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
         """
+        self.__mc._get_drive(servo)
         # Save previous mode
         prev_op_mode = self.mc.motion.get_operation_mode(servo, axis)
 
@@ -122,6 +126,7 @@ class Homing:
             motor_enable : if ``True`` do motor enable. ``True`` by default.
 
         """
+        self.__mc._get_drive(servo)
         self.mc.motion.set_operation_mode(OperationMode.HOMING, servo, axis)
         if direction > 0:
             # Positive direction
@@ -176,6 +181,7 @@ class Homing:
             axis : servo axis. ``1`` by default.
             motor_enable : if ``True`` do motor enable. ``True`` by default.
         """
+        self.__mc._get_drive(servo)
         self.mc.motion.set_operation_mode(OperationMode.HOMING, servo, axis)
         if direction > 0:
             # Positive direction
@@ -228,6 +234,7 @@ class Homing:
             axis : servo axis. ``1`` by default.
             motor_enable : if ``True`` do motor enable. ``True`` by default.
         """
+        self.__mc._get_drive(servo)
         self.mc.motion.set_operation_mode(OperationMode.HOMING, servo, axis)
         if direction > 0:
             # Positive direction

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -50,7 +50,7 @@ class Information:
             IMRegisterNotExist: If register does not exist in dictionary.
 
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         try:
             return drive.dictionary.registers(axis)[register]
         except KeyError:
@@ -76,6 +76,7 @@ class Information:
             IMRegisterNotExist: If register does not exist in dictionary.
 
         """
+        self.mc._get_drive(servo)
         register_obj = self.register_info(register, axis=axis, servo=servo)
         return register_obj.dtype
 
@@ -99,6 +100,7 @@ class Information:
             IMRegisterNotExist: If register does not exist in dictionary.
 
         """
+        self.mc._get_drive(servo)
         register_obj = self.register_info(register, axis=axis, servo=servo)
         return register_obj.access
 
@@ -122,6 +124,7 @@ class Information:
             IMRegisterNotExist: If register does not exist in dictionary.
 
         """
+        self.mc._get_drive(servo)
         register_obj = self.register_info(register, axis=axis, servo=servo)
         return register_obj.range
 
@@ -142,7 +145,7 @@ class Information:
             ``True`` if register exists, else ``False``.
 
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         return register in drive.dictionary.registers(axis)
 
     def get_product_name(self, servo: str = DEFAULT_SERVO) -> Optional[str]:
@@ -154,7 +157,7 @@ class Information:
         Returns:
             If it exists for example: "EVE-NET-E", "CAP-NET-E", etc.
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         product_name = drive.dictionary.part_number
         if self.is_comkit(servo):
             return f"{product_name} + {self.PART_NUMBER_COMKIT}"
@@ -169,8 +172,8 @@ class Information:
         Returns:
             Node ID of the drive.
         """
+        drive = self.mc._get_drive(servo)
         net = self.mc._get_network(servo)
-        drive = self.mc.servos[servo]
         if isinstance(net, CanopenNetwork):
             return int(drive.target)
         else:
@@ -185,6 +188,7 @@ class Information:
         Returns:
             Baudrate of the drive.
         """
+        self.mc._get_drive(servo)
         net = self.mc._get_network(servo)
         if isinstance(net, CanopenNetwork):
             return CanBaudrate(net.baudrate)
@@ -199,8 +203,8 @@ class Information:
         Returns:
             IP of the drive.
         """
+        drive = self.mc._get_drive(servo)
         net = self.mc._get_network(servo)
-        drive = self.mc.servos[servo]
         if isinstance(net, EthernetNetwork):
             return str(drive.target)
         else:
@@ -216,8 +220,8 @@ class Information:
             Slave ID of the servo.
 
         """
+        drive = self.mc._get_drive(servo)
         net = self.mc._get_network(servo)
-        drive = self.mc.servos[servo]
         if isinstance(net, EoENetwork) and isinstance(drive.target, str):
             return net._configured_slaves[drive.target]
         elif isinstance(net, EthercatNetwork) and isinstance(drive.target, int):
@@ -233,7 +237,7 @@ class Information:
         Returns:
             The name of the drive.
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         drive_name = drive.name
         return f"{drive_name}"
 
@@ -265,6 +269,7 @@ class Information:
         Returns:
             Full name.
         """
+        self.mc._get_drive(servo)
         prod_name = self.get_product_name(servo)
         name = self.get_name(servo)
         full_name = f"{prod_name} - {name}"
@@ -283,7 +288,7 @@ class Information:
         Returns:
             Dictionary of subnode ids and their type.
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         return drive.subnodes
 
     def get_categories(self, servo: str = DEFAULT_SERVO) -> dict[str, str]:
@@ -295,7 +300,7 @@ class Information:
         Returns:
             Categories instance.
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         dictionary_categories = drive.dictionary.categories
         if not dictionary_categories:
             raise IMException("Dictionary categories are not defined.")
@@ -314,7 +319,7 @@ class Information:
         Returns:
             Dictionary file name.
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         return str(os.path.basename(drive.dictionary.path))
 
     def get_encoded_image_from_dictionary(self, servo: str = DEFAULT_SERVO) -> Optional[str]:
@@ -329,7 +334,7 @@ class Information:
         Returns:
             The encoded image or NoneType object.
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         return drive.dictionary.image
 
     def is_comkit(self, servo: str = DEFAULT_SERVO) -> bool:
@@ -342,5 +347,5 @@ class Information:
             True if using COM-KIT, False otherwise.
 
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         return drive.dictionary.coco_product_code == self.PRODUCT_CODE_COMKIT

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -76,7 +76,6 @@ class Information:
             IMRegisterNotExist: If register does not exist in dictionary.
 
         """
-        self.mc._get_drive(servo)
         register_obj = self.register_info(register, axis=axis, servo=servo)
         return register_obj.dtype
 
@@ -100,7 +99,6 @@ class Information:
             IMRegisterNotExist: If register does not exist in dictionary.
 
         """
-        self.mc._get_drive(servo)
         register_obj = self.register_info(register, axis=axis, servo=servo)
         return register_obj.access
 
@@ -124,7 +122,6 @@ class Information:
             IMRegisterNotExist: If register does not exist in dictionary.
 
         """
-        self.mc._get_drive(servo)
         register_obj = self.register_info(register, axis=axis, servo=servo)
         return register_obj.range
 
@@ -188,7 +185,6 @@ class Information:
         Returns:
             Baudrate of the drive.
         """
-        self.mc._get_drive(servo)
         net = self.mc._get_network(servo)
         if isinstance(net, CanopenNetwork):
             return CanBaudrate(net.baudrate)
@@ -269,7 +265,6 @@ class Information:
         Returns:
             Full name.
         """
-        self.mc._get_drive(servo)
         prod_name = self.get_product_name(servo)
         name = self.get_name(servo)
         full_name = f"{prod_name} - {name}"

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -13,7 +13,7 @@ from ingenialink.register import Register
 
 from ingeniamotion.enums import COMMUNICATION_TYPE
 from ingeniamotion.exceptions import IMException, IMRegisterNotExist
-from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
+from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = ingenialogger.get_logger(__name__)
 
 
-class Information(metaclass=MCMetaClass):
+class Information:
     """Information."""
 
     PRODUCT_CODE_COMKIT = 0x3214001

--- a/ingeniamotion/input_output.py
+++ b/ingeniamotion/input_output.py
@@ -74,7 +74,6 @@ class InputsOutputs:
             Polarity of the specified GPI.
 
         """
-        self.mc._get_drive(servo)
         gpi_polarity = int(
             self.mc.communication.get_register(
                 self.GPIO_IN_POLARITY_REGISTER, servo=servo, axis=axis
@@ -99,7 +98,6 @@ class InputsOutputs:
             axis : axis that will run the test. 1 by default.
 
         """
-        self.mc._get_drive(servo)
         gpis_actual_polarity = int(
             self.mc.communication.get_register(
                 self.GPIO_IN_POLARITY_REGISTER, servo=servo, axis=axis
@@ -129,7 +127,6 @@ class InputsOutputs:
             LOW if the voltage level is 0, HIGH if the voltage level is 1.
 
         """
-        self.mc._get_drive(servo)
         gpi_value = int(
             self.mc.communication.get_register(self.GPIO_IN_VALUE_REGISTER, servo=servo, axis=axis)
         )
@@ -151,7 +148,6 @@ class InputsOutputs:
             Polarity of the specified GPI.
 
         """
-        self.mc._get_drive(servo)
         gpo_polarity = int(
             self.mc.communication.get_register(
                 self.GPIO_OUT_POLARITY_REGISTER, servo=servo, axis=axis
@@ -176,7 +172,6 @@ class InputsOutputs:
             axis : axis that will run the test. 1 by default.
 
         """
-        self.mc._get_drive(servo)
         gpos_actual_polarity = int(
             self.mc.communication.get_register(
                 self.GPIO_OUT_POLARITY_REGISTER, servo=servo, axis=axis
@@ -215,7 +210,6 @@ class InputsOutputs:
         Raise:
             IMException: if the GPOs final value does not match with the desired GPOs set point.
         """
-        self.mc._get_drive(servo)
         new_target_value = bool(voltage_level.value)
 
         gpos_previous_value = int(

--- a/ingeniamotion/input_output.py
+++ b/ingeniamotion/input_output.py
@@ -4,13 +4,13 @@ import ingenialogger
 
 from ingeniamotion.enums import GPI, GPO, DigitalVoltageLevel, GPIOPolarity
 from ingeniamotion.exceptions import IMException
-from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
+from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
 
 
-class InputsOutputs(metaclass=MCMetaClass):
+class InputsOutputs:
     """Class that contains the GPIO functionalities."""
 
     GPIO_IN_VALUE_REGISTER = "IO_IN_VALUE"

--- a/ingeniamotion/input_output.py
+++ b/ingeniamotion/input_output.py
@@ -74,6 +74,7 @@ class InputsOutputs:
             Polarity of the specified GPI.
 
         """
+        self.mc._get_drive(servo)
         gpi_polarity = int(
             self.mc.communication.get_register(
                 self.GPIO_IN_POLARITY_REGISTER, servo=servo, axis=axis
@@ -98,6 +99,7 @@ class InputsOutputs:
             axis : axis that will run the test. 1 by default.
 
         """
+        self.mc._get_drive(servo)
         gpis_actual_polarity = int(
             self.mc.communication.get_register(
                 self.GPIO_IN_POLARITY_REGISTER, servo=servo, axis=axis
@@ -127,6 +129,7 @@ class InputsOutputs:
             LOW if the voltage level is 0, HIGH if the voltage level is 1.
 
         """
+        self.mc._get_drive(servo)
         gpi_value = int(
             self.mc.communication.get_register(self.GPIO_IN_VALUE_REGISTER, servo=servo, axis=axis)
         )
@@ -148,6 +151,7 @@ class InputsOutputs:
             Polarity of the specified GPI.
 
         """
+        self.mc._get_drive(servo)
         gpo_polarity = int(
             self.mc.communication.get_register(
                 self.GPIO_OUT_POLARITY_REGISTER, servo=servo, axis=axis
@@ -172,6 +176,7 @@ class InputsOutputs:
             axis : axis that will run the test. 1 by default.
 
         """
+        self.mc._get_drive(servo)
         gpos_actual_polarity = int(
             self.mc.communication.get_register(
                 self.GPIO_OUT_POLARITY_REGISTER, servo=servo, axis=axis
@@ -210,6 +215,7 @@ class InputsOutputs:
         Raise:
             IMException: if the GPOs final value does not match with the desired GPOs set point.
         """
+        self.mc._get_drive(servo)
         new_target_value = bool(voltage_level.value)
 
         gpos_previous_value = int(

--- a/ingeniamotion/metaclass.py
+++ b/ingeniamotion/metaclass.py
@@ -1,7 +1,6 @@
 import inspect
 from functools import wraps
-from types import FunctionType
-from typing import Any, Callable, TypeVar
+from typing import Callable, TypeVar
 
 from ingeniamotion.exceptions import IMStatusWordError
 
@@ -14,50 +13,12 @@ T = TypeVar("T")
 class MCMetaClass(type):
     """MotionController submodules metaclass.
 
-    It adds a servo checker for all the functions that has an argument named servo.
-
-    This class also have other decorators that can be useful for some
+    This class has decorators that can be useful for some
     functions, as motor disabled checker.
     """
 
     SERVO_ARG_NAME = "servo"
     AXIS_ARG_NAME = "axis"
-
-    def __new__(
-        cls: type["MCMetaClass"], name: str, bases: tuple[type, ...], local: dict[str, Any]
-    ) -> "MCMetaClass":
-        """If a function has argument named servo, decorates it with check_servo decorator."""
-        for attr in local:
-            value = local[attr]
-            if (
-                callable(value)
-                and isinstance(value, FunctionType)
-                and cls.SERVO_ARG_NAME in inspect.getfullargspec(value).args
-            ):
-                local[attr] = cls.check_servo(value)
-        return type.__new__(cls, name, bases, local)
-
-    @classmethod
-    def check_servo(cls, func: Callable[..., T]) -> Callable[..., T]:
-        """Decorator to check if the servo is connected.
-
-        If servo is not connected raises an exception.
-        """
-
-        @wraps(func)
-        def wrapper(self, *args, **kwargs):  # type: ignore[no-untyped-def]
-            mc = self.mc
-            func_args = inspect.getfullargspec(func).args
-            servo_index = func_args.index(cls.SERVO_ARG_NAME)
-            if len(args) < servo_index:
-                servo = kwargs.get(cls.SERVO_ARG_NAME, DEFAULT_SERVO)
-            else:
-                servo = args[servo_index - 1]
-            if servo not in mc.servos:
-                raise KeyError(f"Servo '{servo}' is not connected")
-            return func(self, *args, **kwargs)
-
-        return wrapper
 
     @classmethod
     def check_motor_disabled(cls, func: Callable[..., T]) -> Callable[..., T]:

--- a/ingeniamotion/motion.py
+++ b/ingeniamotion/motion.py
@@ -52,6 +52,7 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         control_word = self.mc.communication.get_register(
             self.CONTROL_WORD_REGISTER, servo=servo, axis=axis
         )
@@ -80,6 +81,7 @@ class Motion:
             axis : servo axis. ``1`` by default.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.OPERATION_MODE_REGISTER, operation_mode, servo=servo, axis=axis
         )
@@ -114,6 +116,7 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         operation_mode = self.mc.communication.get_register(
             self.OPERATION_MODE_DISPLAY_REGISTER, servo=servo, axis=axis
         )
@@ -135,7 +138,7 @@ class Motion:
             ingenialink.exceptions.ILError: If the servo cannot enable the motor.
 
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         try:
             drive.enable(subnode=axis)
         except ILError as e:
@@ -154,13 +157,13 @@ class Motion:
             axis : servo axis. ``1`` by default.
 
         """
+        drive = self.mc._get_drive(servo)
         try:
             is_motor_enabled = self.mc.configuration.is_motor_enabled(servo=servo, axis=axis)
         except ILError as e:
             self.logger.info(f"Unable to check if motor is enabled. Reason: {e}")
             return
         if is_motor_enabled:
-            drive = self.mc.servos[servo]
             try:
                 drive.disable(subnode=axis)
             except ILError as e:
@@ -174,7 +177,7 @@ class Motion:
             axis : servo axis. ``1`` by default.
 
         """
-        drive = self.mc.servos[servo]
+        drive = self.mc._get_drive(servo)
         try:
             drive.fault_reset(axis)
         except ILError as e:
@@ -214,6 +217,7 @@ class Motion:
             IMTimeoutError: If the target position is not reached in time.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.POSITION_SET_POINT_REGISTER, position, servo=servo, axis=axis
         )
@@ -262,6 +266,7 @@ class Motion:
             IMTimeoutError: If the target velocity is not reached in time.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.VELOCITY_SET_POINT_REGISTER, velocity, servo=servo, axis=axis
         )
@@ -290,6 +295,7 @@ class Motion:
             TypeError: If current is not a float.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.CURRENT_QUADRATURE_SET_POINT_REGISTER, current, servo=servo, axis=axis
         )
@@ -308,6 +314,7 @@ class Motion:
             TypeError: If current is not a float.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.CURRENT_DIRECT_SET_POINT_REGISTER, current, servo=servo, axis=axis
         )
@@ -326,6 +333,7 @@ class Motion:
             TypeError: If voltage is not a float.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.VOLTAGE_QUADRATURE_SET_POINT_REGISTER, voltage, servo=servo, axis=axis
         )
@@ -344,6 +352,7 @@ class Motion:
             TypeError: If voltage is not a float.
 
         """
+        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.VOLTAGE_DIRECT_SET_POINT_REGISTER, voltage, servo=servo, axis=axis
         )
@@ -376,6 +385,7 @@ class Motion:
             TypeError: If target_value or time_s is not a float.
 
         """
+        self.mc._get_drive(servo)
         for value in self.ramp_generator(init_value, target_value, time_s, interval):
             self.set_current_quadrature(value, servo=servo, axis=axis)
 
@@ -407,6 +417,7 @@ class Motion:
             TypeError: If target_value or time_s is not a float.
 
         """
+        self.mc._get_drive(servo)
         for value in self.ramp_generator(init_value, target_value, time_s, interval):
             self.set_current_direct(value, servo=servo, axis=axis)
 
@@ -438,6 +449,7 @@ class Motion:
             TypeError: If target_value or time_s is not a float.
 
         """
+        self.mc._get_drive(servo)
         for value in self.ramp_generator(init_value, target_value, time_s, interval):
             self.set_voltage_quadrature(value, servo=servo, axis=axis)
 
@@ -469,6 +481,7 @@ class Motion:
             TypeError: If target_value or time_s is not a float.
 
         """
+        self.mc._get_drive(servo)
         for value in self.ramp_generator(init_value, target_value, time_s, interval):
             self.set_voltage_direct(value, servo=servo, axis=axis)
 
@@ -513,6 +526,7 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         actual_position = self.mc.communication.get_register(
             self.ACTUAL_POSITION_REGISTER, servo=servo, axis=axis
         )
@@ -534,6 +548,7 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         actual_velocity = self.mc.communication.get_register(
             self.ACTUAL_VELOCITY_REGISTER, servo=servo, axis=axis
         )
@@ -557,6 +572,7 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         actual_current_direct = self.mc.communication.get_register(
             self.ACTUAL_DIRECT_CURRENT_REGISTER, servo=servo, axis=axis
         )
@@ -580,6 +596,7 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
+        self.mc._get_drive(servo)
         actual_current_quadrature = self.mc.communication.get_register(
             self.ACTUAL_QUADRATURE_CURRENT_REGISTER, servo=servo, axis=axis
         )
@@ -614,6 +631,7 @@ class Motion:
             IMTimeoutError: If the target position is not reached in time.
 
         """
+        self.mc._get_drive(servo)
         target_reached = False
         init_time = time.time()
         self.logger.debug(
@@ -661,6 +679,7 @@ class Motion:
             IMTimeoutError: If the target velocity is not reached in time.
 
         """
+        self.mc._get_drive(servo)
         target_reached = False
         init_time = time.time()
         self.logger.debug(
@@ -702,6 +721,7 @@ class Motion:
             ValueError: If operation mode is not set to Current or Voltage.
 
         """
+        self.mc._get_drive(servo)
         if op_mode not in [OperationMode.CURRENT, OperationMode.VOLTAGE]:
             raise ValueError("Operation mode must be Current or Voltage")
         self.set_operation_mode(op_mode, servo=servo, axis=axis)
@@ -740,6 +760,7 @@ class Motion:
             ValueError: If gain is not positive.
 
         """
+        self.mc._get_drive(servo)
         if gain < 0:
             raise ValueError("Gain should be positive")
         self.mc.configuration.set_generator_mode(GeneratorMode.SAW_TOOTH, servo=servo, axis=axis)
@@ -780,6 +801,7 @@ class Motion:
             TypeError: If offset is not an int.
 
         """
+        self.mc._get_drive(servo)
         self.mc.configuration.set_generator_mode(GeneratorMode.CONSTANT, servo=servo, axis=axis)
         self.mc.communication.set_register(self.GENERATOR_GAIN_REGISTER, 0, servo=servo, axis=axis)
         self.mc.communication.set_register(

--- a/ingeniamotion/motion.py
+++ b/ingeniamotion/motion.py
@@ -9,10 +9,10 @@ if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
 from ingeniamotion.enums import GeneratorMode, OperationMode, PhasingMode, SensorType
 from ingeniamotion.exceptions import IMTimeoutError
-from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
+from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 
-class Motion(metaclass=MCMetaClass):
+class Motion:
     """Motion."""
 
     CONTROL_WORD_REGISTER = "DRV_STATE_CONTROL"

--- a/ingeniamotion/motion.py
+++ b/ingeniamotion/motion.py
@@ -52,7 +52,6 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         control_word = self.mc.communication.get_register(
             self.CONTROL_WORD_REGISTER, servo=servo, axis=axis
         )
@@ -81,7 +80,6 @@ class Motion:
             axis : servo axis. ``1`` by default.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.OPERATION_MODE_REGISTER, operation_mode, servo=servo, axis=axis
         )
@@ -116,7 +114,6 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         operation_mode = self.mc.communication.get_register(
             self.OPERATION_MODE_DISPLAY_REGISTER, servo=servo, axis=axis
         )
@@ -217,7 +214,6 @@ class Motion:
             IMTimeoutError: If the target position is not reached in time.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.POSITION_SET_POINT_REGISTER, position, servo=servo, axis=axis
         )
@@ -266,7 +262,6 @@ class Motion:
             IMTimeoutError: If the target velocity is not reached in time.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.VELOCITY_SET_POINT_REGISTER, velocity, servo=servo, axis=axis
         )
@@ -295,7 +290,6 @@ class Motion:
             TypeError: If current is not a float.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.CURRENT_QUADRATURE_SET_POINT_REGISTER, current, servo=servo, axis=axis
         )
@@ -314,7 +308,6 @@ class Motion:
             TypeError: If current is not a float.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.CURRENT_DIRECT_SET_POINT_REGISTER, current, servo=servo, axis=axis
         )
@@ -333,7 +326,6 @@ class Motion:
             TypeError: If voltage is not a float.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.VOLTAGE_QUADRATURE_SET_POINT_REGISTER, voltage, servo=servo, axis=axis
         )
@@ -352,7 +344,6 @@ class Motion:
             TypeError: If voltage is not a float.
 
         """
-        self.mc._get_drive(servo)
         self.mc.communication.set_register(
             self.VOLTAGE_DIRECT_SET_POINT_REGISTER, voltage, servo=servo, axis=axis
         )
@@ -385,7 +376,6 @@ class Motion:
             TypeError: If target_value or time_s is not a float.
 
         """
-        self.mc._get_drive(servo)
         for value in self.ramp_generator(init_value, target_value, time_s, interval):
             self.set_current_quadrature(value, servo=servo, axis=axis)
 
@@ -417,7 +407,6 @@ class Motion:
             TypeError: If target_value or time_s is not a float.
 
         """
-        self.mc._get_drive(servo)
         for value in self.ramp_generator(init_value, target_value, time_s, interval):
             self.set_current_direct(value, servo=servo, axis=axis)
 
@@ -449,7 +438,6 @@ class Motion:
             TypeError: If target_value or time_s is not a float.
 
         """
-        self.mc._get_drive(servo)
         for value in self.ramp_generator(init_value, target_value, time_s, interval):
             self.set_voltage_quadrature(value, servo=servo, axis=axis)
 
@@ -481,7 +469,6 @@ class Motion:
             TypeError: If target_value or time_s is not a float.
 
         """
-        self.mc._get_drive(servo)
         for value in self.ramp_generator(init_value, target_value, time_s, interval):
             self.set_voltage_direct(value, servo=servo, axis=axis)
 
@@ -526,7 +513,6 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         actual_position = self.mc.communication.get_register(
             self.ACTUAL_POSITION_REGISTER, servo=servo, axis=axis
         )
@@ -548,7 +534,6 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         actual_velocity = self.mc.communication.get_register(
             self.ACTUAL_VELOCITY_REGISTER, servo=servo, axis=axis
         )
@@ -572,7 +557,6 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         actual_current_direct = self.mc.communication.get_register(
             self.ACTUAL_DIRECT_CURRENT_REGISTER, servo=servo, axis=axis
         )
@@ -596,7 +580,6 @@ class Motion:
             TypeError: If some read value has a wrong type.
 
         """
-        self.mc._get_drive(servo)
         actual_current_quadrature = self.mc.communication.get_register(
             self.ACTUAL_QUADRATURE_CURRENT_REGISTER, servo=servo, axis=axis
         )
@@ -631,7 +614,6 @@ class Motion:
             IMTimeoutError: If the target position is not reached in time.
 
         """
-        self.mc._get_drive(servo)
         target_reached = False
         init_time = time.time()
         self.logger.debug(
@@ -679,7 +661,6 @@ class Motion:
             IMTimeoutError: If the target velocity is not reached in time.
 
         """
-        self.mc._get_drive(servo)
         target_reached = False
         init_time = time.time()
         self.logger.debug(
@@ -721,7 +702,6 @@ class Motion:
             ValueError: If operation mode is not set to Current or Voltage.
 
         """
-        self.mc._get_drive(servo)
         if op_mode not in [OperationMode.CURRENT, OperationMode.VOLTAGE]:
             raise ValueError("Operation mode must be Current or Voltage")
         self.set_operation_mode(op_mode, servo=servo, axis=axis)
@@ -760,7 +740,6 @@ class Motion:
             ValueError: If gain is not positive.
 
         """
-        self.mc._get_drive(servo)
         if gain < 0:
             raise ValueError("Gain should be positive")
         self.mc.configuration.set_generator_mode(GeneratorMode.SAW_TOOTH, servo=servo, axis=axis)
@@ -801,7 +780,6 @@ class Motion:
             TypeError: If offset is not an int.
 
         """
-        self.mc._get_drive(servo)
         self.mc.configuration.set_generator_mode(GeneratorMode.CONSTANT, servo=servo, axis=axis)
         self.mc.communication.set_register(self.GENERATOR_GAIN_REGISTER, 0, servo=servo, axis=axis)
         self.mc.communication.set_register(

--- a/ingeniamotion/motion_controller.py
+++ b/ingeniamotion/motion_controller.py
@@ -45,7 +45,8 @@ class MotionController:
             The servo name.
 
         """
-        return "{} ({})".format(self.servos[servo].info["product_code"], servo)
+        drive = self._get_drive(servo)
+        return "{} ({})".format(drive.info["product_code"], servo)
 
     def get_register_enum(
         self, register: str, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS
@@ -61,7 +62,7 @@ class MotionController:
             The register enum as an IntEnum.
 
         """
-        drive = self.servos[servo]
+        drive = self._get_drive(servo)
         enum_dict = drive.dictionary.registers(axis)[register].enums
         return IntEnum(register, enum_dict)
 

--- a/ingeniamotion/motion_controller.py
+++ b/ingeniamotion/motion_controller.py
@@ -91,7 +91,7 @@ class MotionController:
         net_key = self.servo_net[servo]
         return self.net[net_key]
 
-    def _get_drive(self, servo: str) -> Servo:
+    def _get_drive(self, servo: str = DEFAULT_SERVO) -> Servo:
         """Return servo drive instance.
 
         Args:
@@ -101,6 +101,9 @@ class MotionController:
             Servo instance.
 
         """
+        if servo not in self.servos:
+            msg = f"Servo {servo} is not connected"
+            raise KeyError(msg)
         return self.servos[servo]
 
     # Properties

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -737,7 +737,6 @@ class PDONetworkManager:
             The poller instance.
 
         """
-        self.mc._get_drive(servo)
         poller = PDOPoller(self.mc, servo, sampling_time, watchdog_timeout, buffer_size)
         poller.add_channels(registers)
         if start:

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -358,11 +358,11 @@ class PDONetworkManager:
             AttributeError: If an initial value is not provided for an RPDO register.
 
         """
+        drive = self.mc._get_drive(servo)
         pdo_map_item_dict: dict[RegCyclicType, type[Union[RPDOMapItem, TPDOMapItem]]] = {
             RegCyclicType.RX: RPDOMapItem,
             RegCyclicType.TX: TPDOMapItem,
         }
-        drive = self.mc._get_drive(servo)
         register = drive.dictionary.registers(axis)[register_uid]
         if not isinstance(register, EthercatRegister):
             raise ValueError(f"Expected EthercatRegister. Got {type(register)}")
@@ -737,6 +737,7 @@ class PDONetworkManager:
             The poller instance.
 
         """
+        self.mc._get_drive(servo)
         poller = PDOPoller(self.mc, servo, sampling_time, watchdog_timeout, buffer_size)
         poller.add_channels(registers)
         if start:

--- a/tests/test_motion_controller.py
+++ b/tests/test_motion_controller.py
@@ -63,14 +63,15 @@ def test_is_alive(motion_controller):
 
 @pytest.mark.virtual
 class TestMetaclass:
-    class DummyClass(metaclass=MCMetaClass):
+    class DummyClass:
         mc = MotionController()
 
         def is_motor_enabled(self, servo: str, axis: int):
+            self.mc._get_drive(servo)
             return servo == "a" and axis == 1
 
         def __init__(self):
-            self.mc.servos = ["a", "b"]
+            self.mc.servos = {"a": None, "b": None}
             self.mc.configuration.is_motor_enabled = self.is_motor_enabled
 
         @MCMetaClass.check_motor_disabled


### PR DESCRIPTION
### Description

The check_servo decorator uses the [inspect.getfullargspec()](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) which can be a cause of performance issues. 

The decorator is replaced with the _get_drive method.

Fixes # INGM-579

### Type of change

- Remove the check_servo decorator.
- Update modules.
- Update tests.


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
