### PR TITLE
INGM-541 Use rack service to acquire dictionary and firmware from att

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -438,9 +438,13 @@ def load_firmware(setup_specifier: SetupSpecifier, setup_descriptor: SetupDescri
         else [setup_descriptor]
     )
     for descriptor in descriptors:
-        client.client.firmware_load(
-            drive_idx=descriptor.rack_drive_idx,
-            revision_number=descriptor.fw_file,
-            product_code=descriptor.rack_drive.product_code,
-            serial_number=descriptor.rack_drive.serial_number,
-        )
+        load_firmware_args = {
+            "drive_idx": descriptor.rack_drive_idx,
+            "product_code": descriptor.rack_drive.product_code,
+            "serial_number": descriptor.rack_drive.serial_number,
+        }
+        if isinstance(descriptor.fw_file, Path):
+            load_firmware_args["file"] = descriptor.fw_file.as_posix()
+        else:
+            load_firmware_args["revision_number"] = descriptor.fw_file
+        client.client.firmware_load(**load_firmware_args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -439,8 +439,8 @@ def load_firmware(setup_specifier: SetupSpecifier, setup_descriptor: SetupDescri
     )
     for descriptor in descriptors:
         client.client.firmware_load(
-            descriptor.rack_drive_idx,
-            descriptor.fw_file.as_posix(),
-            descriptor.rack_drive.product_code,
-            descriptor.rack_drive.serial_number,
+            drive_idx=descriptor.rack_drive_idx,
+            revision_number=descriptor.fw_file,
+            product_code=descriptor.rack_drive.product_code,
+            serial_number=descriptor.rack_drive.serial_number,
         )

--- a/tests/setups/descriptors.py
+++ b/tests/setups/descriptors.py
@@ -169,9 +169,9 @@ def descriptor_from_specifier(
         }
         network = _get_network_from_drive(drive=rack_drive, interface=eval_specifier.interface)
 
-        if eval_specifier.interface is Interface.ETHERNET:
+        if eval_specifier.interface is Interface.ETH:
             descriptor = DriveEthernetSetup(**args, ip=network.ip)
-        elif eval_specifier.interface is Interface.CANOPEN:
+        elif eval_specifier.interface is Interface.CAN:
             descriptor = DriveCanOpenSetup(
                 **args,
                 device=network.device,
@@ -179,7 +179,7 @@ def descriptor_from_specifier(
                 node_id=network.node_id,
                 baudrate=network.baudrate,
             )
-        elif eval_specifier.interface is Interface.ETHERCAT:
+        elif eval_specifier.interface is Interface.ECAT:
             descriptor = DriveEcatSetup(
                 **args, ifname=network.ifname, slave=network.slave, boot_in_app=network.boot_in_app
             )

--- a/tests/setups/descriptors.py
+++ b/tests/setups/descriptors.py
@@ -104,7 +104,7 @@ def _get_dictionary_and_firmware_file(
         specifier.dictionary
         if isinstance(specifier.dictionary, Path)
         else rack_service_client.get_dictionary(
-            rack_drive_idx, specifier.dictionary.firmware_version
+            rack_drive_idx, specifier.dictionary.firmware_version, specifier.interface
         )
     )
     firmware_file = (

--- a/tests/setups/descriptors.py
+++ b/tests/setups/descriptors.py
@@ -106,7 +106,7 @@ def _get_dictionary_and_firmware_file(
     firmware_file = (
         specifier.firmware_file
         if isinstance(specifier.firmware_file, Path)
-        else rack_service_client.get_firmware(specifier.firmware_file.firmware_version)
+        else specifier.firmware_file.firmware_version
     )
     return dictionary, firmware_file
 

--- a/tests/setups/descriptors.py
+++ b/tests/setups/descriptors.py
@@ -2,9 +2,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from ingenialink.dictionary import Interface
+
 from tests.setups.rack_service_client import RackServiceClient
 from tests.setups.specifiers import (
-    Interface,
     MultiDriveConfigSpecifier,
     MultiRackServiceConfigSpecifier,
     RackServiceConfigSpecifier,
@@ -80,11 +81,11 @@ class EthercatMultiSlaveSetup(SetupDescriptor):
 
 
 def _get_network_from_drive(drive: object, interface: Interface) -> object:
-    if interface is Interface.CANOPEN:
+    if interface is Interface.CAN:
         attribute = "node_id"
-    elif interface is Interface.ETHERNET:
+    elif interface is Interface.ETH:
         attribute = "ip"
-    elif interface is Interface.ETHERCAT:
+    elif interface is Interface.ECAT:
         attribute = "ifname"
     else:
         raise RuntimeError(f"No network associated with {interface=}")

--- a/tests/setups/descriptors.py
+++ b/tests/setups/descriptors.py
@@ -96,12 +96,16 @@ def _get_network_from_drive(drive: object, interface: Interface) -> object:
 
 
 def _get_dictionary_and_firmware_file(
-    specifier: SetupSpecifier, rack_service_client: RackServiceClient
+    specifier: SetupSpecifier,
+    rack_service_client: RackServiceClient,
+    rack_drive_idx: int,
 ) -> tuple[Path, Path]:
     dictionary = (
         specifier.dictionary
         if isinstance(specifier.dictionary, Path)
-        else rack_service_client.get_dictionary(specifier.dictionary.firmware_version)
+        else rack_service_client.get_dictionary(
+            rack_drive_idx, specifier.dictionary.firmware_version
+        )
     )
     firmware_file = (
         specifier.firmware_file
@@ -150,7 +154,9 @@ def descriptor_from_specifier(
         # Common arguments for DriveHwSetup
         rack_drive_idx, rack_drive = rack_service_client.get_drive(eval_specifier.part_number)
         dictionary, firmware_file = _get_dictionary_and_firmware_file(
-            specifier=eval_specifier, rack_service_client=rack_service_client
+            specifier=eval_specifier,
+            rack_service_client=rack_service_client,
+            rack_drive_idx=rack_drive_idx,
         )
         args = {
             "dictionary": dictionary,

--- a/tests/setups/rack_service_client.py
+++ b/tests/setups/rack_service_client.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 import rpyc
+from ingenialink.dictionary import Interface
 from rpyc.core.protocol import Connection
 from rpyc.core.service import Service
 
@@ -133,8 +134,10 @@ class RackServiceClient:
                 return idx, drive
         raise ValueError(f"Drive {part_number_value} cannot be found on the rack's configuration.")
 
-    def get_dictionary(self, rack_drive_idx: int, firmware_version: str) -> Path:
-        return self.client.get_dictionary(rack_drive_idx, firmware_version)
+    def get_dictionary(
+        self, rack_drive_idx: int, firmware_version: str, interface: Interface
+    ) -> Path:
+        return self.client.get_dictionary(rack_drive_idx, firmware_version, interface)
 
     def teardown(self) -> None:
         """Closes the connection to the rack service."""

--- a/tests/setups/rack_service_client.py
+++ b/tests/setups/rack_service_client.py
@@ -133,13 +133,8 @@ class RackServiceClient:
                 return idx, drive
         raise ValueError(f"Drive {part_number_value} cannot be found on the rack's configuration.")
 
-    def get_dictionary(self, firmware_version: str) -> Path:  # noqa: ARG002
-        return Path(".")  # INGM-541: retrieve dictionary
-
-    def get_firmware(self, firmware_version: str) -> Path:  # noqa: ARG002
-        return Path(
-            "."
-        )  # INGM-541: retrieve firmware / remove and just send revision number in fw loading
+    def get_dictionary(self, rack_drive_idx: int, firmware_version: str) -> Path:
+        return self.client.get_dictionary(rack_drive_idx, firmware_version)
 
     def teardown(self) -> None:
         """Closes the connection to the rack service."""

--- a/tests/setups/rack_service_client.py
+++ b/tests/setups/rack_service_client.py
@@ -137,7 +137,7 @@ class RackServiceClient:
     def get_dictionary(
         self, rack_drive_idx: int, firmware_version: str, interface: Interface
     ) -> Path:
-        return self.client.get_dictionary(rack_drive_idx, firmware_version, interface)
+        return self.client.get_dictionary(rack_drive_idx, firmware_version, interface.value)
 
     def teardown(self) -> None:
         """Closes the connection to the rack service."""

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -7,82 +7,46 @@ from tests.setups.specifiers import (
     RackServiceConfigSpecifier,
 )
 
-# INGM-541: use from_frozen_firmware(firmware_version=2.4.0)
-ETH_EVE_SETUP = RackServiceConfigSpecifier.from_local_firmware(
+ETH_EVE_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.EVE_XCR_C,
     interface=Interface.ETHERNET,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_can/1.2.0/config.xml"),
-    dictionary_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/EVE-XCR/firmware/2.4.0/eve-xcr-c_eth_2.4.0.xdf"
-    ),
-    firmware_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/EVE-XCR/firmware/2.4.0/eve-xcr-c_2.4.0.sfu"
-    ),
+    firmware_version="2.4.0",
 )
 
-# INGM-541: use from_frozen_firmware(firmware_version=2.4.0)
-ETH_CAP_SETUP = RackServiceConfigSpecifier.from_local_firmware(
+ETH_CAP_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.CAP_XCR_C,
     interface=Interface.ETHERNET,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_can/1.1.0/config.xml"),
-    dictionary_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/CAP-XCR/firmware/2.4.0/cap-xcr-c_eth_2.4.0.xdf"
-    ),
-    firmware_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/CAP-XCR/firmware/2.4.0/cap-xcr-c_2.4.0.lfu"
-    ),
+    firmware_version="2.4.0",
 )
 
-# INGM-541: use from_frozen_firmware(firmware_version=2.5.1)
-ECAT_EVE_SETUP = RackServiceConfigSpecifier.from_local_firmware(
+ECAT_EVE_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.EVE_XCR_E,
     interface=Interface.ETHERCAT,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_ecat/1.2.0/config.xml"),
-    dictionary_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/EVE-XCR/firmware/2.5.1/eve-xcr-e_eoe_2.5.1.xdf"
-    ),
-    firmware_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/EVE-XCR/firmware/2.5.1/eve-xcr-e_2.5.1.sfu"
-    ),
+    firmware_version="2.5.1",
 )
 
-# INGM-541: use from_frozen_firmware (firmware_version=2.5.1)
-ECAT_CAP_SETUP = RackServiceConfigSpecifier.from_local_firmware(
+ECAT_CAP_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.CAP_XCR_E,
     interface=Interface.ETHERCAT,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_ecat/1.1.0/config.xml"),
-    dictionary_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/CAP-XCR/firmware/2.5.1/cap-xcr-e_eoe_2.5.1.xdf"
-    ),
-    firmware_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/CAP-XCR/firmware/2.5.1/cap-xcr-e_2.5.1.lfu"
-    ),
+    firmware_version="2.5.1",
 )
 
