### PR TITLE
motor enable after restoring operation mode

### DIFF
--- a/ingeniamotion/wizard_tests/base_test.py
+++ b/ingeniamotion/wizard_tests/base_test.py
@@ -76,6 +76,10 @@ class BaseTest(ABC, Stoppable, Generic[T]):
             for key, value in self.backup_registers[subnode].items():
                 try:
                     self.mc.communication.set_register(key, value, servo=self.servo, axis=self.axis)
+                    # From FW>=2.7.3, to set the operation mode a motor enable is needed
+                    if key == self.mc.motion.OPERATION_MODE_REGISTER:
+                        self.mc.motion.motor_enable(servo=self.servo, axis=self.axis)
+                        self.mc.motion.motor_disable(servo=self.servo, axis=self.axis)
                 except IMRegisterNotExistError as e:  # noqa: PERF203
                     self.logger.warning(e, axis=subnode)
                 except IMRegisterWrongAccessError as e:


### PR DESCRIPTION
### Description

Perform motor enable after resetting the operation mode once a test finishes. 

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Motor enable after setting operation mode once a test finishes.

### Tests
- [ ] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [ ] Set fix version field in the Jira issue.
