### PR TITLE
MOT3-4852 Check that the feedback resolution is valid

### DIFF
--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -205,6 +205,10 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
         self.feedback_resolution = self.mc.configuration.get_feedback_resolution(
             self.sensor, servo=self.servo, axis=self.axis
         )
+        if self.feedback_resolution == 0:
+            raise ValueError(
+                "The feedback resolution must be greater than 0. Please adjust it accordingly."
+            )
 
     @BaseTest.stoppable
     def __reaction_codes_to_warning(self) -> None:


### PR DESCRIPTION
### Description

Check that the feedback resolution is valid before running a feedback test.

Fixes # MOT3-4852

### Type of change

- Check that the feedback resolution is valid (> 0).

### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [x] USe [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
