### PR TITLE
INGM-589: ProcessDataThread should notify when it ends

### DIFF
--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -219,25 +219,10 @@ class PDONetworkManager:
                 )
             self._refresh_rate = refresh_rate
             self._watchdog_timeout = watchdog_timeout
-            self._notify_send_process_data_callable = notify_send_process_data
-            self._notify_receive_process_data_callable = notify_receive_process_data
-            self._notify_exceptions_callable = notify_exceptions
+            self._notify_send_process_data = notify_send_process_data
+            self._notify_receive_process_data = notify_receive_process_data
+            self._notify_exceptions = notify_exceptions
             self._pd_thread_stop_event = threading.Event()
-
-        def _notify_send_process_data(self) -> None:
-            if self._notify_send_process_data_callable is None:
-                return
-            self._notify_send_process_data_callable()
-
-        def _notify_receive_process_data(self) -> None:
-            if self._notify_receive_process_data_callable is None:
-                return
-            self._notify_receive_process_data_callable()
-
-        def _notify_exceptions(self, exception: IMError) -> None:
-            if self._notify_exceptions_callable is None:
-                return
-            self._notify_exceptions_callable(exception)
 
         def run(self) -> None:
             """Start the PDO exchange."""

--- a/tests/test_pdo.py
+++ b/tests/test_pdo.py
@@ -176,7 +176,6 @@ def test_pdos_watchdog_exception_auto(motion_controller):
     mc.capture.pdo.start_pdos(CommunicationType.Ethercat, refresh_rate)
     time.sleep(1)
     mc.capture.pdo.unsubscribe_to_exceptions(exception_callback)
-    mc.capture.pdo.stop_pdos()
     assert len(exceptions) > 0
     exception = exceptions[0]
     assert str(exception) == "The sampling time is too high. The max sampling time is 3276.75 ms."
@@ -195,7 +194,6 @@ def test_pdos_watchdog_exception_manual(motion_controller):
     mc.capture.pdo.start_pdos(CommunicationType.Ethercat, watchdog_timeout=watchdog_timeout)
     time.sleep(1)
     mc.capture.pdo.unsubscribe_to_exceptions(exception_callback)
-    mc.capture.pdo.stop_pdos()
     assert len(exceptions) > 0
     exception = exceptions[0]
     assert (


### PR DESCRIPTION
### Description

Clear `ProcessDataThread` reference in `PDONetworkManager` if it has finished due to an exception.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Remove optional arguments from `ProcessDataThread`.
- [X] Clear `ProcessDataThread` reference when there is an exception.
- [X] Remove `stop_pdos` from pytests if PDOs didn't really started.


### Tests
- [ ] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [X] Update docstrings of every function, method or class that change.
- [X] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [ ] Set fix version field in the Jira issue.
