### PR TITLE
MOT3-4674 - feedback and commutation tests to perform a full mech revolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - Renamed the `TYPE_SUBNODES` and `COMMUNICATION_TYPE` enums to follow CapWords convention. Old names are still supported, but will soon be deprecated.
 - Renamed the `IMException`, `IMRegisterNotExist` and `IMRegisterWrongAccess` exceptions to `IMError`, `IMRegisterNotExistError` and `IMRegisterWrongAccessError` respectively. Old names are still supported, but will soon be deprecated.
+- Feedback test to perform a full revolution.
 
 ## [0.9.0] - 2025-01-29
 ### Added

--- a/ingeniamotion/motion.py
+++ b/ingeniamotion/motion.py
@@ -704,7 +704,11 @@ class Motion:
                 raise IMTimeoutError("Velocity was not reached in time")
 
     def set_internal_generator_configuration(
-        self, op_mode: OperationMode, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS
+        self,
+        op_mode: OperationMode,
+        servo: str = DEFAULT_SERVO,
+        axis: int = DEFAULT_AXIS,
+        poles_pair: int = 1,
     ) -> None:
         """Set internal generator configuration.
 
@@ -719,6 +723,7 @@ class Motion:
              for internal generator configuration.
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
+            poles_pair: motor poles pair. ``1`` by default.
 
         Raises:
             ValueError: If operation mode is not set to Current or Voltage.
@@ -727,7 +732,7 @@ class Motion:
         if op_mode not in [OperationMode.CURRENT, OperationMode.VOLTAGE]:
             raise ValueError("Operation mode must be Current or Voltage")
         self.set_operation_mode(op_mode, servo=servo, axis=axis)
-        self.mc.configuration.set_motor_pair_poles(1, servo=servo, axis=axis)
+        self.mc.configuration.set_motor_pair_poles(poles_pair, servo=servo, axis=axis)
         self.mc.configuration.set_phasing_mode(PhasingMode.NO_PHASING, servo=servo, axis=axis)
         if op_mode == OperationMode.CURRENT:
             self.set_current_quadrature(0, servo=servo, axis=axis)

--- a/ingeniamotion/motion.py
+++ b/ingeniamotion/motion.py
@@ -708,7 +708,7 @@ class Motion:
         op_mode: OperationMode,
         servo: str = DEFAULT_SERVO,
         axis: int = DEFAULT_AXIS,
-        poles_pair: int = 1,
+        pair_poles: int = 1,
     ) -> None:
         """Set internal generator configuration.
 
@@ -723,7 +723,7 @@ class Motion:
              for internal generator configuration.
             servo : servo alias to reference it. ``default`` by default.
             axis : servo axis. ``1`` by default.
-            poles_pair: motor poles pair. ``1`` by default.
+            pair_poles: motor poles pair. ``1`` by default.
 
         Raises:
             ValueError: If operation mode is not set to Current or Voltage.
@@ -732,7 +732,7 @@ class Motion:
         if op_mode not in [OperationMode.CURRENT, OperationMode.VOLTAGE]:
             raise ValueError("Operation mode must be Current or Voltage")
         self.set_operation_mode(op_mode, servo=servo, axis=axis)
-        self.mc.configuration.set_motor_pair_poles(poles_pair, servo=servo, axis=axis)
+        self.mc.configuration.set_motor_pair_poles(pair_poles, servo=servo, axis=axis)
         self.mc.configuration.set_phasing_mode(PhasingMode.NO_PHASING, servo=servo, axis=axis)
         if op_mode == OperationMode.CURRENT:
             self.set_current_quadrature(0, servo=servo, axis=axis)

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -10,9 +10,18 @@ from typing_extensions import override
 if TYPE_CHECKING:
     from ingeniamotion import MotionController
 
-from ingeniamotion.enums import CommutationMode, OperationMode, SensorType, SeverityLevel
+from ingeniamotion.enums import (
+    CommutationMode,
+    OperationMode,
+    SensorType,
+    SeverityLevel,
+)
 from ingeniamotion.exceptions import IMRegisterNotExistError
-from ingeniamotion.wizard_tests.base_test import BaseTest, LegacyDictReportType, TestError
+from ingeniamotion.wizard_tests.base_test import (
+    BaseTest,
+    LegacyDictReportType,
+    TestError,
+)
 
 
 class Feedbacks(BaseTest[LegacyDictReportType]):
@@ -98,7 +107,11 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
     SENSOR_TYPE_FEEDBACK_TEST: SensorType
 
     def __init__(
-        self, mc: "MotionController", servo: str, axis: int, logger_drive_name: Optional[str]
+        self,
+        mc: "MotionController",
+        servo: str,
+        axis: int,
+        logger_drive_name: Optional[str],
     ) -> None:
         super().__init__()
         self.mc = mc
@@ -183,7 +196,10 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
         self.mc.configuration.set_auxiliar_feedback(self.sensor, servo=self.servo, axis=self.axis)
         # Set Polarity to 0
         self.mc.communication.set_register(
-            self.FEEDBACK_POLARITY_REGISTER, self.Polarity.NORMAL, servo=self.servo, axis=self.axis
+            self.FEEDBACK_POLARITY_REGISTER,
+            self.Polarity.NORMAL,
+            servo=self.servo,
+            axis=self.axis,
         )
         # Depending on the type of the feedback, calculate the correct
         # feedback resolution
