### PR TITLE
 context and fixture to rollback changes after a test

### DIFF
--- a/ingeniamotion/drive_context_manager.py
+++ b/ingeniamotion/drive_context_manager.py
@@ -1,0 +1,97 @@
+from typing import Optional, Union
+
+from ingenialink.enums.register import RegAccess
+from ingenialink.exceptions import ILIOError
+from ingenialink.register import Register
+from ingenialink.servo import Servo
+
+from ingeniamotion import MotionController
+from ingeniamotion.metaclass import DEFAULT_SERVO
+
+
+class DriveContextManager:
+    """Context used to make modifications in the drive.
+
+    Once the modifications are not needed anymore, the drive values will be restored.
+    """
+
+    def __init__(
+        self,
+        motion_controller: MotionController,
+        alias: str = DEFAULT_SERVO,
+        axis: Optional[int] = None,
+    ):
+        self._mc: MotionController = motion_controller
+        self._alias: str = alias
+        self._axis: Optional[int] = axis
+
+        self._original_register_values: dict[int, dict[str, Union[int, float, str]]] = {}
+        self._registers_changed: dict[int, dict[str, Union[int, float, str]]] = {}
+
+    @property
+    def drive(self) -> Servo:
+        """Returns the servo."""
+        return self._mc._get_drive(self._alias)
+
+    def _register_update_callback(
+        self,
+        alias: str,  # noqa: ARG002
+        servo: Servo,  # noqa: ARG002
+        register: Register,
+        value: Union[int, float, str, bytes],
+    ) -> None:
+        """Saves the register uids that are changed.
+
+        Args:
+            alias: servo alias.
+            servo: servo.
+            register: register.
+            value: changed value.
+        """
+        if register.subnode not in self._registers_changed:
+            self._registers_changed[register.subnode] = {}
+        self._registers_changed[register.subnode][register.identifier] = value
+
+    def _store_register_data(self) -> None:
+        """It subscribes to register update callbacks and saves the value of all registers."""
+        self._mc.communication.subscribe_register_update(
+            self._register_update_callback, servo=self._alias
+        )
+
+        drive = self.drive
+        axes = list(drive.dictionary.subnodes) if self._axis is None else [self._axis]
+        for axis in axes:
+            self._original_register_values[axis] = {}
+            for uid, register in drive.dictionary.registers(subnode=axis).items():
+                if register.access == RegAccess.WO:
+                    continue
+                try:
+                    register_value = self._mc.communication.get_register(
+                        register=uid, servo=self._alias, axis=axis
+                    )
+                except ILIOError:
+                    continue
+                self._original_register_values[axis][uid] = register_value
+
+    def _restore_register_data(self) -> None:
+        """Unsubscribes from register updates and restores the drive values."""
+        self._mc.communication.unsubscribe_register_update(
+            self._register_update_callback, servo=self._alias
+        )
+
+        for axis, registers in self._registers_changed.items():
+            for uid, current_value in registers.items():
+                restore_value = self._original_register_values[axis].get(uid, None)
+                if restore_value is None or current_value == restore_value:
+                    continue
+                self._mc.communication.set_register(
+                    uid, restore_value, servo=self._alias, axis=axis
+                )
+
+    def __enter__(self) -> None:
+        """Saves the drive values."""
+        self._store_register_data()
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        """Restores the drive values."""
+        self._restore_register_data()

--- a/ingeniamotion/drive_context_manager.py
+++ b/ingeniamotion/drive_context_manager.py
@@ -53,11 +53,7 @@ class DriveContextManager:
         self._registers_changed[register.subnode][cast("str", register.identifier)] = value
 
     def _store_register_data(self) -> None:
-        """It subscribes to register update callbacks and saves the value of all registers."""
-        self._mc.communication.subscribe_register_update(
-            self._register_update_callback, servo=self._alias
-        )
-
+        """It saves the value of all registers and subscribes to register update callbacks."""
         drive = self.drive
         axes = list(drive.dictionary.subnodes) if self._axis is None else [self._axis]
         for axis in axes:
@@ -72,6 +68,10 @@ class DriveContextManager:
                 except ILIOError:
                     continue
                 self._original_register_values[axis][uid] = register_value
+
+        self._mc.communication.subscribe_register_update(
+            self._register_update_callback, servo=self._alias
+        )
 
     def _restore_register_data(self) -> None:
         """Unsubscribes from register updates and restores the drive values."""

--- a/ingeniamotion/drive_context_manager.py
+++ b/ingeniamotion/drive_context_manager.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 from ingenialink.enums.register import RegAccess
 from ingenialink.exceptions import ILIOError
