### PR TITLE
INGM-569 Fix N801 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 - Methods to scan Ethernet drives.
 
+### Changed
+- Renamed the `TYPE_SUBNODES` and `COMMUNICATION_TYPE` enums to follow CapWords convention. Old names are still supported, but will soon be deprecated.
+
 ## [0.9.0] - 2025-01-29
 ### Added
 - Method to subscribe to register value updates.

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
 
 
-class TYPE_SUBNODES(IntEnum):  # noqa: N801
+class SubnodeType(IntEnum):
     """Subnode type enum."""
 
     COCO = 0
@@ -138,20 +138,20 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
     STO_INACTIVE_STATE = 23
 
     PRODUCT_ID_REGISTERS = {
-        TYPE_SUBNODES.COCO: "DRV_ID_PRODUCT_CODE_COCO",
-        TYPE_SUBNODES.MOCO: "DRV_ID_PRODUCT_CODE",
+        SubnodeType.COCO: "DRV_ID_PRODUCT_CODE_COCO",
+        SubnodeType.MOCO: "DRV_ID_PRODUCT_CODE",
     }
     REVISION_NUMBER_REGISTERS = {
-        TYPE_SUBNODES.COCO: "DRV_ID_REVISION_NUMBER_COCO",
-        TYPE_SUBNODES.MOCO: "DRV_ID_REVISION_NUMBER",
+        SubnodeType.COCO: "DRV_ID_REVISION_NUMBER_COCO",
+        SubnodeType.MOCO: "DRV_ID_REVISION_NUMBER",
     }
     SERIAL_NUMBER_REGISTERS = {
-        TYPE_SUBNODES.COCO: "DRV_ID_SERIAL_NUMBER_COCO",
-        TYPE_SUBNODES.MOCO: "DRV_ID_SERIAL_NUMBER",
+        SubnodeType.COCO: "DRV_ID_SERIAL_NUMBER_COCO",
+        SubnodeType.MOCO: "DRV_ID_SERIAL_NUMBER",
     }
     SOFTWARE_VERSION_REGISTERS = {
-        TYPE_SUBNODES.COCO: "DRV_APP_COCO_VERSION",
-        TYPE_SUBNODES.MOCO: "DRV_ID_SOFTWARE_VERSION",
+        SubnodeType.COCO: "DRV_APP_COCO_VERSION",
+        SubnodeType.MOCO: "DRV_ID_SOFTWARE_VERSION",
     }
     VENDOR_ID_COCO_REGISTER = "DRV_ID_VENDOR_ID_COCO"
     VENDOR_ID_REGISTER = "DRV_ID_VENDOR_ID"
@@ -1016,7 +1016,7 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
         return prod_codes, rev_numbers, fw_versions, serial_number
 
     @staticmethod
-    def get_subnode_type(axis: int) -> TYPE_SUBNODES:
+    def get_subnode_type(axis: int) -> SubnodeType:
         """Get a subnode type depending on the axis number.
 
         Args:
@@ -1030,7 +1030,7 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
         """
         if axis < 0:
             raise ValueError("There are no subnodes with negative values")