-# INGM-541: use from_frozen_firmware (firmware_version=2.4.0)
-CAN_EVE_SETUP = RackServiceConfigSpecifier.from_local_firmware(
+CAN_EVE_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.EVE_XCR_C,
     interface=Interface.CANOPEN,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_can/1.2.0/config.xml"),
-    dictionary_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/EVE-XCR/firmware/2.4.0/eve-xcr-c_can_2.4.0.xdf"
-    ),
-    firmware_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/EVE-XCR/firmware/2.4.0/eve-xcr-c_2.4.0.sfu"
-    ),
+    firmware_version="2.4.0",
 )
 
-# INGM-541: use from_frozen_firmware (firmware_version=2.4.0)
-CAN_CAP_SETUP = RackServiceConfigSpecifier.from_local_firmware(
+CAN_CAP_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.CAP_XCR_C,
     interface=Interface.CANOPEN,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_can/1.1.0/config.xml"),
-    dictionary_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/CAP-XCR/firmware/2.4.0/cap-xcr-c_can_2.4.0.xdf"
-    ),
-    firmware_file=Path(
-        "//azr-srv-ingfs1/pool/distext/products/CAP-XCR/firmware/2.4.0/cap-xcr-c_2.4.0.lfu"
-    ),
+    firmware_version="2.4.0",
 )
 
 ECAT_MULTISLAVE_SETUP = MultiRackServiceConfigSpecifier(

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
+from ingenialink.dictionary import Interface
+
 from tests.setups.specifiers import (
-    Interface,
     MultiRackServiceConfigSpecifier,
     PartNumber,
     RackServiceConfigSpecifier,
@@ -9,42 +10,42 @@ from tests.setups.specifiers import (
 
 ETH_EVE_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.EVE_XCR_C,
-    interface=Interface.ETHERNET,
+    interface=Interface.ETH,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_can/1.2.0/config.xml"),
     firmware_version="2.4.0",
 )
 
 ETH_CAP_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.CAP_XCR_C,
-    interface=Interface.ETHERNET,
+    interface=Interface.ETH,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_can/1.1.0/config.xml"),
     firmware_version="2.4.0",
 )
 
 ECAT_EVE_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.EVE_XCR_E,
-    interface=Interface.ETHERCAT,
+    interface=Interface.ECAT,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_ecat/1.2.0/config.xml"),
     firmware_version="2.5.1",
 )
 
 ECAT_CAP_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.CAP_XCR_E,