@@ -26,7 +26,7 @@ class DriveContextManager:
         self._axis: Optional[int] = axis
 
         self._original_register_values: dict[int, dict[str, Union[int, float, str]]] = {}
-        self._registers_changed: dict[int, dict[str, Union[int, float, str]]] = {}
+        self._registers_changed: dict[int, dict[str, Union[int, float, str, bytes]]] = {}
 
     @property
     def drive(self) -> Servo:
@@ -50,7 +50,7 @@ class DriveContextManager:
         """
         if register.subnode not in self._registers_changed:
             self._registers_changed[register.subnode] = {}
-        self._registers_changed[register.subnode][register.identifier] = value
+        self._registers_changed[register.subnode][cast("str", register.identifier)] = value
 
     def _store_register_data(self) -> None:
         """It subscribes to register update callbacks and saves the value of all registers."""
@@ -92,6 +92,6 @@ class DriveContextManager:
         """Saves the drive values."""
         self._store_register_data()
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
+    def __exit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore [no-untyped-def]
         """Restores the drive values."""
         self._restore_register_data()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,8 +475,17 @@ def load_firmware(setup_specifier: SetupSpecifier, setup_descriptor: SetupDescri
 
 @pytest.fixture
 def drive_context_manager(motion_controller):
-    mc, alias, _ = motion_controller
-    context_manager = DriveContextManager(mc, alias)
-    context_manager.__enter__()
-    yield context_manager
-    context_manager.__exit__(None, None, None)
+    """Drive context manager.
+
+    It is in charge of returning the drive to the values it had before the tests,
+    if the test alters it."""
+    mc, aliases, _ = motion_controller
+    if isinstance(aliases, str):
+        aliases = [aliases]
+
+    context_managers = [DriveContextManager(mc, alias) for alias in aliases]
+    for context_manager in context_managers:
+        context_manager.__enter__()
+    yield
+    for context_manager in context_managers:
+        context_manager.__exit__(None, None, None)

--- a/tests/setups/descriptors.py
+++ b/tests/setups/descriptors.py
@@ -5,7 +5,9 @@ from typing import Optional
 from tests.setups.rack_service_client import RackServiceClient
 from tests.setups.specifiers import (
     Interface,
+    LocalDriveConfigSpecifier,
     MultiDriveConfigSpecifier,
+    MultiLocalDriveConfigSpecifier,
     MultiRackServiceConfigSpecifier,
     RackServiceConfigSpecifier,
     SetupSpecifier,
@@ -41,8 +43,8 @@ class DriveHwSetup(SetupDescriptor):
     identifier: str
     config_file: Optional[Path]
     fw_file: Path
-    rack_drive_idx: int
-    rack_drive: object
+    rack_drive_idx: Optional[int]
+    rack_drive: Optional[object]
 
 
 @dataclass(frozen=True)
@@ -111,6 +113,37 @@ def _get_dictionary_and_firmware_file(
     return dictionary, firmware_file
 
 
+def _descriptor_from_local_hw_specifier(specifier: SetupSpecifier) -> SetupDescriptor:
+    is_multidrive_config = isinstance(specifier, MultiDriveConfigSpecifier)
+    eval_specifiers = specifier.specifiers if is_multidrive_config else [specifier]
+
+    descriptors = []
+    for eval_specifier in eval_specifiers:
+        if eval_specifier.interface is Interface.ETHERNET:
+            descriptor_instance = DriveEthernetSetup
+        elif eval_specifier.interface is Interface.CANOPEN:
+            descriptor_instance = DriveCanOpenSetup
+        elif eval_specifier.interface is Interface.ETHERCAT:
+            descriptor_instance = DriveEcatSetup
+        else:
+            raise RuntimeError(f"No descriptor for specifier {eval_specifier}")
+        descriptors.append(
+            descriptor_instance(
+                dictionary=eval_specifier.dictionary,
+                identifier=eval_specifier.identifier,
+                config_file=eval_specifier.config_file,
+                fw_file=eval_specifier.firmware_file,
+                rack_drive_idx=None,
+                rack_drive=None,
+                **eval_specifier.interface_data,
+            )
+        )
+
+    if is_multidrive_config:
+        return EthercatMultiSlaveSetup(drives=descriptors)
+    return descriptors[0]
+
+
 def descriptor_from_specifier(
     specifier: SetupSpecifier, rack_service_client: Optional[RackServiceClient]
 ) -> SetupDescriptor:
@@ -133,6 +166,9 @@ def descriptor_from_specifier(
         return VirtualDriveSetup(
             ip=specifier.ip, dictionary=specifier.dictionary, port=specifier.port
         )
+
+    if isinstance(specifier, (LocalDriveConfigSpecifier, MultiLocalDriveConfigSpecifier)):
+        return _descriptor_from_local_hw_specifier(specifier=specifier)
 
     if (
         isinstance(specifier, (RackServiceConfigSpecifier, MultiRackServiceConfigSpecifier))

--- a/tests/test_drive_context_manager.py
+++ b/tests/test_drive_context_manager.py
@@ -1,0 +1,28 @@
+import pytest
+
+from ingeniamotion.drive_context_manager import DriveContextManager
+
+
+@pytest.mark.ethernet
+@pytest.mark.soem
+@pytest.mark.canopen
+def test_drive_context_manager(motion_controller):
+    user_over_voltage_uid = "DRV_PROT_USER_OVER_VOLT"
+    mc, alias, _ = motion_controller
+
+    def _read_user_over_voltage_uid():
+        return mc.communication.get_register(user_over_voltage_uid, servo=alias)
+
+    context = DriveContextManager(motion_controller=mc, alias=alias)
+
+    new_reg_value = 100.0
+    previous_reg_value = _read_user_over_voltage_uid()
+    assert previous_reg_value != new_reg_value
+
+    with context:
+        mc.communication.set_register(
+            register=user_over_voltage_uid, value=new_reg_value, servo=alias
+        )
+        assert _read_user_over_voltage_uid() == new_reg_value
+
+    assert _read_user_over_voltage_uid() == previous_reg_value

--- a/tests/test_drive_context_manager.py
+++ b/tests/test_drive_context_manager.py
@@ -2,27 +2,86 @@ import pytest
 
 from ingeniamotion.drive_context_manager import DriveContextManager
 
+_USER_OVER_VOLTAGE_UID = "DRV_PROT_USER_OVER_VOLT"
+
+
+def _read_user_over_voltage_uid(mc, alias):
+    return mc.communication.get_register(_USER_OVER_VOLTAGE_UID, servo=alias)
+
 
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
+@pytest.mark.skip()
 def test_drive_context_manager(motion_controller):
-    user_over_voltage_uid = "DRV_PROT_USER_OVER_VOLT"
     mc, alias, _ = motion_controller
-
-    def _read_user_over_voltage_uid():
-        return mc.communication.get_register(user_over_voltage_uid, servo=alias)
-
     context = DriveContextManager(motion_controller=mc, alias=alias)
 
     new_reg_value = 100.0
-    previous_reg_value = _read_user_over_voltage_uid()
+    previous_reg_value = _read_user_over_voltage_uid(mc, alias)
     assert previous_reg_value != new_reg_value
 
     with context:
         mc.communication.set_register(
-            register=user_over_voltage_uid, value=new_reg_value, servo=alias
+            register=_USER_OVER_VOLTAGE_UID, value=new_reg_value, servo=alias
         )
-        assert _read_user_over_voltage_uid() == new_reg_value
+        assert _read_user_over_voltage_uid(mc, alias) == new_reg_value
 
-    assert _read_user_over_voltage_uid() == previous_reg_value
+    assert _read_user_over_voltage_uid(mc, alias) == previous_reg_value
+
+
+class TestDriveContextFixture:
+    original_value = None
+
+    @pytest.mark.dependency(name="test_change_register_without_context")
+    def test_change_register_without_context(self, motion_controller):
+        mc, alias, _ = motion_controller
+        new_reg_value = 100.0
+
+        original_value = _read_user_over_voltage_uid(mc, alias)
+        TestDriveContextFixture.original_value = original_value
+        assert original_value != new_reg_value
+
+        mc.communication.set_register(
+            register=_USER_OVER_VOLTAGE_UID, value=new_reg_value, servo=alias
+        )
+        assert _read_user_over_voltage_uid(mc, alias) == new_reg_value
+
+    @pytest.mark.dependency(
+        name="test_read_register_if_changed_without_context",
+        depends=["test_read_register_if_changed_without_context"],
+    )
+    def test_read_register_if_changed_without_context(self, motion_controller):
+        mc, alias, _ = motion_controller
+        assert TestDriveContextFixture.original_value is not None
+        # Drive context manager didn't restore the value
+        assert _read_user_over_voltage_uid(mc, alias) != TestDriveContextFixture.original_value
+        TestDriveContextFixture.original_value = None
+
+    @pytest.mark.dependency(
+        name="test_change_register_with_context",
+        depends=["test_read_register_if_changed_without_context"],
+    )
+    def test_change_register_with_context(self, motion_controller, drive_context_manager):  # noqa: ARG002
+        mc, alias, _ = motion_controller
+        new_reg_value = 60.0
+
+        assert TestDriveContextFixture.original_value is None
+        original_value = _read_user_over_voltage_uid(mc, alias)
+        TestDriveContextFixture.original_value = original_value
+        assert original_value != new_reg_value
+
+        mc.communication.set_register(
+            register=_USER_OVER_VOLTAGE_UID, value=new_reg_value, servo=alias
+        )
+        assert _read_user_over_voltage_uid(mc, alias) == new_reg_value
+
+    @pytest.mark.dependency(
+        name="test_read_register_if_changed_with_context",
+        depends=["test_change_register_with_context"],
+    )
+    def test_read_register_if_changed_with_context(self, motion_controller):
+        mc, alias, _ = motion_controller
+        assert TestDriveContextFixture.original_value is not None
+        # Drive context manager didn't restore the value
+        assert _read_user_over_voltage_uid(mc, alias) == TestDriveContextFixture.original_value

--- a/tests/test_drive_context_manager.py
+++ b/tests/test_drive_context_manager.py
@@ -12,7 +12,6 @@ def _read_user_over_voltage_uid(mc, alias):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.skip()
 def test_drive_context_manager(motion_controller):
     mc, alias, _ = motion_controller
     context = DriveContextManager(motion_controller=mc, alias=alias)
@@ -33,6 +32,9 @@ def test_drive_context_manager(motion_controller):
 class TestDriveContextFixture:
     original_value = None
 
+    @pytest.mark.ethernet
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.dependency(name="test_change_register_without_context")
     def test_change_register_without_context(self, motion_controller):
         mc, alias, _ = motion_controller
@@ -47,6 +49,9 @@ class TestDriveContextFixture:
         )
         assert _read_user_over_voltage_uid(mc, alias) == new_reg_value
 
+    @pytest.mark.ethernet
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.dependency(
         name="test_read_register_if_changed_without_context",
         depends=["test_read_register_if_changed_without_context"],
@@ -58,6 +63,9 @@ class TestDriveContextFixture:
         assert _read_user_over_voltage_uid(mc, alias) != TestDriveContextFixture.original_value
         TestDriveContextFixture.original_value = None
 
+    @pytest.mark.ethernet
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.dependency(
         name="test_change_register_with_context",
         depends=["test_read_register_if_changed_without_context"],
@@ -76,6 +84,9 @@ class TestDriveContextFixture:
         )
         assert _read_user_over_voltage_uid(mc, alias) == new_reg_value
 
+    @pytest.mark.ethernet
+    @pytest.mark.soem
+    @pytest.mark.canopen
     @pytest.mark.dependency(
         name="test_read_register_if_changed_with_context",
         depends=["test_change_register_with_context"],

--- a/tests/test_drive_context_manager.py
+++ b/tests/test_drive_context_manager.py
@@ -54,7 +54,7 @@ class TestDriveContextFixture:
     @pytest.mark.canopen
     @pytest.mark.dependency(
         name="test_read_register_if_changed_without_context",
-        depends=["test_read_register_if_changed_without_context"],
+        depends=["test_change_register_without_context"],
     )
     def test_read_register_if_changed_without_context(self, motion_controller):
         mc, alias, _ = motion_controller

--- a/tests/test_drive_context_manager.py
+++ b/tests/test_drive_context_manager.py
@@ -83,5 +83,5 @@ class TestDriveContextFixture:
     def test_read_register_if_changed_with_context(self, motion_controller):
         mc, alias, _ = motion_controller
         assert TestDriveContextFixture.original_value is not None
-        # Drive context manager didn't restore the value
+        # Drive context manager restored the value, so it should be the original one
         assert _read_user_over_voltage_uid(mc, alias) == TestDriveContextFixture.original_value


### PR DESCRIPTION
### Description

Drive context manager to rollback the changes in drive registers that the tests may perform.

It has been created as a context, but it can also be used as a fixture.


### Type of change

Please add a description and delete options that are not relevant.

- [X] Drive context manager
- [X] Fix `LocalDriveConfigSpecifier` creation for different types of networks


### Tests
- [X] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [X] Update docstrings of every function, method or class that change.
- [X] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [ ] Set fix version field in the Jira issue.