-        return TYPE_SUBNODES.COCO if axis == 0 else TYPE_SUBNODES.MOCO
+        return SubnodeType.COCO if axis == 0 else SubnodeType.MOCO
 
     def get_product_code(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> int:
         """Get the product code of a drive.

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -1,7 +1,8 @@
 import re
+import warnings
 from enum import IntEnum
 from os import path
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import ingenialogger
 from ingenialink import CanBaudrate
@@ -1435,3 +1436,20 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
                 continue
             register = reg_template.format(signal.value, number.value)
             self.mc.communication.set_register(register, value, servo, axis)
+
+
+# WARNING: Deprecated aliases
+_DEPRECATED = {
+    "TYPE_SUBNODES": "SubnodeType",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED[name]} instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED[name]]
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/ingeniamotion/enums/__init__.py
+++ b/ingeniamotion/enums/__init__.py
@@ -197,7 +197,7 @@ class SeverityLevel(IntEnum, metaclass=MetaEnum):
 
 
 @export
-class COMMUNICATION_TYPE(IntEnum, metaclass=MetaEnum):  # noqa: N801
+class CommunicationType(IntEnum, metaclass=MetaEnum):
     Canopen = 0
     Ethernet = 1
     Ethercat = 2

--- a/ingeniamotion/enums/__init__.py
+++ b/ingeniamotion/enums/__init__.py
@@ -1,5 +1,6 @@
+import warnings
 from enum import Enum, EnumMeta, IntEnum
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from ingenialink import (
     CAN_BAUDRATE,
@@ -341,3 +342,20 @@ class STOAbnormalLatchedStatus(IntEnum, metaclass=MetaEnum):
     NOT_LATCHED = 0
     LATCHED = 1
     UNDETERMINATED = 2
+
+
+# WARNING: Deprecated aliases
+_DEPRECATED = {
+    "COMMUNICATION_TYPE": "CommunicationType",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED[name]} instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED[name]]
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -11,7 +11,7 @@ from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.register import Register
 
-from ingeniamotion.enums import COMMUNICATION_TYPE
+from ingeniamotion.enums import CommunicationType
 from ingeniamotion.exceptions import IMException, IMRegisterNotExist
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
 
@@ -237,7 +237,7 @@ class Information(metaclass=MCMetaClass):
         drive_name = drive.name
         return f"{drive_name}"
 
-    def get_communication_type(self, servo: str = DEFAULT_SERVO) -> COMMUNICATION_TYPE:
+    def get_communication_type(self, servo: str = DEFAULT_SERVO) -> CommunicationType:
         """Get the connected drive's communication type.
 
         Args:
@@ -249,11 +249,11 @@ class Information(metaclass=MCMetaClass):
         """
         drive_network = self.mc._get_network(servo)
         if isinstance(drive_network, CanopenNetwork):
-            communication_type = COMMUNICATION_TYPE.Canopen
+            communication_type = CommunicationType.Canopen
         elif isinstance(drive_network, EthernetNetwork):
-            communication_type = COMMUNICATION_TYPE.Ethernet
+            communication_type = CommunicationType.Ethernet
         elif isinstance(drive_network, (EoENetwork, EthercatNetwork)):
-            communication_type = COMMUNICATION_TYPE.Ethercat
+            communication_type = CommunicationType.Ethercat
         return communication_type
 
     def get_full_name(self, servo: str = DEFAULT_SERVO) -> str:

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -13,7 +13,7 @@ from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.exceptions import ILError, ILWrongWorkingCountError
 from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
 
-from ingeniamotion.enums import COMMUNICATION_TYPE
+from ingeniamotion.enums import CommunicationType
 from ingeniamotion.exceptions import IMException
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
@@ -544,7 +544,7 @@ class PDONetworkManager:
 
     def start_pdos(
         self,
-        network_type: Optional[COMMUNICATION_TYPE] = None,
+        network_type: Optional[CommunicationType] = None,
         refresh_rate: Optional[float] = None,
         watchdog_timeout: Optional[float] = None,
     ) -> None:
@@ -572,11 +572,11 @@ class PDONetworkManager:
                     " provided."
                 )
             net = next(iter(self.mc.net.values()))
-        elif not isinstance(network_type, COMMUNICATION_TYPE):
+        elif not isinstance(network_type, CommunicationType):
             raise ValueError(
-                f"Wrong value for the network_type argument. Must be of type {COMMUNICATION_TYPE}"
+                f"Wrong value for the network_type argument. Must be of type {CommunicationType}"
             )
-        elif network_type == COMMUNICATION_TYPE.Canopen:
+        elif network_type == CommunicationType.Canopen:
             raise NotImplementedError
         else:
             ethercat_networks = [
@@ -593,7 +593,7 @@ class PDONetworkManager:
                 )
             net = (
                 ethercat_networks[0]
-                if network_type == COMMUNICATION_TYPE.Ethercat
+                if network_type == CommunicationType.Ethercat
                 else canopen_networks[0]
             )
         if self._pdo_thread is not None:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,7 +4,7 @@ import pytest
 from ingenialink import CanBaudrate
 from ingenialink.ethercat.servo import EthercatServo
 
-from ingeniamotion.configuration import SubnodeType, MACAddressConverter
+from ingeniamotion.configuration import MACAddressConverter, SubnodeType
 from ingeniamotion.enums import (
     CommutationMode,
     FilterNumber,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,7 +4,7 @@ import pytest
 from ingenialink import CanBaudrate
 from ingenialink.ethercat.servo import EthercatServo
 
-from ingeniamotion.configuration import TYPE_SUBNODES, MACAddressConverter
+from ingeniamotion.configuration import SubnodeType, MACAddressConverter
 from ingeniamotion.enums import (
     CommutationMode,
     FilterNumber,
@@ -859,8 +859,8 @@ def test_store_restore_tcp_ip_parameters_exception(mocker, motion_controller, fu
 @pytest.mark.parametrize(
     "subnode, expected_result",
     [
-        (0, TYPE_SUBNODES.COCO),
-        (1, TYPE_SUBNODES.MOCO),
+        (0, SubnodeType.COCO),
+        (1, SubnodeType.MOCO),
     ],
 )
 @pytest.mark.virtual

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -7,7 +7,7 @@ from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.register import RegAccess, RegDtype
 
 from ingeniamotion.exceptions import IMException, IMRegisterNotExist
-from ingeniamotion.information import COMMUNICATION_TYPE
+from ingeniamotion.information import CommunicationType
 
 
 @pytest.mark.virtual
@@ -129,9 +129,9 @@ def test_get_name(motion_controller):
 @pytest.mark.parametrize(
     "communication, expected_result, args",
     [
-        (EthernetNetwork, COMMUNICATION_TYPE.Ethernet, None),
-        (EthercatNetwork, COMMUNICATION_TYPE.Ethercat, "fake_interface_name"),
-        (CanopenNetwork, COMMUNICATION_TYPE.Canopen, CanDevice.PCAN),
+        (EthernetNetwork, CommunicationType.Ethernet, None),
+        (EthercatNetwork, CommunicationType.Ethercat, "fake_interface_name"),
+        (CanopenNetwork, CommunicationType.Canopen, CanDevice.PCAN),
     ],
 )
 @pytest.mark.virtual

--- a/tests/test_pdo.py
+++ b/tests/test_pdo.py
@@ -7,7 +7,7 @@ from ingenialink.exceptions import ILWrongWorkingCountError
 from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
 from packaging import version
 
-from ingeniamotion.enums import COMMUNICATION_TYPE, OperationMode
+from ingeniamotion.enums import CommunicationType, OperationMode
 from ingeniamotion.exceptions import IMException
 
 from .setups.descriptors import EthercatMultiSlaveSetup
@@ -160,7 +160,7 @@ def test_pdos_min_refresh_rate(motion_controller):
     mc, alias, environment = motion_controller
     refresh_rate = 0.0001
     with pytest.raises(ValueError):
-        mc.capture.pdo.start_pdos(COMMUNICATION_TYPE.Ethercat, refresh_rate)
+        mc.capture.pdo.start_pdos(CommunicationType.Ethercat, refresh_rate)
 
 
 @pytest.mark.soem
@@ -173,7 +173,7 @@ def test_pdos_watchdog_exception_auto(motion_controller):
     mc, alias, environment = motion_controller
     refresh_rate = 3.5
     mc.capture.pdo.subscribe_to_exceptions(exception_callback)
-    mc.capture.pdo.start_pdos(COMMUNICATION_TYPE.Ethercat, refresh_rate)
+    mc.capture.pdo.start_pdos(CommunicationType.Ethercat, refresh_rate)
     time.sleep(1)
     mc.capture.pdo.unsubscribe_to_exceptions(exception_callback)
     mc.capture.pdo.stop_pdos()
@@ -192,7 +192,7 @@ def test_pdos_watchdog_exception_manual(motion_controller):
     mc, alias, environment = motion_controller
     watchdog_timeout = 7
     mc.capture.pdo.subscribe_to_exceptions(exception_callback)
-    mc.capture.pdo.start_pdos(COMMUNICATION_TYPE.Ethercat, watchdog_timeout=watchdog_timeout)
+    mc.capture.pdo.start_pdos(CommunicationType.Ethercat, watchdog_timeout=watchdog_timeout)
     time.sleep(1)
     mc.capture.pdo.unsubscribe_to_exceptions(exception_callback)
     mc.capture.pdo.stop_pdos()
@@ -276,7 +276,7 @@ def test_stop_pdos_exception(motion_controller):
 def test_start_pdos_not_implemented_exception(motion_controller):
     mc, alias, environment = motion_controller
     with pytest.raises(NotImplementedError):
-        mc.capture.pdo.start_pdos(COMMUNICATION_TYPE.Canopen)
+        mc.capture.pdo.start_pdos(CommunicationType.Canopen)
 
 
 @pytest.mark.soem
@@ -294,7 +294,7 @@ def test_start_pdos_number_of_network_exception(mocker, motion_controller):
     with pytest.raises(ValueError):
         mc.capture.pdo.start_pdos()
     with pytest.raises(IMException):
-        mc.capture.pdo.start_pdos(COMMUNICATION_TYPE.Ethercat)
+        mc.capture.pdo.start_pdos(CommunicationType.Ethercat)
 
 
 def skip_if_pdo_padding_is_not_available(mc, alias):


### PR DESCRIPTION
### Description

The `TYPE_SUBNODES` and `COMMUNICATION_TYPE` enums were renamed to follow the CapWords convention.

Fixes # INGM-569

### Type of change

- Rename TYPE_SUBNODES to SubnodeTypes.
- Rename COMMUNICATION_TYPE to CommunicationType.
- Add deprecation warnings.

### Tests
- [ ] Add new unit tests if it applies.
- [ ] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
