### PR TITLE
Ingm 585 remove examples and tests import from ingeniamotion pytests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,11 +1,6 @@
 [run]
 relative_files = True
 omit = tests/*
-source =
-    .tox/py39/Lib/site-packages/ingeniamotion
-    .tox/py310/Lib/site-packages/ingeniamotion
-    .tox/py311/Lib/site-packages/ingeniamotion
-    .tox/py312/Lib/site-packages/ingeniamotion
 
 ; Specify that all these paths should be considered as a single package, otherwise
 ; it would duplicate the lines for each python version that has coverage data

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,26 @@
 [run]
 relative_files = True
+omit = tests/*
+source =
+    .tox/py39/Lib/site-packages/ingeniamotion
+    .tox/py310/Lib/site-packages/ingeniamotion
+    .tox/py311/Lib/site-packages/ingeniamotion
+    .tox/py312/Lib/site-packages/ingeniamotion
+
+; Specify that all these paths should be considered as a single package, otherwise
+; it would duplicate the lines for each python version that has coverage data
+; `ingeniamotion` path is included because the coverage step runs skipping installation in tox
+; so it is needed to indicate that the site-packages and the cloned repo should be the same
+[paths]
+source =
+    ingeniamotion
+    .tox/py39/Lib/site-packages/ingeniamotion
+    .tox/py310/Lib/site-packages/ingeniamotion
+    .tox/py311/Lib/site-packages/ingeniamotion
+    .tox/py312/Lib/site-packages/ingeniamotion
+
+; Skip empty files
+[report]
+skip_empty = true
+omit =
+    */__init__.py

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,6 +68,7 @@ def runTestHW(markers, setup_name) {
             bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${version} -- " +
                     "-m \"${markers}\" " +
                     "--setup tests.setups.rack_setups.${setup_name} " +
+                    "--cov " +
                     "--job_name=\"${env.JOB_NAME}-#${env.BUILD_NUMBER}-${setup_name}\""
         } catch (err) {
             unstable(message: "Tests failed")
@@ -301,6 +302,7 @@ pipeline {
                                         }
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
                                                 "-m \"not ethernet and not soem and not canopen and not virtual and not soem_multislave\" "
+                                                "--cov "
                                     }
                                     post {
                                         always {
@@ -323,6 +325,7 @@ pipeline {
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
                                                 "-m virtual " +
                                                 "--setup tests.setups.virtual_drive.TESTS_SETUP "
+                                                "--cov "
                                     }
                                     post {
                                         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,6 @@ def runTestHW(markers, setup_name) {
             bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${version} -- " +
                     "-m \"${markers}\" " +
                     "--setup tests.setups.rack_setups.${setup_name} " +
-                    "--cov " +
                     "--job_name=\"${env.JOB_NAME}-#${env.BUILD_NUMBER}-${setup_name}\""
         } catch (err) {
             unstable(message: "Tests failed")
@@ -301,8 +300,7 @@ pipeline {
                                             restoreIngenialinkWheelEnvVar()
                                         }
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
-                                                "-m \"not ethernet and not soem and not canopen and not virtual and not soem_multislave\" " +
-                                                "--cov "
+                                                "-m \"not ethernet and not soem and not canopen and not virtual and not soem_multislave\" "
                                     }
                                     post {
                                         always {
@@ -324,8 +322,7 @@ pipeline {
                                         }
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
                                                 "-m virtual " +
-                                                "--setup tests.setups.virtual_drive.TESTS_SETUP " +
-                                                "--cov "
+                                                "--setup tests.setups.virtual_drive.TESTS_SETUP "
                                     }
                                     post {
                                         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,6 @@ def runTestHW(markers, setup_name) {
             bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${version} -- " +
                     "-m \"${markers}\" " +
                     "--setup tests.setups.rack_setups.${setup_name} " +
-                    "--cov=ingeniamotion " +
                     "--job_name=\"${env.JOB_NAME}-#${env.BUILD_NUMBER}-${setup_name}\""
         } catch (err) {
             unstable(message: "Tests failed")
@@ -298,8 +297,7 @@ pipeline {
                                             restoreIngenialinkWheelEnvVar()
                                         }
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
-                                                "-m \"not ethernet and not soem and not canopen and not virtual and not soem_multislave\" " +
-                                                "--cov=ingeniamotion"
+                                                "-m \"not ethernet and not soem and not canopen and not virtual and not soem_multislave\" "
                                     }
                                     post {
                                         always {
@@ -321,8 +319,7 @@ pipeline {
                                         }
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
                                                 "-m virtual " +
-                                                "--setup tests.setups.virtual_drive.TESTS_SETUP "  +
-                                                "--cov=ingeniamotion"
+                                                "--setup tests.setups.virtual_drive.TESTS_SETUP "
                                     }
                                     post {
                                         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -301,7 +301,7 @@ pipeline {
                                             restoreIngenialinkWheelEnvVar()
                                         }
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
-                                                "-m \"not ethernet and not soem and not canopen and not virtual and not soem_multislave\" "
+                                                "-m \"not ethernet and not soem and not canopen and not virtual and not soem_multislave\" " +
                                                 "--cov "
                                     }
                                     post {
@@ -324,7 +324,7 @@ pipeline {
                                         }
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
                                                 "-m virtual " +
-                                                "--setup tests.setups.virtual_drive.TESTS_SETUP "
+                                                "--setup tests.setups.virtual_drive.TESTS_SETUP " +
                                                 "--cov "
                                     }
                                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -236,6 +236,9 @@ pipeline {
                     stages {
                         stage('Run no-connection tests') {
                             steps {
+                                script {
+                                    restoreIngenialinkWheelEnvVar()
+                                }
                                 sh "python${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
                                     "-m virtual " +
                                     "--setup tests.setups.virtual_drive.TESTS_SETUP"

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ tox -e docs
 Run PyTest
 ----------
 
-Create tests/setups/tests_setup.py file with configuration file.
-This file is ignored by git and won't be uploaded to the repository
+Create *tests/setups/tests_setup.py* file with configuration file.
+
+This file is ignored by git and won't be uploaded to the repository.
 Example of a setup:
 
 ```python
@@ -65,9 +66,33 @@ TESTS_SETUP = DriveEcatSetup(
 )
 ```
 
+To obtain *ifname* setting, can run the following:
+
+```python
+from ingeniamotion.communication import Communication
+
+def main() -> None:
+    network_adapters = Communication.get_network_adapters()
+    for adapter_name, adapter_guid in network_adapters.items():
+        print(f"{adapter_name}: {adapter_guid}")
+
+if __name__ == "__main__":
+    main()
+```
+
+This will print a list of adapters, select the one that you are currently using (check your network settings).
+
 Run tests selecting the markers that you want and are appropriate for your setup.
 Beware that some tests may not be appropiate for the setup that you have and may fail.
 
 ```bash
 tox -e py39 -- -m soem
+```
+
+This will use the default *ingenialink* installation from *[develop]* setting. If you want to send a custom wheel or a different commit, you can do it by changing *INGENIALINK_INSTALL_PATH* variable.
+
+For example, to send a custom wheel:
+
+```python
+INGENIALINK_INSTALL_PATH=dist/ingenialink-7.4.1-cp39-cp39-win_amd64.whl tox -e py39
 ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = tests
+addopts = --import-mode=importlib
 markers =
     develop: test in develop
     smoke: smoke tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,8 @@ import importlib
 import sys
 import time
 from pathlib import Path
-from typing import Optional, Union
+from types import ModuleType
+from typing import Optional
 
 import numpy as np
 import pytest
@@ -13,34 +14,7 @@ from virtual_drive.core import VirtualDrive
 
 from ingeniamotion import MotionController
 from ingeniamotion.enums import SensorType
-
-
-def dynamic_import(module_path: Union[Path, str], import_name: Optional[Union[str, list[str]]]):
-    if not isinstance(module_path, Path):
-        module_path = Path(module_path)
-    absolute_module_path = module_path.with_suffix(".py").resolve()
-    module_name = absolute_module_path.stem  # Get the module name without the .py extension
-
-    # Check if the module is already loaded
-    sys_module_name = module_path.with_suffix("").as_posix().replace("/", ".")
-    if sys_module_name in sys.modules:
-        module = sys.modules[sys_module_name]
-    # Load the module
-    else:
-        spec = importlib.util.spec_from_file_location(module_name, absolute_module_path)
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        sys.modules[sys_module_name] = module
-
-    # Get the method/variable
-    if import_name is None:
-        return module
-    if not isinstance(import_name, list):
-        return getattr(module, import_name)
-    return [getattr(module, n) for n in import_name]
-
-
-(
+from tests.setups.descriptors import (
     DriveCanOpenSetup,
     DriveEcatSetup,
     DriveEthernetSetup,
@@ -48,30 +22,90 @@ def dynamic_import(module_path: Union[Path, str], import_name: Optional[Union[st
     EthercatMultiSlaveSetup,
     Setup,
     VirtualDriveSetup,
-) = dynamic_import(
-    module_path="tests/setups/descriptors",
-    import_name=[
-        "DriveCanOpenSetup",
-        "DriveEcatSetup",
-        "DriveEthernetSetup",
-        "DriveHwSetup",
-        "EthercatMultiSlaveSetup",
-        "Setup",
-        "VirtualDriveSetup",
-    ],
 )
-(
+from tests.setups.environment_control import (
     ManualUserEnvironmentController,
     RackServiceEnvironmentController,
     VirtualDriveEnvironmentController,
-) = dynamic_import(
-    module_path="tests/setups/environment_control",
-    import_name=[
-        "ManualUserEnvironmentController",
-        "RackServiceEnvironmentController",
-        "VirtualDriveEnvironmentController",
-    ],
 )
+
+# Pytest runs with importlib import mode, which means that it will run the tests with the installed
+# version of the package. Therefore, modules that are not included in the package cannot be imported
+# in the tests.
+# The issue is solved by dynamically importing them before the tests start. All modules that should
+# be imported and ARE NOT part of the package should be specified here
+_DYNAMIC_MODULES_IMPORT = ["tests", "examples"]
+
+
+def import_module_from_local_path(
+    module_name: str, module_path: Path, add_to_sys_modules: bool = True
+) -> Optional[ModuleType]:
+    """Imports a module using a local path.
+
+    Args:
+        module_name: name that it will have in `sys.modules`.
+        module_path: module path.
+        add_to_sys_modules (bool, optional): True to add the module to `sys.modules`,
+            False otherwise. Defaults to True.
+
+    Returns:
+        imported module, None if it can not be imported.
+    """
+    # Check if it is already loaded
+    module = sys.modules.get(module_name)
+    if module is not None and hasattr(module, "__file__") and Path(module.__file__) == module_path:
+        return sys.modules[module_name]
+
+    # Load the module and add it to sys modules if required
+    if module_path.is_dir():
+        module_name = module_path.name
+        module_path /= "__init__.py"
+        if not module_path.exists():
+            return None
+    else:
+        module_name = module_path.stem
+
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if add_to_sys_modules:
+        sys.modules[module_name] = module
+    return module
+
+
+def dynamic_loader(module_path: Path) -> None:
+    """Dynamically loads the modules that are not part of the package.
+
+    Should only be used if import mode is `importlib`.
+
+    Args:
+        module_path: path to the module to be loaded.
+
+    Raises:
+        RuntimeError: if the provided path is not a directory with a valid `__init__.py` file.
+    """
+    if not (module_path / "__init__.py").exists():
+        raise RuntimeError("Only directories with init path can be added in the dynamic loader")
+
+    import_module_from_local_path(module_name=module_path.name, module_path=module_path)
+
+    # Import all the submodules and files from the indicated module
+    for path in module_path.rglob("*"):
+        if "__pycache__" in path.parts:
+            continue  # Skip __pycache__ and its contents
+        elif path.is_dir():
+            if not (path / "__init__.py").exists():
+                continue  # Ignore directories without init ifle
+            sys_module_name = ".".join(path.relative_to(module_path).parts)
+        elif path.suffix == ".py":
+            if path.name == "__init__.py" or path.name.startswith("test_"):
+                continue  # Skip init file and avoid including all tests as modules
+            sys_module_name = ".".join(path.relative_to(module_path).with_suffix("").parts)
+        else:
+            continue
+
+        import_module_from_local_path(module_name=sys_module_name, module_path=path)
+
 
 test_report_key = pytest.StashKey[dict[str, pytest.CollectReport]]()
 
@@ -94,10 +128,27 @@ def pytest_addoption(parser):
     )
 
 
+def pytest_sessionstart(session):
+    """Loads the modules that are not part of the package if import mode is importlib.
+
+    Args:
+        session: session.
+    """
+    if session.config.option.importmode != "importlib":
+        return
+    ingeniamotion_base_path = Path(__file__).parents[1]
+    for module_name in _DYNAMIC_MODULES_IMPORT:
+        dynamic_loader((ingeniamotion_base_path / module_name).resolve())
+
+
 @pytest.fixture(scope="session")
 def tests_setup(request) -> Setup:
     setup_location = Path(request.config.getoption("--setup").replace(".", "/"))
-    return dynamic_import(module_path=setup_location.parent, import_name=setup_location.name)
+    setup_module = import_module_from_local_path(
+        module_name=setup_location.parent.name,
+        module_path=setup_location.parent.with_suffix(".py").resolve(),
+    )
+    return getattr(setup_module, setup_location.name)
 
 
 def connect_ethernet(mc, config, alias):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,14 +22,15 @@ def dynamic_import(module_path: Union[Path, str], import_name: Optional[Union[st
     module_name = absolute_module_path.stem  # Get the module name without the .py extension
 
     # Check if the module is already loaded
-    if module_name in sys.modules:
-        module = sys.modules[module_name]
+    sys_module_name = module_path.with_suffix("").as_posix().replace("/", ".")
+    if sys_module_name in sys.modules:
+        module = sys.modules[sys_module_name]
     # Load the module
     else:
         spec = importlib.util.spec_from_file_location(module_name, absolute_module_path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-        sys.modules[module_name] = module
+        sys.modules[sys_module_name] = module
 
     # Get the method/variable
     if import_name is None:

--- a/tests/dictionaries/__init__.py
+++ b/tests/dictionaries/__init__.py
@@ -1,4 +1,5 @@
-from os.path import abspath, dirname, join
+from pathlib import Path
 
-PATH = dirname(abspath(__file__))
-VIRTUAL_DRIVE_XDF_PATH = join(PATH, "virtual_drive.xdf")
+__dictionaries_root_path = absolute_module_path = Path(__file__).parent
+PATH = __dictionaries_root_path.as_posix()
+VIRTUAL_DRIVE_XDF_PATH = (__dictionaries_root_path / "virtual_drive.xdf").as_posix()

--- a/tests/setups/rack_setups.py
+++ b/tests/setups/rack_setups.py
@@ -1,8 +1,13 @@
-from .descriptors import (
-    DriveCanOpenSetup,
-    DriveEcatSetup,
-    DriveEthernetSetup,
-    EthercatMultiSlaveSetup,
+from tests.conftest import dynamic_import
+
+DriveCanOpenSetup, DriveEcatSetup, DriveEthernetSetup, EthercatMultiSlaveSetup = dynamic_import(
+    module_path="tests/setups/descriptors",
+    import_name=[
+        "DriveCanOpenSetup",
+        "DriveEcatSetup",
+        "DriveEthernetSetup",
+        "EthercatMultiSlaveSetup",
+    ],
 )
 
 ETH_EVE_SETUP = DriveEthernetSetup(

--- a/tests/setups/rack_setups.py
+++ b/tests/setups/rack_setups.py
@@ -1,13 +1,8 @@
-from tests.conftest import dynamic_import
-
-DriveCanOpenSetup, DriveEcatSetup, DriveEthernetSetup, EthercatMultiSlaveSetup = dynamic_import(
-    module_path="tests/setups/descriptors",
-    import_name=[
-        "DriveCanOpenSetup",
-        "DriveEcatSetup",
-        "DriveEthernetSetup",
-        "EthercatMultiSlaveSetup",
-    ],
+from tests.setups.descriptors import (
+    DriveCanOpenSetup,
+    DriveEcatSetup,
+    DriveEthernetSetup,
+    EthercatMultiSlaveSetup,
 )
 
 ETH_EVE_SETUP = DriveEthernetSetup(

--- a/tests/setups/virtual_drive.py
+++ b/tests/setups/virtual_drive.py
@@ -1,6 +1,9 @@
-from tests import dictionaries
+from tests.conftest import dynamic_import
 
-from .descriptors import VirtualDriveSetup
+dictionaries = dynamic_import(module_path="tests/dictionaries/__init__", import_name=None)
+VirtualDriveSetup = dynamic_import(
+    module_path="tests/setups/descriptors.py", import_name="VirtualDriveSetup"
+)
 
 TESTS_SETUP = VirtualDriveSetup(
     ip="127.0.0.1", dictionary=dictionaries.VIRTUAL_DRIVE_XDF_PATH, port=1061

--- a/tests/setups/virtual_drive.py
+++ b/tests/setups/virtual_drive.py
@@ -1,9 +1,5 @@
-from tests.conftest import dynamic_import
-
-dictionaries = dynamic_import(module_path="tests/dictionaries/__init__", import_name=None)
-VirtualDriveSetup = dynamic_import(
-    module_path="tests/setups/descriptors.py", import_name="VirtualDriveSetup"
-)
+from tests import dictionaries
+from tests.setups.descriptors import VirtualDriveSetup
 
 TESTS_SETUP = VirtualDriveSetup(
     ip="127.0.0.1", dictionary=dictionaries.VIRTUAL_DRIVE_XDF_PATH, port=1061

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -26,17 +26,6 @@ from ingeniamotion.exceptions import (
 )
 from tests.setups.descriptors import DriveCanOpenSetup, DriveEcatSetup, EthernetSetup, Setup
 
-
-@pytest.fixture
-def adapters_module():
-    current_platform = platform.system()
-    if current_platform == "Windows":
-        import ingenialink.get_adapters_addresses as adapters
-
-        return adapters
-    pytest.skip(f"Skipping test, only available on Windows, platform={current_platform}")
-
-
 TEST_ENSEMBLE_FW_FILE = "tests/resources/example_ensemble_fw.zfu"
 
 

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -22,8 +22,12 @@ from ingeniamotion.exceptions import (
     IMRegisterNotExistError,
     IMRegisterWrongAccessError,
 )
+from tests.conftest import dynamic_import
 
-from .setups.descriptors import DriveCanOpenSetup, EthernetSetup, Setup
+DriveCanOpenSetup, EthernetSetup, Setup = dynamic_import(
+    module_path="tests/setups/descriptors",
+    import_name=["DriveCanOpenSetup", "EthernetSetup", "Setup"],
+)
 
 
 @pytest.fixture

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -24,12 +24,7 @@ from ingeniamotion.exceptions import (
     IMRegisterNotExistError,
     IMRegisterWrongAccessError,
 )
-from tests.conftest import dynamic_import
-
-DriveCanOpenSetup, DriveEcatSetup, EthernetSetup, Setup = dynamic_import(
-    module_path="tests/setups/descriptors",
-    import_name=["DriveCanOpenSetup", "DriveEcatSetup", "EthernetSetup", "Setup"],
-)
+from tests.setups.descriptors import DriveCanOpenSetup, DriveEcatSetup, EthernetSetup, Setup
 
 
 @pytest.fixture

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import sys
 import tempfile
 import time
 from collections import OrderedDict
@@ -321,7 +322,8 @@ def dummy_callback(status, _, axis):
 def test_subscribe_servo_status(mocker, motion_controller):
     mc, alias, environment = motion_controller
     axis = 1
-    patch_callback = mocker.patch("tests.test_communication.dummy_callback")
+    current_module = sys.modules[__name__]
+    patch_callback = mocker.patch.object(current_module, "dummy_callback")
     mc.communication.subscribe_servo_status(patch_callback, alias)
     time.sleep(0.5)
     mc.motion.motor_enable(alias, axis)

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -26,7 +26,7 @@ from ingeniamotion.exceptions import (
 )
 from tests.conftest import dynamic_import
 
-DriveCanOpenSetup, EthernetSetup, Setup = dynamic_import(
+DriveCanOpenSetup, DriveEcatSetup, EthernetSetup, Setup = dynamic_import(
     module_path="tests/setups/descriptors",
     import_name=["DriveCanOpenSetup", "DriveEcatSetup", "EthernetSetup", "Setup"],
 )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -6,6 +6,18 @@ from ingenialink import CanBaudrate, CanDevice
 from ingenialink.exceptions import ILFirmwareLoadError
 from ingenialink.pdo import RPDOMap, TPDOMap
 
+from examples.change_baudrate import change_baudrate
+from examples.change_node_id import change_node_id
+from examples.commutation_test_encoders import main as main_commutation_test_encoders
+from examples.connect_ecat_coe import connect_ethercat_coe
+from examples.load_fw_canopen import load_firmware_canopen
+from examples.load_save_config_register_changes import (
+    main as main_load_save_config_register_changes,
+)
+from examples.load_save_configuration import main as main_load_save_configuration
+from examples.pdo_poller_example import main as set_up_pdo_poller
+from examples.position_ramp import main as main_position_ramp
+from examples.process_data_object import main as main_process_data_object
 from ingeniamotion import MotionController
 from ingeniamotion.communication import Communication
 from ingeniamotion.configuration import Configuration
@@ -14,42 +26,13 @@ from ingeniamotion.enums import SeverityLevel
 from ingeniamotion.information import Information
 from ingeniamotion.motion import Motion
 from ingeniamotion.pdo import PDONetworkManager, PDOPoller
-from tests.conftest import connect_canopen, connect_ethernet, connect_soem, dynamic_import
-
-DriveCanOpenSetup, DriveEcatSetup, DriveEthernetSetup, EthernetSetup, Setup = dynamic_import(
-    module_path="tests/setups/descriptors",
-    import_name=[
-        "DriveCanOpenSetup",
-        "DriveEcatSetup",
-        "DriveEthernetSetup",
-        "EthernetSetup",
-        "Setup",
-    ],
-)
-
-change_baudrate = dynamic_import(
-    module_path="examples/change_baudrate", import_name="change_baudrate"
-)
-change_node_id = dynamic_import(module_path="examples/change_node_id", import_name="change_node_id")
-main_commutation_test_encoders = dynamic_import(
-    module_path="examples/commutation_test_encoders", import_name="main"
-)
-connect_ethercat_coe = dynamic_import(
-    module_path="examples/connect_ecat_coe", import_name="connect_ethercat_coe"
-)
-load_firmware_canopen = dynamic_import(
-    module_path="examples/load_fw_canopen", import_name="load_firmware_canopen"
-)
-main_load_save_config_register_changes = dynamic_import(
-    module_path="examples/load_save_config_register_changes", import_name="main"
-)
-main_load_save_configuration = dynamic_import(
-    module_path="examples/load_save_configuration", import_name="main"
-)
-set_up_pdo_poller = dynamic_import(module_path="examples/pdo_poller_example", import_name="main")
-main_position_ramp = dynamic_import(module_path="examples/position_ramp", import_name="main")
-main_process_data_object = dynamic_import(
-    module_path="examples/process_data_object", import_name="main"
+from tests.conftest import connect_canopen, connect_ethernet, connect_soem
+from tests.setups.descriptors import (
+    DriveCanOpenSetup,
+    DriveEcatSetup,
+    DriveEthernetSetup,
+    EthernetSetup,
+    Setup,
 )
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -6,18 +6,6 @@ from ingenialink import CanBaudrate, CanDevice
 from ingenialink.exceptions import ILFirmwareLoadError
 from ingenialink.pdo import RPDOMap, TPDOMap
 
-from examples.change_baudrate import change_baudrate
-from examples.change_node_id import change_node_id
-from examples.commutation_test_encoders import main as main_commutation_test_encoders
-from examples.connect_ecat_coe import connect_ethercat_coe
-from examples.load_fw_canopen import load_firmware_canopen
-from examples.load_save_config_register_changes import (
-    main as main_load_save_config_register_changes,
-)
-from examples.load_save_configuration import main as main_load_save_configuration
-from examples.pdo_poller_example import main as set_up_pdo_poller
-from examples.position_ramp import main as main_position_ramp
-from examples.process_data_object import main as main_process_data_object
 from ingeniamotion import MotionController
 from ingeniamotion.communication import Communication
 from ingeniamotion.configuration import Configuration
@@ -26,14 +14,42 @@ from ingeniamotion.enums import SeverityLevel
 from ingeniamotion.information import Information
 from ingeniamotion.motion import Motion
 from ingeniamotion.pdo import PDONetworkManager, PDOPoller
-from tests.conftest import connect_canopen, connect_ethernet, connect_soem
+from tests.conftest import connect_canopen, connect_ethernet, connect_soem, dynamic_import
 
-from .setups.descriptors import (
-    DriveCanOpenSetup,
-    DriveEcatSetup,
-    DriveEthernetSetup,
-    EthernetSetup,
-    Setup,
+DriveCanOpenSetup, DriveEcatSetup, DriveEthernetSetup, EthernetSetup, Setup = dynamic_import(
+    module_path="tests/setups/descriptors",
+    import_name=[
+        "DriveCanOpenSetup",
+        "DriveEcatSetup",
+        "DriveEthernetSetup",
+        "EthernetSetup",
+        "Setup",
+    ],
+)
+
+change_baudrate = dynamic_import(
+    module_path="examples/change_baudrate", import_name="change_baudrate"
+)
+change_node_id = dynamic_import(module_path="examples/change_node_id", import_name="change_node_id")
+main_commutation_test_encoders = dynamic_import(
+    module_path="examples/commutation_test_encoders", import_name="main"
+)
+connect_ethercat_coe = dynamic_import(
+    module_path="examples/connect_ecat_coe", import_name="connect_ethercat_coe"
+)
+load_firmware_canopen = dynamic_import(
+    module_path="examples/load_fw_canopen", import_name="load_firmware_canopen"
+)
+main_load_save_config_register_changes = dynamic_import(
+    module_path="examples/load_save_config_register_changes", import_name="main"
+)
+main_load_save_configuration = dynamic_import(
+    module_path="examples/load_save_configuration", import_name="main"
+)
+set_up_pdo_poller = dynamic_import(module_path="examples/pdo_poller_example", import_name="main")
+main_position_ramp = dynamic_import(module_path="examples/position_ramp", import_name="main")
+main_process_data_object = dynamic_import(
+    module_path="examples/process_data_object", import_name="main"
 )
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,12 +2,7 @@ import pytest
 
 from ingeniamotion.enums import GPI, GPO, DigitalVoltageLevel, GPIOPolarity
 from ingeniamotion.exceptions import IMError
-from tests.conftest import dynamic_import
-
-CAN_CAP_SETUP, ECAT_CAP_SETUP, ETH_CAP_SETUP = dynamic_import(
-    module_path="tests/setups/rack_setups",
-    import_name=["CAN_CAP_SETUP", "ECAT_CAP_SETUP", "ETH_CAP_SETUP"],
-)
+from tests.setups.rack_setups import CAN_CAP_SETUP, ECAT_CAP_SETUP, ETH_CAP_SETUP
 
 
 @pytest.mark.virtual

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,8 +2,12 @@ import pytest
 
 from ingeniamotion.enums import GPI, GPO, DigitalVoltageLevel, GPIOPolarity
 from ingeniamotion.exceptions import IMError
+from tests.conftest import dynamic_import
 
-from .setups.rack_setups import CAN_CAP_SETUP, ECAT_CAP_SETUP, ETH_CAP_SETUP
+CAN_CAP_SETUP, ECAT_CAP_SETUP, ETH_CAP_SETUP = dynamic_import(
+    module_path="tests/setups/rack_setups",
+    import_name=["CAN_CAP_SETUP", "ECAT_CAP_SETUP", "ETH_CAP_SETUP"],
+)
 
 
 @pytest.mark.virtual

--- a/tests/test_pdo.py
+++ b/tests/test_pdo.py
@@ -9,11 +9,7 @@ from packaging import version
 
 from ingeniamotion.enums import CommunicationType, OperationMode
 from ingeniamotion.exceptions import IMError
-from tests.conftest import dynamic_import
-
-EthercatMultiSlaveSetup = dynamic_import(
-    module_path="tests/setups/descriptors", import_name="EthercatMultiSlaveSetup"
-)
+from tests.setups.descriptors import EthercatMultiSlaveSetup
 
 
 @pytest.mark.soem

--- a/tests/test_pdo.py
+++ b/tests/test_pdo.py
@@ -9,8 +9,11 @@ from packaging import version
 
 from ingeniamotion.enums import CommunicationType, OperationMode
 from ingeniamotion.exceptions import IMError
+from tests.conftest import dynamic_import
 
-from .setups.descriptors import EthercatMultiSlaveSetup
+EthercatMultiSlaveSetup = dynamic_import(
+    module_path="tests/setups/descriptors", import_name="EthercatMultiSlaveSetup"
+)
 
 
 @pytest.mark.soem

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     pytest-console-scripts==1.4.1
     matplotlib==3.8.2
 commands =
-    python -I -m pytest {posargs:tests} --cov={envsitepackagesdir}/ingeniamotion --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
+    python -I -m pytest {posargs:tests} --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
 # Pass the WINDIR environment variable (it is needed by matplotlib).
 # Check https://travis-ci.community/t/matplotlib-font-manager-fails-to-find-windir-environment-variable/14145
 passenv = WINDIR

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     pytest-console-scripts==1.4.1
     matplotlib==3.8.2
 commands =
-    python -I -m pytest {posargs:tests} --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
+    python -I -m pytest {posargs:tests} --cov={envsitepackagesdir}/ingeniamotion --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
 # Pass the WINDIR environment variable (it is needed by matplotlib).
 # Check https://travis-ci.community/t/matplotlib-font-manager-fails-to-find-windir-environment-variable/14145
 passenv = WINDIR


### PR DESCRIPTION
### Description

`tests` and `examples` modules are referenced in the pytests, but they are not part of `ingeniamotion` package. 
This prevents from being able to use `addopts = --import-mode=importlib` in the pytests, which ensures that the package is being tested with the same wheel that will be published.

To solve this, they are dynamically imported from a local path. 
All the modules that are not part of the package should be specified in `tests/conftest.py` -> `_DYNAMIC_MODULES_IMPORT`.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Created `dynamic_loader` function to be able to import modules in pytests that are not part of `ingeniamotion` package.
- [X] Updated `README` with information on how to run the tests.

### Tests
- [ ] Add new unit tests if it applies.
- [ ] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [X] Update docstrings of every function, method or class that change.
- [X] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [ ] Set fix version field in the Jira issue.
