### PR TITLE
INGK-1076: Adapt code to accept pysoem nogil functionalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Methods to scan Ethernet drives.
 - Error-raised timeout to motor_enable
+- No-GIL support for EtherCAT functions.
 
 ### Changed
 - Renamed the `TYPE_SUBNODES` and `COMMUNICATION_TYPE` enums to follow CapWords convention. Old names are still supported, but will soon be deprecated.

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -736,6 +736,7 @@ class Communication:
         alias: str = DEFAULT_SERVO,
         servo_status_listener: bool = False,
         net_status_listener: bool = False,
+        gil_release_config: GilReleaseConfig = GilReleaseConfig(),
     ) -> None:
         """Connect to an EtherCAT slave - CoE.
 
@@ -749,6 +750,7 @@ class Communication:
                 its status, errors, faults, etc.
             net_status_listener : Toggle the listener of the network
                 status, connection and disconnection.
+            gil_release_config: GIL release configuration.
 
         Raises:
             IndexError: If interface index is out of range.
@@ -761,6 +763,7 @@ class Communication:
             alias,
             servo_status_listener,
             net_status_listener,
+            gil_release_config=gil_release_config,
         )
 
     def connect_servo_ethercat_interface_ip(
@@ -771,6 +774,7 @@ class Communication:
         alias: str = DEFAULT_SERVO,
         servo_status_listener: bool = False,
         net_status_listener: bool = False,
+        gil_release_config: GilReleaseConfig = GilReleaseConfig(),
     ) -> None:
         """Connect to an EtherCAT slave - CoE.
 
@@ -783,6 +787,7 @@ class Communication:
                 its status, errors, faults, etc.
             net_status_listener : Toggle the listener of the network
                 status, connection and disconnection.
+            gil_release_config: GIL release configuration.
 
         """
         self.connect_servo_ethercat(
@@ -792,6 +797,7 @@ class Communication:
             alias,
             servo_status_listener,
             net_status_listener,
+            gil_release_config=gil_release_config,
         )
 
     @staticmethod

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -19,7 +19,7 @@ from ingenialink.emcy import EmergencyMessage
 from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.enums.servo import ServoState
 from ingenialink.eoe.network import EoENetwork
-from ingenialink.ethercat.network import EthercatNetwork
+from ingenialink.ethercat.network import EthercatNetwork, GilReleaseConfig
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.exceptions import ILError
 from ingenialink.network import SlaveInfo
@@ -687,6 +687,7 @@ class Communication:
         alias: str = DEFAULT_SERVO,
         servo_status_listener: bool = False,
         net_status_listener: bool = False,
+        gil_release_config: GilReleaseConfig = GilReleaseConfig(),
     ) -> None:
         r"""Connect to an EtherCAT slave - CoE.
 
@@ -700,6 +701,7 @@ class Communication:
                 its status, errors, faults, etc.
             net_status_listener : Toggle the listener of the network
                 status, connection and disconnection.
+            gil_release_config: GIL release configuration.
 
         Raises:
             FileNotFoundError: If the dict file doesn't exist.
@@ -708,7 +710,9 @@ class Communication:
         if not path.isfile(dict_path):
             raise FileNotFoundError(f"Dict file {dict_path} does not exist!")
         if interface_name not in self.mc.net:
-            self.mc.net[interface_name] = EthercatNetwork(interface_name)
+            self.mc.net[interface_name] = EthercatNetwork(
+                interface_name, gil_release_config=gil_release_config
+            )
         net = self.mc.net[interface_name]
         try:
             servo = net.connect_to_slave(
@@ -792,7 +796,7 @@ class Communication:
 
     @staticmethod
     def scan_servos_ethercat_with_info(
-        interface_name: str,
+        interface_name: str, gil_release_config: GilReleaseConfig = GilReleaseConfig()
     ) -> OrderedDict[int, SlaveInfo]:
         r"""Scan a network adapter.
 
@@ -801,6 +805,7 @@ class Communication:
         Args:
             interface_name : interface name. It should have format
                 ``\\Device\\NPF_[...]``.
+            gil_release_config: GIL release configuration.
 
         Returns:
             Dictionary of nodes available in the network and slave information.
@@ -808,19 +813,19 @@ class Communication:
         Raises:
             TypeError: If some parameter has a wrong type.
         """
-        net = EthercatNetwork(interface_name)
+        net = EthercatNetwork(interface_name, gil_release_config=gil_release_config)
         slaves_info = net.scan_slaves_info()
         return slaves_info
 
     def scan_servos_ethercat(
-        self,
-        interface_name: str,
+        self, interface_name: str, gil_release_config: GilReleaseConfig = GilReleaseConfig()
     ) -> list[int]:
         r"""Scan a network adapter to get all connected EtherCAT slaves.
 
         Args:
             interface_name : interface name. It should have format
                 ``\\Device\\NPF_[...]``.
+            gil_release_config: GIL release configuration.
 
         Returns:
             List of EtherCAT slaves available in the network.
@@ -828,7 +833,7 @@ class Communication:
         Raises:
             TypeError: If some parameter has a wrong type.
         """
-        net = EthercatNetwork(interface_name)
+        net = EthercatNetwork(interface_name, gil_release_config=gil_release_config)
         slaves = net.scan_slaves()
         return slaves
 
@@ -1329,6 +1334,7 @@ class Communication:
         slave: int = 1,
         boot_in_app: Optional[bool] = None,
         password: Optional[int] = None,
+        gil_release_config: GilReleaseConfig = GilReleaseConfig(),
     ) -> None:
         r"""Load firmware via ECAT.
 
@@ -1341,6 +1347,7 @@ class Communication:
                 If None, the file extension is used to define it.
             password: Password to load the firmware file. If ``None`` the default password will be
                 used.
+            gil_release_config: GIL release config.
 
         Raises:
             FileNotFoundError: If the firmware file cannot be found.
@@ -1349,7 +1356,7 @@ class Communication:
             ingenialink.exceptions.ILFirmwareLoadError: If the FoE write operation fails.
 
         """
