### PR TITLE
Fix jenkins FSoE installation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,11 +29,7 @@ FSOE_INSTALL_VERSION = ".[FSoE]"
 
 coverage_stashes = []
 
-// Run this before any tox command that requires develop ingenialink installation and that
-// may run in parallel/after with HW tests, because HW tests alter its value
-def restoreIngenialinkWheelEnvVar() {
-    env.INGENIALINK_INSTALL_PATH = ORG_INGENIALINK_INSTALL_PATH
-}
+
 
 def clearIngenialinkWheelDir() {
     if (fileExists(INGENIALINK_WHEELS_DIR)) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,27 +75,27 @@ def runTestHW(markers, setup_name, install_fsoe = false) {
 
     pythonVersions.each { version ->
         def wheelFile = getIngenialinkArtifactWheelPath(version)
-        withEnv(["INGENIALINK_INSTALL_PATH=${wheelFile}", "FSOE_PACKAGE=${fsoe_package}"]) {
-            try {
-                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${version} -- " +
-                        "-m \"${markers}\" " +
-                        "--setup tests.setups.rack_specifiers.${setup_name} " +
-                        "--job_name=\"${env.JOB_NAME}-#${env.BUILD_NUMBER}-${setup_name}\""
-            } catch (err) {
-                unstable(message: "Tests failed")
-            } finally {
-                junit "pytest_reports\\*.xml"
-                // Delete the junit after publishing it so it not re-published on the next stage
-                bat "del /S /Q pytest_reports\\*.xml"
-                if (firstIteration) {
-                    def coverage_stash = ".coverage_${setup_name}"
-                    bat "move .coverage ${coverage_stash}"
-                    stash includes: coverage_stash, name: coverage_stash
-                    coverage_stashes.add(coverage_stash)
-                    firstIteration = false
-                }
+        // withEnv(["INGENIALINK_INSTALL_PATH=${wheelFile}", "FSOE_PACKAGE=${fsoe_package}"]) {
+        try {
+            bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${version} -- " +
+                    "-m \"${markers}\" " +
+                    "--setup tests.setups.rack_specifiers.${setup_name} " +
+                    "--job_name=\"${env.JOB_NAME}-#${env.BUILD_NUMBER}-${setup_name}\""
+        } catch (err) {
+            unstable(message: "Tests failed")
+        } finally {
+            junit "pytest_reports\\*.xml"
+            // Delete the junit after publishing it so it not re-published on the next stage
+            bat "del /S /Q pytest_reports\\*.xml"
+            if (firstIteration) {
+                def coverage_stash = ".coverage_${setup_name}"
+                bat "move .coverage ${coverage_stash}"
+                stash includes: coverage_stash, name: coverage_stash
+                coverage_stashes.add(coverage_stash)
+                firstIteration = false
             }
         }
+        // }
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,9 +255,6 @@ pipeline {
                     stages {
                         stage('Run no-connection tests') {
                             steps {
-                                script {
-                                    restoreIngenialinkWheelEnvVar()
-                                }
                                 sh "python${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
                                     "-m virtual " +
                                     "--setup summit_testing_framework.setups.virtual_drive.TESTS_SETUP"
@@ -290,9 +287,6 @@ pipeline {
                                 }
                                 stage('Make a static type analysis') {
                                     steps {
-                                        script {
-                                            restoreIngenialinkWheelEnvVar()
-                                        }
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
                                     }
                                 }
@@ -303,9 +297,6 @@ pipeline {
                                 }
                                 stage('Generate documentation') {
                                     steps {
-                                        script {
-                                            restoreIngenialinkWheelEnvVar()
-                                        }
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e docs"
                                         bat """
                                             "C:\\Program Files\\7-Zip\\7z.exe" a -r docs.zip -w _docs -mem=AES256
@@ -315,9 +306,6 @@ pipeline {
                                 }
                                 stage("Run unit tests") {
                                     steps {
-                                        script {
-                                            restoreIngenialinkWheelEnvVar()
-                                        }
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
                                                 "-m \"not ethernet and not soem and not fsoe and not canopen and not virtual and not soem_multislave\" "
                                     }
@@ -336,9 +324,6 @@ pipeline {
                                 }
                                 stage("Run virtual drive tests") {
                                     steps {
-                                        script {
-                                            restoreIngenialinkWheelEnvVar()
-                                        }
                                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
                                                 "-m virtual " +
                                                 "--setup summit_testing_framework.setups.virtual_drive.TESTS_SETUP "


### PR DESCRIPTION
### Description

Improve environment variables for _tox_ in _Jenkins_.

_withEnv_  limits the scope of the environment variable. If _Jenkins_ enviornment variables are used, parallel jobs may alter its value leading to wrong results.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Use _withEnv_ to limit the scope of the environment variable.


### Tests
- [ ] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

