### PR TITLE
Ingm 617 move servo to fsoe master handler instance

### DIFF
--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -205,14 +205,10 @@ class FSoEMasterHandler:
         return safe_inputs_value
 
     def get_safety_address(self) -> int:
-        """Get the drive's FSoE slave address.
-
-        Args:
-            servo: servo alias to reference it. ``default`` by default.
+        """Get the FSoE slave address configured on the master.
 
         Returns:
             The FSoE slave address.
-
         """
         # https://novantamotion.atlassian.net/browse/INGK-1090
         value = self._master_handler.master.session.slave_address.value
@@ -221,12 +217,10 @@ class FSoEMasterHandler:
         return value
 
     def set_safety_address(self, address: int) -> None:
-        """Set the drive's FSoE slave address.
+        """Set the drive's FSoE slave address to the master and the slave.
 
         Args:
             address: The address to be set.
-            servo: servo alias to reference it. ``default`` by default.
-
         """
         self.__servo.write(self.FSOE_MANUF_SAFETY_ADDRESS, address)
         self._master_handler.set_slave_address(address)

--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -68,11 +68,9 @@ class FSoEMasterHandler:
 
     DEFAULT_WATCHDOG_TIMEOUT_S = 1
 
-    # Pending
-    __servo: EthercatServo
-
     def __init__(
         self,
+        servo: EthercatServo,
         *,
         slave_address: int,
         connection_id: int,
@@ -82,6 +80,8 @@ class FSoEMasterHandler:
     ):
         if not FSOE_MASTER_INSTALLED:
             return