-        net = EthercatNetwork(ifname)
+        net = EthercatNetwork(ifname, gil_release_config=gil_release_config)
         if fw_file.endswith(self.ENSEMBLE_FIRMWARE_EXTENSION):
             self.__load_ensemble_fw_ecat(net, fw_file, slave, boot_in_app, password)
         else:

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -1370,6 +1370,7 @@ class Communication:
         slave: int = 1,
         boot_in_app: Optional[bool] = None,
         password: Optional[int] = None,
+        gil_release_config: GilReleaseConfig = GilReleaseConfig(),
     ) -> None:
         """Load firmware via ECAT.
 
@@ -1382,6 +1383,7 @@ class Communication:
                 If ``None``, the file extension is used to define it.
             password: Password to load the firmware file. If ``None`` the default password will be
                 used.
+            gil_release_config: GIL release config.
 
         Raises:
             IndexError: If interface index is out of range.
@@ -1392,7 +1394,12 @@ class Communication:
 
         """
         self.load_firmware_ecat(
-            self.get_ifname_by_index(if_index), fw_file, slave, boot_in_app, password
+            self.get_ifname_by_index(if_index),
+            fw_file,
+            slave,
+            boot_in_app,
+            password,
+            gil_release_config=gil_release_config,
         )
 
     def load_firmware_ethernet(

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # It should be empty in production.
 # Use full commit hash
 [develop]
-    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@8233acf75e55475717531da4a87c20958f0e80b6}
+    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@3e76b81a98db0e11597a3cc92e7b24c4aea4ef57}
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # It should be empty in production.
 # Use full commit hash
 [develop]
-    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@9e4a10a77946c155776b8919cedad4d87276e6a6}
+    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@daa5795013e5cf693f83d0026effac863fbbea12}
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # It should be empty in production.
 # Use full commit hash
 [develop]
-    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@ffbdc247245b3e891206bd5049fb135d6cc40aa9}
+    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@8233acf75e55475717531da4a87c20958f0e80b6}
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # It should be empty in production.
 # Use full commit hash
 [develop]
-    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@daa5795013e5cf693f83d0026effac863fbbea12}
+    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@d5ffb350501d6aa1e1ccc6ecd9a2bc1b7e3d7e07}
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # It should be empty in production.
 # Use full commit hash
 [develop]
-    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@b1ff1ee2c73e80f474aea93214b3d05a9b89ba5e}
+    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@cd73570e13fd85d083c761887b38d43cd182de98}
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # It should be empty in production.
 # Use full commit hash
 [develop]
-    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@cd73570e13fd85d083c761887b38d43cd182de98}
+    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@9e4a10a77946c155776b8919cedad4d87276e6a6}
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # It should be empty in production.
 # Use full commit hash
 [develop]
-    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@9bb05f974cac75fd2183641eaf4b9e9d798ff025}
+    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@ffbdc247245b3e891206bd5049fb135d6cc40aa9}
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list = coverage, build, firmware, docs, format, type, py{39,310,311,312}, vi
 # It should be empty in production.
 # Use full commit hash
 [develop]
-    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@d5ffb350501d6aa1e1ccc6ecd9a2bc1b7e3d7e07}
+    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@9bb05f974cac75fd2183641eaf4b9e9d798ff025}
 
 
 [testenv]


### PR DESCRIPTION
### Description

Expose GIL release configuration.

### Type of change

- [X] Add GIL release configuration argument where `EthercatNetwork` is created. It uses `pysoem` configuration by default (`release_gil=False`).

### Tests
- [ ] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [X] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [X] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

