### PR TITLE
INGM-568 Fix N818 error

### DIFF
--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -15,7 +15,7 @@ from ingeniamotion.enums import (
 )
 from ingeniamotion.exceptions import (
     IMMonitoringError,
-    IMRegisterNotExist,
+    IMRegisterNotExistError,
     IMStatusWordError,
 )
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
@@ -301,7 +301,7 @@ class Capture:
                 self.MONITORING_VERSION_REGISTER, servo=servo, axis=0
             )
             return MonitoringVersion.MONITORING_V3
-        except (IMRegisterNotExist, ILIOError):
+        except (IMRegisterNotExistError, ILIOError):
             # The Monitoring V3 is NOT available
             pass
         try:
@@ -309,13 +309,13 @@ class Capture:
                 self.MONITORING_CURRENT_NUMBER_BYTES_REGISTER, servo=servo, axis=0
             )
             return MonitoringVersion.MONITORING_V2
-        except (IMRegisterNotExist, ILIOError):
+        except (IMRegisterNotExistError, ILIOError):
             # The Monitoring V2 is NOT available
             pass
         try:
             self.mc.communication.get_register(self.MONITORING_STATUS_REGISTER, servo=servo, axis=0)
             return MonitoringVersion.MONITORING_V1
-        except (IMRegisterNotExist, ILIOError):
+        except (IMRegisterNotExistError, ILIOError):
             # Monitoring/disturbance are not available
             raise NotImplementedError(
                 "The monitoring and disturbance features are not available for this drive"
@@ -667,7 +667,7 @@ class Capture:
             if not isinstance(max_sample_size, int):
                 raise TypeError("Maximum sample size has to be an integer")
             return max_sample_size
-        except IMRegisterNotExist:
+        except IMRegisterNotExistError:
             return self.MINIMUM_BUFFER_SIZE
 
     def monitoring_max_sample_size(self, servo: str = DEFAULT_SERVO) -> int:
@@ -690,7 +690,7 @@ class Capture:
             if not isinstance(max_sample_size, int):
                 raise TypeError("Maximum sample size has to be an integer")
             return max_sample_size
-        except IMRegisterNotExist:
+        except IMRegisterNotExistError:
             return self.MINIMUM_BUFFER_SIZE
 
     def get_frequency(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> float:

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -30,7 +30,7 @@ from ingenialink.virtual.network import VirtualNetwork
 from ping3 import ping
 from virtual_drive.core import VirtualDrive
 
-from ingeniamotion.exceptions import IMFirmwareLoadError, IMRegisterWrongAccess
+from ingeniamotion.exceptions import IMFirmwareLoadError, IMRegisterWrongAccessError
 
 if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
@@ -1073,7 +1073,7 @@ class Communication:
         if register_dtype_value in unsigned_int and (not isinstance(value, int) or value < 0):
             raise TypeError("Value must be an unsigned int")
         if register_access_type == RegAccess.RO:
-            raise IMRegisterWrongAccess(
+            raise IMRegisterWrongAccessError(
                 f"Register: {register} cannot write to a read-only register"
             )
         drive.write(register, value, subnode=axis)

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -20,7 +20,7 @@ from ingeniamotion.enums import (
     PhasingMode,
     STOAbnormalLatchedStatus,
 )
-from ingeniamotion.exceptions import IMException
+from ingeniamotion.exceptions import IMError
 from ingeniamotion.feedbacks import Feedbacks
 from ingeniamotion.homing import Homing
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
@@ -882,7 +882,7 @@ class Configuration(Homing, Feedbacks):
         """
         drive = self.mc._get_drive(servo)
         if not isinstance(drive, EthernetServo):
-            raise IMException("TCP IP parameters can only be changed in ethernet servos.")
+            raise IMError("TCP IP parameters can only be changed in ethernet servos.")
         if isinstance(mac_address, str):
             mac_address = MACAddressConverter.str_to_int(mac_address)
         drive.change_tcp_ip_parameters(ip_address, subnet_mask, gateway, mac_address)
@@ -896,7 +896,7 @@ class Configuration(Homing, Feedbacks):
         """
         drive = self.mc._get_drive(servo)
         if not isinstance(drive, EthernetServo):
-            raise IMException("TCP IP parameters can only be stored in ethernet servos.")
+            raise IMError("TCP IP parameters can only be stored in ethernet servos.")
         drive.store_tcp_ip_parameters()
 
     def restore_tcp_ip_parameters(self, servo: str = DEFAULT_SERVO) -> None:
@@ -908,7 +908,7 @@ class Configuration(Homing, Feedbacks):
         """
         drive = self.mc._get_drive(servo)
         if not isinstance(drive, EthernetServo):
-            raise IMException("TCP IP parameters can only be restored in ethernet servos.")
+            raise IMError("TCP IP parameters can only be restored in ethernet servos.")
         drive.restore_tcp_ip_parameters()
 
     def get_mac_address(
@@ -926,7 +926,7 @@ class Configuration(Homing, Feedbacks):
         """
         drive = self.mc._get_drive(servo)
         if not isinstance(drive, EthernetServo):
-            raise IMException("The MAC address can only be read from Ethernet servos.")
+            raise IMError("The MAC address can only be read from Ethernet servos.")
         mac_address = drive.get_mac_address()
         return mac_address
 
@@ -945,7 +945,7 @@ class Configuration(Homing, Feedbacks):
         """
         drive = self.mc._get_drive(servo)
         if not isinstance(drive, EthernetServo):
-            raise IMException("The MAC address can only be read from Ethernet servos.")
+            raise IMError("The MAC address can only be read from Ethernet servos.")
         mac_address = drive.get_mac_address()
         return MACAddressConverter.int_to_str(mac_address)
 
@@ -960,7 +960,7 @@ class Configuration(Homing, Feedbacks):
         """
         drive = self.mc._get_drive(servo)
         if not isinstance(drive, EthernetServo):
-            raise IMException("The MAC address can only be set to Ethernet servos.")
+            raise IMError("The MAC address can only be set to Ethernet servos.")
         if isinstance(mac_address, str):
             mac_address = MACAddressConverter.str_to_int(mac_address)
         drive.set_mac_address(mac_address)
@@ -995,23 +995,23 @@ class Configuration(Homing, Feedbacks):
                 prod_codes[subnode] = self.get_product_code(servo, subnode)
             except (
                 ILError,
-                IMException,
+                IMError,
             ) as e:
                 self.logger.error(e)
             # Revision numbers
             try:
                 rev_numbers[subnode] = self.get_revision_number(servo, subnode)
-            except (ILError, IMException) as e:
+            except (ILError, IMError) as e:
                 self.logger.error(e)
             # FW versions
             try:
                 fw_versions[subnode] = self.get_fw_version(servo, subnode)
-            except (ILError, IMException) as e:
+            except (ILError, IMError) as e:
                 self.logger.error(e)
             # Serial numbers
             try:
                 serial_number[subnode] = self.get_serial_number(servo, subnode)
-            except (ILError, IMException) as e:
+            except (ILError, IMError) as e:
                 self.logger.error(e)
 
         return prod_codes, rev_numbers, fw_versions, serial_number

--- a/ingeniamotion/exceptions.py
+++ b/ingeniamotion/exceptions.py
@@ -1,30 +1,51 @@
-class IMException(Exception):  # noqa: N818
+import warnings
+from typing import Any
+
+
+class IMError(Exception):
     """Exceptions raised by IngeniaMotion."""
 
 
-class IMMonitoringError(IMException):
+class IMMonitoringError(IMError):
     """Monitoring error raised by IngeniaMotion."""
 
 
-class IMDisturbanceError(IMException):
+class IMDisturbanceError(IMError):
     """Disturbance error raised by IngeniaMotion."""
 
 
-class IMStatusWordError(IMException):
+class IMStatusWordError(IMError):
     """Status word error raised by IngeniaMotion."""
 
 
-class IMRegisterNotExist(IMException):
+class IMRegisterNotExist(IMError):
     """Error raised by IngeniaMotion when a register not exists."""
 
 
-class IMRegisterWrongAccess(IMException):
+class IMRegisterWrongAccess(IMError):
     """Error raised by IngeniaMotion when trying to write to a read-only register."""
 
 
-class IMTimeoutError(IMException):
+class IMTimeoutError(IMError):
     """Error raised by IngeniaMotion when a timeout has occurred."""
 
 
-class IMFirmwareLoadError(IMException):
+class IMFirmwareLoadError(IMError):
     """Error raised by IngeniaMotion when a firmware file could not be loaded."""
+
+
+# WARNING: Deprecated aliases
+_DEPRECATED = {
+    "IMException": "IMError",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED[name]} instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED[name]]
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/ingeniamotion/exceptions.py
+++ b/ingeniamotion/exceptions.py
@@ -18,11 +18,11 @@ class IMStatusWordError(IMError):
     """Status word error raised by IngeniaMotion."""
 
 
-class IMRegisterNotExist(IMError):
+class IMRegisterNotExistError(IMError):
     """Error raised by IngeniaMotion when a register not exists."""
 
 
-class IMRegisterWrongAccess(IMError):
+class IMRegisterWrongAccessError(IMError):
     """Error raised by IngeniaMotion when trying to write to a read-only register."""
 
 
@@ -37,6 +37,8 @@ class IMFirmwareLoadError(IMError):
 # WARNING: Deprecated aliases
 _DEPRECATED = {
     "IMException": "IMError",
+    "IMRegisterNotExist": "IMRegisterNotExistError",
+    "IMRegisterWrongAccess": "IMRegisterWrongAccessError",
 }
 
 

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -12,7 +12,7 @@ from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.register import Register
 
 from ingeniamotion.enums import CommunicationType
-from ingeniamotion.exceptions import IMError, IMRegisterNotExist
+from ingeniamotion.exceptions import IMError, IMRegisterNotExistError
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 if TYPE_CHECKING:
@@ -54,7 +54,9 @@ class Information:
         try:
             return drive.dictionary.registers(axis)[register]
         except KeyError:
-            raise IMRegisterNotExist(f"Register: {register} axis: {axis} not exist in dictionary")
+            raise IMRegisterNotExistError(
+                f"Register: {register} axis: {axis} not exist in dictionary"
+            )
 
     def register_type(
         self,

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -12,7 +12,7 @@ from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.register import Register
 
 from ingeniamotion.enums import CommunicationType
-from ingeniamotion.exceptions import IMException, IMRegisterNotExist
+from ingeniamotion.exceptions import IMError, IMRegisterNotExist
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 if TYPE_CHECKING:
@@ -174,7 +174,7 @@ class Information:
         if isinstance(net, CanopenNetwork):
             return int(drive.target)
         else:
-            raise IMException("You need a CANopen communication to use this function")
+            raise IMError("You need a CANopen communication to use this function")
 
     def get_baudrate(self, servo: str = DEFAULT_SERVO) -> CanBaudrate:
         """Get the baudrate of target servo.
@@ -188,7 +188,7 @@ class Information:
         net = self.mc._get_network(servo)
         if isinstance(net, CanopenNetwork):
             return CanBaudrate(net.baudrate)
-        raise IMException(f"The servo {servo} is not a CANopen device.")
+        raise IMError(f"The servo {servo} is not a CANopen device.")
 
     def get_ip(self, servo: str = DEFAULT_SERVO) -> str:
         """Get the IP for Ethernet communications.
@@ -204,7 +204,7 @@ class Information:
         if isinstance(net, EthernetNetwork):
             return str(drive.target)
         else:
-            raise IMException("You need an Ethernet communication to use this function")
+            raise IMError("You need an Ethernet communication to use this function")
 
     def get_slave_id(self, servo: str = DEFAULT_SERVO) -> int:
         """Get the EtherCAT slave ID of a given servo.
@@ -222,7 +222,7 @@ class Information:
             return net._configured_slaves[drive.target]
         elif isinstance(net, EthercatNetwork) and isinstance(drive.target, int):
             return drive.target
-        raise IMException(f"The servo {servo} is not an EtherCAT slave.")
+        raise IMError(f"The servo {servo} is not an EtherCAT slave.")
 
     def get_name(self, servo: str = DEFAULT_SERVO) -> str:
         """Get the drive's name.
@@ -298,7 +298,7 @@ class Information:
         drive = self.mc._get_drive(servo)
         dictionary_categories = drive.dictionary.categories
         if not dictionary_categories:
-            raise IMException("Dictionary categories are not defined.")
+            raise IMError("Dictionary categories are not defined.")
         category_ids = dictionary_categories.category_ids
         categories: dict[str, str] = {}
         for cat_id in category_ids:

--- a/ingeniamotion/input_output.py
+++ b/ingeniamotion/input_output.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Union
 import ingenialogger
 
 from ingeniamotion.enums import GPI, GPO, DigitalVoltageLevel, GPIOPolarity
-from ingeniamotion.exceptions import IMException
+from ingeniamotion.exceptions import IMError
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 if TYPE_CHECKING:
@@ -229,4 +229,4 @@ class InputsOutputs:
         gpo_final_value = self.__get_gpio_bit_value(gpos_final_value, gpo_id)
 
         if gpo_final_value != new_target_value:
-            raise IMException("Unable to set the GPOs set point value.")
+            raise IMError("Unable to set the GPOs set point value.")

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -14,7 +14,7 @@ from ingenialink.exceptions import ILError, ILWrongWorkingCountError
 from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
 
 from ingeniamotion.enums import CommunicationType
-from ingeniamotion.exceptions import IMException
+from ingeniamotion.exceptions import IMError
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 
 if TYPE_CHECKING:
@@ -56,7 +56,7 @@ class PDOPoller:
         self.__tpdo_map: TPDOMap = self.__mc.capture.pdo.create_empty_tpdo_map()
         self.__rpdo_map: RPDOMap = self.__mc.capture.pdo.create_empty_rpdo_map()
         self.__fill_rpdo_map()
-        self.__exception_callbacks: list[Callable[[IMException], None]] = []
+        self.__exception_callbacks: list[Callable[[IMError], None]] = []
 
     def start(self) -> None:
         """Start the poller."""
@@ -108,7 +108,7 @@ class PDOPoller:
         """
         self.__fill_tpdo_map(registers)
 
-    def subscribe_to_exceptions(self, callback: Callable[[IMException], None]) -> None:
+    def subscribe_to_exceptions(self, callback: Callable[[IMError], None]) -> None:
         """Get notified when an exception occurs on the PDO thread.
 
         Args:
@@ -206,7 +206,7 @@ class PDONetworkManager:
             watchdog_timeout: Optional[float],
             notify_send_process_data: Optional[Callable[[], None]] = None,
             notify_receive_process_data: Optional[Callable[[], None]] = None,
-            notify_exceptions: Optional[Callable[[IMException], None]] = None,
+            notify_exceptions: Optional[Callable[[IMError], None]] = None,
         ) -> None:
             super().__init__()
             self._net = net
@@ -227,7 +227,7 @@ class PDONetworkManager:
             """Start the PDO exchange."""
             try:
                 self.__set_watchdog_timeout()
-            except IMException as e:
+            except IMError as e:
                 if self._notify_exceptions is not None:
                     self._notify_exceptions(e)
                 return
@@ -258,7 +258,7 @@ class PDONetworkManager:
                             f" callbacks and/or increase the refresh rate/watchdog timeout."
                         )
                     if self._notify_exceptions is not None:
-                        im_exception = IMException(
+                        im_exception = IMError(
                             "Stopping the PDO thread due to the following exception:"
                             f" {il_error} {duration_error}"
                         )
@@ -266,7 +266,7 @@ class PDONetworkManager:
                 except ILError as il_error:
                     self._pd_thread_stop_event.set()
                     if self._notify_exceptions is not None:
-                        im_exception = IMException(
+                        im_exception = IMError(
                             f"Could not start the PDOs due to the following exception: {il_error}"
                         )
                         self._notify_exceptions(im_exception)
@@ -325,7 +325,7 @@ class PDONetworkManager:
                     if max_pdo_watchdog_ms is not None:
                         max_sampling_time = max_pdo_watchdog_ms / self.PDO_WATCHDOG_INCREMENT_FACTOR
                         error_msg += f" The max sampling time is {max_sampling_time} ms."
-                raise IMException(error_msg) from e
+                raise IMError(error_msg) from e
 
     def __init__(self, motion_controller: "MotionController") -> None:
         self.mc = motion_controller
@@ -333,7 +333,7 @@ class PDONetworkManager:
         self._pdo_thread: Optional[PDONetworkManager.ProcessDataThread] = None
         self._pdo_send_observers: list[Callable[[], None]] = []
         self._pdo_receive_observers: list[Callable[[], None]] = []
-        self._pdo_exceptions_observers: list[Callable[[IMException], None]] = []
+        self._pdo_exceptions_observers: list[Callable[[IMError], None]] = []
 
     def create_pdo_item(
         self,
@@ -586,7 +586,7 @@ class PDONetworkManager:
                 network for network in self.mc.net.values() if isinstance(network, CanopenNetwork)
             ]
             if len(ethercat_networks) > 1 or len(canopen_networks) > 1:
-                raise IMException(
+                raise IMError(
                     "When using PDOs only one instance per network type is allowed. "
                     f"Got {len(ethercat_networks)} instances of EthercatNetwork "
                     f"and {len(canopen_networks)} of CanopenNetwork."
@@ -598,7 +598,7 @@ class PDONetworkManager:
             )
         if self._pdo_thread is not None:
             self.stop_pdos()
-            raise IMException("PDOs are already active.")
+            raise IMError("PDOs are already active.")
         if not isinstance(net, EthercatNetwork):
             raise ValueError(f"Expected EthercatNetwork. Got {type(net)}")
         self._pdo_thread = self.ProcessDataThread(
@@ -619,7 +619,7 @@ class PDONetworkManager:
 
         """
         if self._pdo_thread is None:
-            raise IMException("The PDO exchange has not started yet.")
+            raise IMError("The PDO exchange has not started yet.")
         self._pdo_thread.stop()
         self._pdo_thread = None
 
@@ -657,7 +657,7 @@ class PDONetworkManager:
             return
         self._pdo_receive_observers.append(callback)
 
-    def subscribe_to_exceptions(self, callback: Callable[[IMException], None]) -> None:
+    def subscribe_to_exceptions(self, callback: Callable[[IMError], None]) -> None:
         """Subscribe be notified when there is an exception in the PDO process data thread.
 
         If a callback is subscribed, the PDO exchange process is paused when an exception is raised.
@@ -743,7 +743,7 @@ class PDONetworkManager:
             poller.start()
         return poller
 
-    def unsubscribe_to_exceptions(self, callback: Callable[[IMException], None]) -> None:
+    def unsubscribe_to_exceptions(self, callback: Callable[[IMError], None]) -> None:
         """Unsubscribe from the exceptions in the process data notifications.
 
         Args:
@@ -764,7 +764,7 @@ class PDONetworkManager:
         for callback in self._pdo_receive_observers:
             callback()
 
-    def _notify_exceptions(self, exc: IMException) -> None:
+    def _notify_exceptions(self, exc: IMError) -> None:
         """Notify subscribers that there were an exception.
 
         Args:

--- a/ingeniamotion/wizard_tests/base_test.py
+++ b/ingeniamotion/wizard_tests/base_test.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union
 import ingenialogger
 from ingenialink.exceptions import ILError
 
-from ingeniamotion.exceptions import IMRegisterNotExist, IMRegisterWrongAccess
+from ingeniamotion.exceptions import IMRegisterNotExistError, IMRegisterWrongAccessError
 from ingeniamotion.metaclass import DEFAULT_SERVO
 from ingeniamotion.wizard_tests.stoppable import StopExceptionError, Stoppable
 
@@ -58,7 +58,7 @@ class BaseTest(ABC, Stoppable, Generic[T]):
             try:
                 value = self.mc.communication.get_register(uid, servo=self.servo, axis=self.axis)
                 self.backup_registers[self.axis][uid] = value
-            except IMRegisterNotExist as e:  # noqa: PERF203
+            except IMRegisterNotExistError as e:  # noqa: PERF203
                 self.logger.warning(e, axis=self.axis)
 
         for uid in self.optional_backup_registers_names:
@@ -76,9 +76,9 @@ class BaseTest(ABC, Stoppable, Generic[T]):
             for key, value in self.backup_registers[subnode].items():
                 try:
                     self.mc.communication.set_register(key, value, servo=self.servo, axis=self.axis)
-                except IMRegisterNotExist as e:  # noqa: PERF203
+                except IMRegisterNotExistError as e:  # noqa: PERF203
                     self.logger.warning(e, axis=subnode)
-                except IMRegisterWrongAccess as e:
+                except IMRegisterWrongAccessError as e:
                     self.logger.warning(e, axis=subnode)
 
     @Stoppable.stoppable

--- a/ingeniamotion/wizard_tests/brake_tune.py
+++ b/ingeniamotion/wizard_tests/brake_tune.py
@@ -5,7 +5,7 @@ import ingenialogger
 from typing_extensions import override
 
 from ingeniamotion.enums import OperationMode, SeverityLevel
-from ingeniamotion.exceptions import IMRegisterNotExist
+from ingeniamotion.exceptions import IMRegisterNotExistError
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 from ingeniamotion.motion_controller import MotionController
 from ingeniamotion.wizard_tests import stoppable
@@ -87,7 +87,7 @@ class BrakeTune(BaseTest[LegacyDictReportType]):
     def loop(self) -> Optional[ResultBrakeType]:
         try:
             reg_values = self.__update_brake_registers_values()
-        except IMRegisterNotExist:
+        except IMRegisterNotExistError:
             return ResultBrakeType.FAIL_DICTIONARY
         # Register values to avoid meanwhile the test is being executed
         no_brake_current_feedback_source = 0

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ingeniamotion import MotionController
 
 from ingeniamotion.enums import CommutationMode, OperationMode, SensorType, SeverityLevel
-from ingeniamotion.exceptions import IMRegisterNotExist
+from ingeniamotion.exceptions import IMRegisterNotExistError
 from ingeniamotion.wizard_tests.base_test import BaseTest, LegacyDictReportType, TestError
 
 
@@ -210,7 +210,7 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
                 self.mc.communication.set_register(
                     following_error_uid, 1, servo=self.servo, axis=self.axis
                 )
-            except IMRegisterNotExist as e:  # noqa: PERF203
+            except IMRegisterNotExistError as e:  # noqa: PERF203
                 self.logger.warning(e)
 
     @BaseTest.stoppable

--- a/ingeniamotion/wizard_tests/phase_calibration.py
+++ b/ingeniamotion/wizard_tests/phase_calibration.py
@@ -13,7 +13,7 @@ from ingeniamotion.enums import (
     SensorType,
     SeverityLevel,
 )
-from ingeniamotion.exceptions import IMRegisterNotExist
+from ingeniamotion.exceptions import IMRegisterNotExistError
 from ingeniamotion.wizard_tests.base_test import BaseTest, LegacyDictReportType, TestError
 
 if TYPE_CHECKING:
@@ -245,14 +245,14 @@ class Phasing(BaseTest[LegacyDictReportType]):
             self.mc.communication.set_register(
                 "COMMU_ANGLE_INTEGRITY1_OPTION", 1, servo=self.servo, axis=self.axis
             )
-        except IMRegisterNotExist:
+        except IMRegisterNotExistError:
             self.logger.warning("Could not write COMMU_ANGLE_INTEGRITY1_OPTION")
 
         try:
             self.mc.communication.set_register(
                 "COMMU_ANGLE_INTEGRITY2_OPTION", 1, servo=self.servo, axis=self.axis
             )
-        except IMRegisterNotExist:
+        except IMRegisterNotExistError:
             self.logger.warning("Could not write COMMU_ANGLE_INTEGRITY2_OPTION")
 
     @BaseTest.stoppable

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -6,7 +6,7 @@ import pytest
 from ingenialink import exceptions
 
 from ingeniamotion.enums import SensorType, SeverityLevel
-from ingeniamotion.exceptions import IMRegisterNotExist
+from ingeniamotion.exceptions import IMRegisterNotExistError
 from ingeniamotion.wizard_tests.base_test import TestError
 from ingeniamotion.wizard_tests.feedbacks_tests.absolute_encoder1_test import AbsoluteEncoder1Test
 from ingeniamotion.wizard_tests.feedbacks_tests.absolute_encoder2_test import AbsoluteEncoder2Test
@@ -227,7 +227,7 @@ def test_brake_test(motion_controller):
 def get_backup_registers(test, mc, alias):
     reg_values = {}
     for reg in test.BACKUP_REGISTERS:
-        with contextlib.suppress(IMRegisterNotExist):
+        with contextlib.suppress(IMRegisterNotExistError):
             reg_values[reg] = mc.communication.get_register(reg, servo=alias)
     return reg_values
 

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -19,8 +19,8 @@ import ingeniamotion
 from ingeniamotion import MotionController
 from ingeniamotion.exceptions import (
     IMFirmwareLoadError,
-    IMRegisterNotExist,
-    IMRegisterWrongAccess,
+    IMRegisterNotExistError,
+    IMRegisterWrongAccessError,
 )
 
 from .setups.descriptors import DriveCanOpenSetup, EthernetSetup, Setup
@@ -221,7 +221,7 @@ def test_get_register(motion_controller, uid, value):
 @pytest.mark.smoke
 def test_get_register_wrong_uid(motion_controller):
     mc, alias, environment = motion_controller
-    with pytest.raises(IMRegisterNotExist):
+    with pytest.raises(IMRegisterNotExistError):
         mc.communication.get_register("WRONG_UID", servo=alias)
 
 
@@ -247,7 +247,7 @@ def test_set_register(motion_controller, uid, value):
 @pytest.mark.smoke
 def test_set_register_wrong_uid(motion_controller):
     mc, alias, environment = motion_controller
-    with pytest.raises(IMRegisterNotExist):
+    with pytest.raises(IMRegisterNotExistError):
         mc.communication.set_register("WRONG_UID", 2, servo=alias)
 
 
@@ -282,7 +282,7 @@ def test_set_register_wrong_access(motion_controller):
     mc, alias, environment = motion_controller
     uid = "DRV_STATE_STATUS"
     value = 0
-    with pytest.raises(IMRegisterWrongAccess):
+    with pytest.raises(IMRegisterWrongAccessError):
         mc.communication.set_register(uid, value, servo=alias)
 
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -12,7 +12,7 @@ from ingeniamotion.enums import (
     FilterType,
     STOAbnormalLatchedStatus,
 )
-from ingeniamotion.exceptions import IMException
+from ingeniamotion.exceptions import IMError
 
 BRAKE_OVERRIDE_REGISTER = "MOT_BRAKE_OVERRIDE"
 POSITION_SET_POINT_REGISTER = "CL_POS_SET_POINT_VALUE"
@@ -835,7 +835,7 @@ def test_get_phasing_mode_invalid(mocker, motion_controller):
 def test_change_tcp_ip_parameters_exception(mocker, motion_controller):
     mc, alias, environment = motion_controller
     mocker.patch.object(mc, "_get_drive", return_value=EthercatServo)
-    with pytest.raises(IMException):
+    with pytest.raises(IMError):
         mc.configuration.change_tcp_ip_parameters(
             "192.168.2.22", "255.255.0.0", "192.168.2.1", servo=alias
         )
@@ -852,7 +852,7 @@ def test_change_tcp_ip_parameters_exception(mocker, motion_controller):
 def test_store_restore_tcp_ip_parameters_exception(mocker, motion_controller, function):
     mc, alias, environment = motion_controller
     mocker.patch.object(mc, "_get_drive", return_value=EthercatServo)
-    with pytest.raises(IMException):
+    with pytest.raises(IMError):
         getattr(mc.configuration, function)(servo=alias)
 
 

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -6,7 +6,7 @@ from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.register import RegAccess, RegDtype
 
-from ingeniamotion.exceptions import IMException, IMRegisterNotExist
+from ingeniamotion.exceptions import IMError, IMRegisterNotExist
 from ingeniamotion.information import CommunicationType
 
 
@@ -227,7 +227,7 @@ def test_get_product_name_none(motion_controller):
 @pytest.mark.virtual
 def test_get_node_id_exception(motion_controller):
     mc, alias, environment = motion_controller
-    with pytest.raises(IMException):
+    with pytest.raises(IMError):
         mc.info.get_node_id(alias)
 
 
@@ -236,14 +236,14 @@ def test_get_ip_exception(mocker, motion_controller):
     mc, alias, environment = motion_controller
     mocker.patch("ingenialink.ethercat.network.EthercatNetwork.__init__", return_value=None)
     mocker.patch.object(mc, "_get_network", return_value=EthercatNetwork("fake_interface_name"))
-    with pytest.raises(IMException):
+    with pytest.raises(IMError):
         mc.info.get_ip(alias)
 
 
 @pytest.mark.virtual
 def test_get_slave_id_exception(motion_controller):
     mc, alias, environment = motion_controller
-    with pytest.raises(IMException):
+    with pytest.raises(IMError):
         mc.info.get_slave_id(alias)
 
 
@@ -268,7 +268,7 @@ def test_get_baudrate_failed(motion_controller, mocker):
 
     mocker.patch("ingenialink.ethercat.network.EthercatNetwork.__init__", return_value=None)
     mocker.patch.object(mc, "_get_network", return_value=EthercatNetwork("fake_interface_name"))
-    with pytest.raises(IMException) as imexpeption_info:
+    with pytest.raises(IMError) as imexpeption_info:
         _ = mc.info.get_baudrate(alias)
 
     expected_message_error = "The servo test is not a CANopen device."

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -6,7 +6,7 @@ from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.register import RegAccess, RegDtype
 
-from ingeniamotion.exceptions import IMError, IMRegisterNotExist
+from ingeniamotion.exceptions import IMError, IMRegisterNotExistError
 from ingeniamotion.information import CommunicationType
 
 
@@ -211,7 +211,7 @@ def test_get_encoded_image_from_dictionary(motion_controller):
 @pytest.mark.virtual
 def test_register_info_exception(motion_controller):
     mc, alias, environment = motion_controller
-    with pytest.raises(IMRegisterNotExist):
+    with pytest.raises(IMRegisterNotExistError):
         mc.info.register_info("non_existing_uid", 1, alias)
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ingeniamotion.enums import GPI, GPO, DigitalVoltageLevel, GPIOPolarity
-from ingeniamotion.exceptions import IMException
+from ingeniamotion.exceptions import IMError
 
 from .setups.rack_setups import CAN_CAP_SETUP, ECAT_CAP_SETUP, ETH_CAP_SETUP
 
@@ -141,5 +141,5 @@ def test_set_gpo_voltage_level_fail(motion_controller, gpo_id):
     for map_reg in ["IO_OUT_MAP_1", "IO_OUT_MAP_2", "IO_OUT_MAP_3", "IO_OUT_MAP_4"]:
         mc.communication.set_register(map_reg, 3, servo=alias)
 
-    with pytest.raises(IMException):
+    with pytest.raises(IMError):
         mc.io.set_gpo_voltage_level(gpo_id, DigitalVoltageLevel.LOW, servo=alias)

--- a/tests/test_pdo.py
+++ b/tests/test_pdo.py
@@ -8,7 +8,7 @@ from ingenialink.pdo import RPDOMap, RPDOMapItem, TPDOMap, TPDOMapItem
 from packaging import version
 
 from ingeniamotion.enums import CommunicationType, OperationMode
-from ingeniamotion.exceptions import IMException
+from ingeniamotion.exceptions import IMError
 
 from .setups.descriptors import EthercatMultiSlaveSetup
 
@@ -268,7 +268,7 @@ def test_start_pdos(motion_controller, tests_setup):
 @pytest.mark.soem
 def test_stop_pdos_exception(motion_controller):
     mc, alias, environment = motion_controller
-    with pytest.raises(IMException):
+    with pytest.raises(IMError):
         mc.capture.pdo.stop_pdos()
 
 
@@ -293,7 +293,7 @@ def test_start_pdos_number_of_network_exception(mocker, motion_controller):
     mocker.patch.object(mc, "_MotionController__net", mock_net)
     with pytest.raises(ValueError):
         mc.capture.pdo.start_pdos()
-    with pytest.raises(IMException):
+    with pytest.raises(IMError):
         mc.capture.pdo.start_pdos(CommunicationType.Ethercat)
 
 


### PR DESCRIPTION
### Description

Some exceptions don't follow the [N818 ](https://docs.astral.sh/ruff/rules/error-suffix-on-exception-name/) rule.

Fixes # INGM-568

### Type of change

- Rename IMException to IMError.
- Rename IMRegisterNotExist to IMRegisterNotExistError.
- Rename IMRegisterWrongAccess to IMRegisterWrongAccessError.
- Add deprecation warnings.


### Tests
- [ ] Add new unit tests if it applies.
- [ ] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
