### PR TITLE
INGM-575 Check if monitoring is enabled before reading monitoring data

### DIFF
--- a/ingeniamotion/monitoring/base_monitoring.py
+++ b/ingeniamotion/monitoring/base_monitoring.py
@@ -366,6 +366,8 @@ class Monitoring(ABC):
             Data of monitoring. Each element of the list is a different register data.
 
         """
+        if not self.mc.capture.is_monitoring_enabled(servo=self.servo):
+            raise IMMonitoringError("Cannot read monitoring data. Monitoring is disabled.")
         drive = self.mc.servos[self.servo]
         self._read_process_finished = False
         is_ready, result_text = self._check_monitoring_is_ready()

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -327,8 +327,9 @@ def test_read_monitoring_data_not_configured(motion_controller, monitoring):
 @pytest.mark.usefixtures("mon_map_registers")
 def test_read_monitoring_data_disabled(monitoring):
     monitoring.configure_sample_time(0.8, 0)
-    test_output = monitoring.read_monitoring_data()
-    assert len(test_output[0]) == 0
+    with pytest.raises(IMMonitoringError) as exc:
+        monitoring.read_monitoring_data()
+    assert str(exc.value) == "Cannot read monitoring data. Monitoring is disabled."
 
 
 @pytest.mark.ethernet


### PR DESCRIPTION
### Description

Check if monitoring is enabled before reading monitoring data.

Fixes # INGM-575

### Type of change

- Raise an exception if monitoring is not enabled when reading monitoring data.
-Update tests.


### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