-    interface=Interface.ETHERCAT,
+    interface=Interface.ECAT,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_ecat/1.1.0/config.xml"),
     firmware_version="2.5.1",
 )
 
 CAN_EVE_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.EVE_XCR_C,
-    interface=Interface.CANOPEN,
+    interface=Interface.CAN,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_can/1.2.0/config.xml"),
     firmware_version="2.4.0",
 )
 
 CAN_CAP_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.CAP_XCR_C,
-    interface=Interface.CANOPEN,
+    interface=Interface.CAN,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_can/1.1.0/config.xml"),
     firmware_version="2.4.0",
 )

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -26,14 +26,14 @@ ECAT_EVE_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.EVE_XCR_E,
     interface=Interface.ECAT,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_ecat/1.2.0/config.xml"),
-    firmware_version="2.5.1",
+    firmware_version="2.6.0",
 )
 
 ECAT_CAP_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(
     part_number=PartNumber.CAP_XCR_E,
     interface=Interface.ECAT,
     config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_ecat/1.1.0/config.xml"),
-    firmware_version="2.5.1",
+    firmware_version="2.6.0",
 )
 
 CAN_EVE_SETUP = RackServiceConfigSpecifier.from_frozen_firmware(

--- a/tests/setups/specifiers.py
+++ b/tests/setups/specifiers.py
@@ -260,6 +260,8 @@ class RackServiceConfigSpecifier(DriveHwConfigSpecifier):
         )
 
     def __eq__(self, other):
