### PR TITLE
Ingm 509 - Fix wrong error received when performing motor_enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - Methods to scan Ethernet drives.
+- Error-raised timeout to motor_enable
 
 ### Changed
 - Renamed the `TYPE_SUBNODES` and `COMMUNICATION_TYPE` enums to follow CapWords convention. Old names are still supported, but will soon be deprecated.

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -577,7 +577,7 @@ class Configuration(Homing, Feedbacks, metaclass=MCMetaClass):
         """
         status_word = self.mc.communication.get_register(self.STATUS_WORD_REGISTER, servo, axis)
         if not isinstance(status_word, int):
-            raise TypeError("Power stage frequency value has to be an integer")
+            raise TypeError("Status word value has to be an integer")
         return status_word
 
     def is_motor_enabled(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> bool:

--- a/ingeniamotion/motion.py
+++ b/ingeniamotion/motion.py
@@ -165,7 +165,7 @@ class Motion(metaclass=MCMetaClass):
                     )
             if not error_raised:
                 raise ILTimeoutError(
-                    "An error occurred enabling motor. Reason: Error trigger timeout exceeded. "
+                    "An error occurred enabling motor. Reason: Error trigger timeout exceeded."
                 )
             exception_type = type(e)
             raise exception_type(f"An error occurred enabling motor. Reason: {error_msg}")

--- a/ingeniamotion/motion.py
+++ b/ingeniamotion/motion.py
@@ -141,6 +141,7 @@ class Motion(metaclass=MCMetaClass):
 
         Raises:
             ingenialink.exceptions.ILError: If the servo cannot enable the motor.
+            ingenialink.exceptions.ILTimeoutError: If the error was not raised in time.
 
         """
         drive = self.mc.servos[servo]

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -169,39 +169,6 @@ def test_motor_enable_with_delayed_fault(
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.smoke
-@pytest.mark.parametrize(
-    "uid, value, exception_type, message, timeout",
-    [
-        # Under-Voltage Error is triggered successfully
-        ("DRV_PROT_USER_UNDER_VOLT", 100, exceptions.ILError, "User Under-voltage detected", 6),
-        # Under-Voltage Error is not triggered due to timeout error
-        (
-            "DRV_PROT_USER_UNDER_VOLT",
-            100,
-            exceptions.ILTimeoutError,
-            "Error trigger timeout exceeded.",
-            0.0001,
-        ),
-    ],
-)
-def test_motor_enable_with_error_timeout_fault(
-    motion_controller_teardown, uid, value, exception_type, message, timeout
-):
-    mc, alias, environment = motion_controller_teardown
-    mc.communication.set_register(uid, value, alias)
-    with pytest.raises(exception_type) as excinfo:
-        mc.motion.motor_enable(servo=alias, error_timeout=timeout)
-    if excinfo.type is exceptions.ILIOError:
-        # Retrieving the error code failed. Check INGM-522.
-        with pytest.raises(exception_type) as excinfo:
-            mc.motion.motor_enable(servo=alias, error_timeout=timeout)
-    assert str(excinfo.value) == f"An error occurred enabling motor. Reason: {message}"
-
-
-@pytest.mark.ethernet
-@pytest.mark.soem
-@pytest.mark.canopen
-@pytest.mark.smoke
 @pytest.mark.parametrize("enable_motor", [True, False])
 def test_motor_disable(motion_controller, enable_motor):
     mc, alias, environment = motion_controller

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -115,14 +115,14 @@ def test_motor_enable_with_fault(motion_controller_teardown, uid, value, excepti
     "uid, value, exception_type, message, timeout",
     [
         # Under-Voltage Error is triggered successfully
-        ("DRV_PROT_USER_UNDER_VOLT", 100, exceptions.ILError, "User Under-voltage detected", 6000),
+        ("DRV_PROT_USER_UNDER_VOLT", 100, exceptions.ILError, "User Under-voltage detected", 6),
         # Under-Voltage Error is not triggered due to timeout error
         (
             "DRV_PROT_USER_UNDER_VOLT",
             100,
             exceptions.ILTimeoutError,
             "Error trigger timeout exceeded.",
-            10,
+            0.01,
         ),
     ],
 )

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -111,6 +111,39 @@ def test_motor_enable_with_fault(motion_controller_teardown, uid, value, excepti
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.smoke
+@pytest.mark.parametrize(
+    "uid, value, exception_type, message, timeout",
+    [
+        # Under-Voltage Error is triggered successfully
+        ("DRV_PROT_USER_UNDER_VOLT", 100, exceptions.ILError, "User Under-voltage detected", 6000),
+        # Under-Voltage Error is not triggered due to timeout error
+        (
+            "DRV_PROT_USER_UNDER_VOLT",
+            100,
+            exceptions.ILTimeoutError,
+            "Error trigger timeout exceeded.",
+            10,
+        ),
+    ],
+)
+def test_motor_enable_with_error_timeout_fault(
+    motion_controller_teardown, uid, value, exception_type, message, timeout
+):
+    mc, alias, environment = motion_controller_teardown
+    mc.communication.set_register(uid, value, alias)
+    with pytest.raises(exception_type) as excinfo:
+        mc.motion.motor_enable(servo=alias, error_timeout=timeout)
+    if excinfo.type is exceptions.ILIOError:
+        # Retrieving the error code failed. Check INGM-522.
+        with pytest.raises(exception_type) as excinfo:
+            mc.motion.motor_enable(servo=alias, error_timeout=timeout)
+    assert str(excinfo.value) == f"An error occurred enabling motor. Reason: {message}"
+
+
+@pytest.mark.ethernet
+@pytest.mark.soem
+@pytest.mark.canopen
+@pytest.mark.smoke
 @pytest.mark.parametrize("enable_motor", [True, False])
 def test_motor_disable(motion_controller, enable_motor):
     mc, alias, environment = motion_controller

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -122,7 +122,7 @@ def test_motor_enable_with_fault(motion_controller_teardown, uid, value, excepti
             100,
             exceptions.ILTimeoutError,
             "Error trigger timeout exceeded.",
-            0.01,
+            0.0001,
         ),
     ],
 )


### PR DESCRIPTION
### Description

Fix wrong error received when performing a motor_enable.

Before: If the error took longer to be triggered than the status word to change, the retrieved error was the last one present on the buffer.

Now: Before the motor is enabled, the last error present on the buffer is saved. If then an error causes the motor_enable() to fail, the last error present on the buffer is compared with the saved one until a difference is found. This is performed with a configured timeout with its corresponding raised error.

Fixes # INGM-509

### Type of change
- [x] Modify motor_enable() to look for error change
- [x] Modify motor_enable() to include the error-raised-timeout


### Tests
- [x] Add a new test for the timeout raised error test_motor_enable_with_error_timeout_fault()
- [x] Run tests.

Tests have also been run locally with the proper setup that enables the triggering of the error.
### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [ ] Set fix version field in the Jira issue.