+
+        self.__servo = servo
         self.__master_handler = MasterHandler(
             dictionary=self._saco_phase_1_dictionary(),
             slave_address=slave_address,
@@ -414,9 +414,13 @@ class FSoEMaster:
             fsoe_master_watchdog_timeout: The FSoE master watchdog timeout in seconds.
 
         """
+        node = self.__mc.servos[servo]
+        if not isinstance(node, EthercatServo):
+            raise TypeError("Functional Safety over Ethercat is only available for Ethercat servos")
         slave_address = self.get_safety_address(servo)
         application_parameters = self._get_application_parameters(servo)
         master_handler = FSoEMasterHandler(
+            node,
             slave_address=slave_address,
             connection_id=self.__next_connection_id,
             watchdog_timeout=fsoe_master_watchdog_timeout,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import numpy as np
 import pytest
 from summit_testing_framework import dynamic_loader
 
+from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED
+
 pytest_plugins = [
     "summit_testing_framework.pytest_addoptions",
     "summit_testing_framework.setup_fixtures",
@@ -16,6 +18,9 @@ pytest_plugins = [
 # The issue is solved by dynamically importing them before the tests start. All modules that should
 # be imported and ARE NOT part of the package should be specified here
 _DYNAMIC_MODULES_IMPORT = ["tests", "examples"]
+
+if FSOE_MASTER_INSTALLED:
+    _DYNAMIC_MODULES_IMPORT.append("fsoe_master")
 
 test_report_key = pytest.StashKey[dict[str, pytest.CollectReport]]()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,6 @@ import numpy as np
 import pytest
 from summit_testing_framework import dynamic_loader
 
-from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED
-
 pytest_plugins = [
     "summit_testing_framework.pytest_addoptions",
     "summit_testing_framework.setup_fixtures",
@@ -19,8 +17,6 @@ pytest_plugins = [
 # be imported and ARE NOT part of the package should be specified here
 _DYNAMIC_MODULES_IMPORT = ["tests", "examples"]
 
-if FSOE_MASTER_INSTALLED:
-    _DYNAMIC_MODULES_IMPORT.append("fsoe_master")
 
 test_report_key = pytest.StashKey[dict[str, pytest.CollectReport]]()
 

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -43,6 +43,9 @@ def error_handler(error: FSoEError):
     raise RuntimeError(f"FSoE error received: {error}")
 
 
+# TODO Pending add more tests for the FSoE master API, check it not broke
+
+
 @pytest.mark.fsoe
 @pytest.mark.smoke
 def test_fsoe_master_get_application_parameters(mc, alias):

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -1,7 +1,9 @@
 from typing import TYPE_CHECKING
 
 import pytest
+from fsoe_master import fsoe_master
 
+from ingeniamotion.enums import FSoEState
 from ingeniamotion.fsoe import FSoEError, FSoEMaster
 from ingeniamotion.motion_controller import MotionController
 
@@ -43,9 +45,6 @@ def error_handler(error: FSoEError):
     raise RuntimeError(f"FSoE error received: {error}")
 
 
-# TODO Pending add more tests for the FSoE master API, check it not broke
-
-
 @pytest.mark.fsoe
 @pytest.mark.smoke
 def test_fsoe_master_get_application_parameters(mc, alias):
@@ -69,14 +68,68 @@ def mc_with_fsoe(mc):
     mc.fsoe._delete_master_handler()
 
 
-@pytest.mark.fsoe
-@pytest.mark.smoke
-def test_deactivate_sto(mc_with_fsoe):
+@pytest.fixture()
+def mc_state_data(mc_with_fsoe):
     mc = mc_with_fsoe
 
     mc.fsoe.configure_pdos(start_pdos=True)
     # Wait for the master to reach the Data state
     mc.fsoe.wait_for_state_data(timeout=10)
+
+    yield mc
+
+    # Stop the FSoE master handler
+    mc.fsoe.stop_master(stop_pdos=True)
+
+
+def test_safe_inputs_value(mc_state_data):
+    mc = mc_state_data
+
+    value = mc.fsoe.get_safety_inputs_value()
+
+    # Assume safe inputs are disconnected on the setup
+    assert value == 0
+
+
+def test_safety_address(mc_with_fsoe, alias):
+    mc = mc_with_fsoe
+
+    master_handler = mc.fsoe._handlers[alias]
+
+    mc.fsoe.set_safety_address(0x7453)
+    # Setting the safety address has effects on the master
+    assert master_handler._master_handler.master.session.slave_address.value == 0x7453
+
+    # And on the slave
+    assert mc.communication.get_register("FSOE_MANUF_SAFETY_ADDRESS") == 0x7453
+
+    # The getter also works
+    assert mc.fsoe.get_safety_address() == 0x7453
+
+
+@pytest.mark.parametrize(
+    "state_class, state_enum",
+    [
+        (fsoe_master.StateReset, FSoEState.RESET),
+        (fsoe_master.StateSession, FSoEState.SESSION),
+        (fsoe_master.StateConnection, FSoEState.CONNECTION),
+        (fsoe_master.StateParameter, FSoEState.PARAMETER),
+        (fsoe_master.StateData, FSoEState.DATA),
+    ],
+)
+def test_get_master_state(mocker, mc_with_fsoe, state_class, state_enum):
+    mc = mc_with_fsoe
+
+    mocker.patch("fsoe_master.fsoe_master.MasterHandler.state", state_class)
+
+    assert mc.fsoe.get_fsoe_master_state() == state_enum
+
+
+@pytest.mark.fsoe
+@pytest.mark.smoke
+def test_motor_enable(mc_state_data):
+    mc = mc_state_data
+
     # Deactivate the SS1
     mc.fsoe.ss1_deactivate()
     # Deactivate the STO
@@ -92,5 +145,3 @@ def test_deactivate_sto(mc_with_fsoe):
     mc.fsoe.sto_activate()
     # Activate the STO
     mc.fsoe.sto_activate()
-    # Stop the FSoE master handler
-    mc.fsoe.stop_master(stop_pdos=True)

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -86,6 +86,8 @@ def mc_state_data(mc_with_fsoe):
     mc.fsoe.stop_master(stop_pdos=True)
 
 
+@pytest.mark.fsoe
+@pytest.mark.smoke
 def test_safe_inputs_value(mc_state_data):
     mc = mc_state_data
 
@@ -95,6 +97,8 @@ def test_safe_inputs_value(mc_state_data):
     assert value == 0
 
 
+@pytest.mark.fsoe
+@pytest.mark.smoke
 def test_safety_address(mc_with_fsoe, alias):
     mc = mc_with_fsoe
 
@@ -121,6 +125,8 @@ def mc_state_to_fsoe_master_state(state: FSoEState):
     }[state]
 
 
+@pytest.mark.fsoe
+@pytest.mark.smoke
 @pytest.mark.parametrize(
     "state_enum",
     [

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list = coverage, build, docs, format, type, py{39,310,311,312}, virtual
 # It should be empty in production.
 # Use full commit hash
 [develop]
-    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@047bf1358b1c48fe094822d2809fd8b0c8a99cea}
+    ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@7fd167497e9b2e0fec6a10caeba88d448d4e44d2}
 
 
 [testenv]


### PR DESCRIPTION
### Description

Moved the servo to the FSOEMasterHandler object. 
The object should now be roughtly enought to configure a safe drive by itself using OOP. It has still compatibility to configure it via the non-OOP API.

Fixes INGM-617

### Type of change

Please add a description and delete options that are not relevant.

- [x] Moved methods from FSOEMaster to FSoEMasterHandler
- [x] Propagated safety address also to the master handler new methods: https://github.com/ingeniamc/ingeniamotion/pull/345/files#diff-1322868ebcf8a78a9cd8d609b9883745df286cb31e9dc223971f5d183b538701R226

### Tests
- [x] Add new unit tests that validate the existing but adapted non-OOP API
- [x] Run with DEN-S-NET-E phase I on the table

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md). -> I think this change is 100% internal and should not be logged as a change

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