@@ -257,7 +273,10 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
         self.feedback_setting()
 
         self.mc.motion.set_internal_generator_configuration(
-            OperationMode.CURRENT, servo=self.servo, axis=self.axis, pole_pair=self.pair_poles
+            OperationMode.CURRENT,
+            servo=self.servo,
+            axis=self.axis,
+            poles_pair=self.pair_poles,
         )
         self.logger.info(f"Pole pairs set to {self.pair_poles}")
         self.logger.info("Mode of operation set to Current mode")
@@ -275,19 +294,28 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
             self.POSITIONING_OPTION_CODE_REGISTER, servo=self.servo, axis=self.axis
         ):
             self.mc.communication.set_register(
-                self.POSITIONING_OPTION_CODE_REGISTER, 0, servo=self.servo, axis=self.axis
+                self.POSITIONING_OPTION_CODE_REGISTER,
+                0,
+                servo=self.servo,
+                axis=self.axis,
             )
         if self.mc.info.register_exists(
             self.MIN_POSITION_RANGE_LIMIT_REGISTER, servo=self.servo, axis=self.axis
         ):
             self.mc.communication.set_register(
-                self.MIN_POSITION_RANGE_LIMIT_REGISTER, 0, servo=self.servo, axis=self.axis
+                self.MIN_POSITION_RANGE_LIMIT_REGISTER,
+                0,
+                servo=self.servo,
+                axis=self.axis,
             )
         if self.mc.info.register_exists(
             self.MAX_POSITION_RANGE_LIMIT_REGISTER, servo=self.servo, axis=self.axis
         ):
             self.mc.communication.set_register(
-                self.MAX_POSITION_RANGE_LIMIT_REGISTER, 0, servo=self.servo, axis=self.axis
+                self.MAX_POSITION_RANGE_LIMIT_REGISTER,
+                0,
+                servo=self.servo,
+                axis=self.axis,
             )
 
     def __set_resolution_multiplier(self) -> None:
@@ -342,7 +370,9 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
         if not isinstance(rated_current, float):
             raise TypeError("Rated current has to be a float")
         nominal_current = self.mc.communication.get_register(
-            self.MAXIMUM_CONTINUOUS_CURRENT_DRIVE_PROTECTION, servo=self.servo, axis=self.axis
+            self.MAXIMUM_CONTINUOUS_CURRENT_DRIVE_PROTECTION,
+            servo=self.servo,
+            axis=self.axis,
         )
         if not isinstance(nominal_current, float):
             raise TypeError("Nominal current has to be a float")

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -169,7 +169,6 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
             raise TypeError("Pair poles has to be set before resolution checking.")
         if self.feedback_resolution is None:
             raise TypeError("Feedback resolution has to be set before resolution checking.")
-        displacement = displacement
         self.logger.info("RESOLUTION CHECK")
         self.logger.info("Theoretical resolution: %.0f", self.feedback_resolution)
         self.logger.info("Detected resolution (pos): %.0f", abs(displacement))
@@ -276,7 +275,7 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
             OperationMode.CURRENT,
             servo=self.servo,
             axis=self.axis,
-            poles_pair=self.pair_poles,
+            pair_poles=self.pair_poles,
         )
         self.logger.info(f"Pole pairs set to {self.pair_poles}")
         self.logger.info("Mode of operation set to Current mode")

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -156,7 +156,7 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
             raise TypeError("Pair poles has to be set before resolution checking.")
         if self.feedback_resolution is None:
             raise TypeError("Feedback resolution has to be set before resolution checking.")
-        displacement = displacement * self.pair_poles
+        displacement = displacement
         self.logger.info("RESOLUTION CHECK")
         self.logger.info("Theoretical resolution: %.0f", self.feedback_resolution)
         self.logger.info("Detected resolution (pos): %.0f", abs(displacement))
@@ -257,9 +257,9 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
         self.feedback_setting()
 
         self.mc.motion.set_internal_generator_configuration(
-            OperationMode.CURRENT, servo=self.servo, axis=self.axis
+            OperationMode.CURRENT, servo=self.servo, axis=self.axis, pole_pair=self.pair_poles
         )
-        self.logger.info("Set pair poles to 1")
+        self.logger.info(f"Pole pairs set to {self.pair_poles}")
         self.logger.info("Mode of operation set to Current mode")
         self.logger.info("Set phasing mode to No phasing")
         self.logger.info("Target quadrature current set to zero")

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -171,7 +171,7 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
             raise TypeError("Feedback resolution has to be set before resolution checking.")
         self.logger.info("RESOLUTION CHECK")
         self.logger.info("Theoretical resolution: %.0f", self.feedback_resolution)
-        self.logger.info("Detected resolution (pos): %.0f", abs(displacement))
+        self.logger.info("Measured resolution (pos): %.0f", abs(displacement))
         displacement_value = abs(self.feedback_resolution - abs(displacement))
         error = 100 * displacement_value / self.feedback_resolution
         self.logger.info("Detected mismatch of: %.3f%%", error)

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -260,7 +260,7 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
         self.__set_positioning_register_values()
         # Default resolution multiplier
         self.__set_resolution_multiplier()
-        # Read pole pairs and set to 1 for an electrical revolution
+        # Read pole pairs to perform a full revolution
         self.pair_poles = self.mc.configuration.get_motor_pair_poles(
             servo=self.servo, axis=self.axis
         )


### PR DESCRIPTION
Feedback tests to perform a full mechanical revolution. 
This way the user can visually verify the correct setting of the pole pairs.

Fixes #MOT3-4674

### Type of change

- [x] Modify set_internal_generator_configuration() to accept pole_pairs setting
- [x] Modify feedback tests to use and display the set pole-pairs 


### Tests
- [ ] Add new unit tests if it applies.
- [ ] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [ ] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).
- [x] Update internal documentation

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [ ] Set fix version field in the Jira issue.