+        if not all(hasattr(obj, "part_number") for obj in [self, other]):
+            return False
         return self.part_number == other.part_number
 
 

--- a/tests/setups/specifiers.py
+++ b/tests/setups/specifiers.py
@@ -1,18 +1,12 @@
 from dataclasses import dataclass
-from enum import Enum, auto
 from functools import cached_property
 from pathlib import Path
 from typing import Optional, Union
 
+from ingenialink.dictionary import Interface
 from ingenialink.ethernet.network import VIRTUAL_DRIVE_DICTIONARY
 
 from tests.setups.rack_service_client import PartNumber
-
-
-class Interface(Enum):
-    CANOPEN = auto()
-    ETHERNET = auto()
-    ETHERCAT = auto()
 
 
 class PromisedFilePath:
@@ -55,9 +49,9 @@ class MultiDriveConfigSpecifier(SetupSpecifier):
 
     def __post_init__(self):
         for specifier in self.specifiers:
-            if specifier.interface is not Interface.ETHERCAT:
+            if specifier.interface is not Interface.ECAT:
                 raise RuntimeError(
-                    f"Multiple part numbers can only be provided for {Interface.ETHERCAT}"
+                    f"Multiple part numbers can only be provided for {Interface.ECAT}"
                 )
 
 

--- a/tests/setups/specifiers.py
+++ b/tests/setups/specifiers.py
@@ -259,6 +259,9 @@ class RackServiceConfigSpecifier(DriveHwConfigSpecifier):
             firmware_file=PromisedFilePath(firmware_version),
         )
 
+    def __eq__(self, other):
+        return self.part_number == other.part_number
+
 
 @dataclass(frozen=True)
 class MultiRackServiceConfigSpecifier(MultiDriveConfigSpecifier):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -43,6 +43,7 @@ def test_set_get_gpi_polarity(motion_controller, gpi_id, polarity):
     assert mc.io.get_gpi_polarity(gpi_id, servo=alias) == polarity
 
 
+@pytest.mark.skip("Skip until is fixed INGM-605")
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen


### PR DESCRIPTION
### Description

Use the new ATT features of the rack service.

Fixes # INGM-541

### Type of change

- Provide the firmware version to be loaded instead of a local firmware file.
- Retrieve the dictionary from the rack service.

### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
