### PR TITLE
INGM-606 Fix rack specifier comparison

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,6 +3,7 @@ import pytest
 from ingeniamotion.enums import GPI, GPO, DigitalVoltageLevel, GPIOPolarity
 from ingeniamotion.exceptions import IMError
 from tests.setups.rack_specifiers import CAN_CAP_SETUP, ECAT_CAP_SETUP, ETH_CAP_SETUP
+from tests.tests_toolkit.setups import MultiRackServiceConfigSpecifier, RackServiceConfigSpecifier
 
 
 @pytest.mark.virtual
@@ -50,6 +51,11 @@ def test_set_get_gpi_polarity(motion_controller, gpi_id, polarity):
 @pytest.mark.smoke
 def test_get_gpi_voltage_level(motion_controller, setup_specifier):
     mc, alias, environment = motion_controller
+
+    if not isinstance(
+        setup_specifier, (RackServiceConfigSpecifier, MultiRackServiceConfigSpecifier)
+    ):
+        pytest.skip("Skipping test for local configurations")
 
     if setup_specifier in [ETH_CAP_SETUP, ECAT_CAP_SETUP, CAN_CAP_SETUP]:
         pytest.skip("Capitan rack setups do not have gpio control")

--- a/tests/tests_toolkit/setups/specifiers.py
+++ b/tests/tests_toolkit/setups/specifiers.py
@@ -13,6 +13,9 @@ class PromisedFilePath:
     def __init__(self, firmware_version: str):
         self.firmware_version = firmware_version
 
+    def __eq__(self, other):
+        return self.firmware_version == other.firmware_version
+
 
 @dataclass(frozen=True)
 class SetupSpecifier:
@@ -255,11 +258,6 @@ class RackServiceConfigSpecifier(DriveHwConfigSpecifier):
             dictionary=PromisedFilePath(firmware_version),
             firmware_file=PromisedFilePath(firmware_version),
         )
-
-    def __eq__(self, other):
-        if not all(hasattr(obj, "part_number") for obj in [self, other]):
-            return False
-        return self.part_number == other.part_number
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### Description

Fix the rack specifier comparison.

Fixes # INGM-606

### Type of change

- Define the comparison method for the PromisedFilePath class.

### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
