### PR TITLE
Fix wrong deprecated imports

### DIFF
--- a/ingeniamotion/enums/__init__.py
+++ b/ingeniamotion/enums/__init__.py
@@ -3,10 +3,6 @@ from enum import Enum, EnumMeta, IntEnum
 from typing import Any, TypeVar
 
 from ingenialink import (
-    CAN_BAUDRATE,
-    CAN_DEVICE,
-    REG_ACCESS,
-    REG_DTYPE,
     CanBaudrate,
     CanDevice,
     RegAccess,
@@ -16,13 +12,9 @@ from ingenialink import (
 T = TypeVar("T", bound=type[Enum])
 
 __all__ = [
-    "CAN_BAUDRATE",
     "CanBaudrate",
-    "CAN_DEVICE",
     "CanDevice",
-    "REG_ACCESS",
     "RegAccess",
-    "REG_DTYPE",
     "RegDtype",
 ]
 
@@ -347,6 +339,10 @@ class STOAbnormalLatchedStatus(IntEnum, metaclass=MetaEnum):
 # WARNING: Deprecated aliases
 _DEPRECATED = {
     "COMMUNICATION_TYPE": "CommunicationType",
+    "CAN_DEVICE": "CanDevice",
+    "CAN_BAUDRATE": "CanBaudrate",
+    "REG_DTYPE": "RegDtype",
+    "REG_ACCESS": "RegAccess",
 }
 
 


### PR DESCRIPTION
### Description

Fix wrong import from ingenialink - deprecation warnings were always shown.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Add deprecated imports in proper section


### Tests
- [ ] Add new unit tests if it applies.
- [ ] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [X] Set fix version field in the Jira issue.
