### PR TITLE
Ingm 643 the safe inputs appear to not be mapped correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Created PDUMaps that parses pdos and converts them to pdos.
 - Added methods to intelligently add i/o on the map.
 
+### Fixed
+- Safety map and safe inputs reading
+
 ## [0.9.1] - 2025-05-07
 ### Added
 - Methods to scan Ethernet drives.

--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -364,9 +364,9 @@ class FSoEMasterHandler:
         # Phase 1 mapping
         self.__maps.inputs.add(self.get_function_instance(STOFunction).command)
         self.__maps.inputs.add(self.get_function_instance(SS1Function).command)
-        self.__maps.inputs.add_padding(bits=7)
-        self.__maps.inputs.add(self.get_function_instance(SafeInputsFunction).value)
         self.__maps.inputs.add_padding(bits=6)
+        self.__maps.inputs.add(self.get_function_instance(SafeInputsFunction).value)
+        self.__maps.inputs.add_padding(bits=7)
 
     def configure_pdo_maps(self) -> None:
         """Configure the PDOMaps used for the Safety PDUs according to the map."""

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
         "ifaddr==0.1.7",
     ],
     extras_require={
-        "FSoE": ["fsoe_master==0.1.4+pr65b7"],
+        "FSoE": ["fsoe_master==0.1.4+pr66b3"],
     },
     python_requires=">=3.9",
 )

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -252,8 +252,8 @@ def test_copy_modify_and_set_map(mc_with_fsoe):
         "Item                                     | Position bytes..bits | Size bytes..bits    \n"
         "FSOE_STO                                 | 0..0                 | 0..1                \n"
         "FSOE_SS1_1                               | 0..1                 | 0..1                \n"
-        "Padding                                  | 0..2                 | 0..7                \n"
-        "Padding                                  | 1..1                 | 0..6                "
+        "Padding                                  | 0..2                 | 0..6                \n"
+        "Padding                                  | 1..0                 | 0..7                "
     )
 
     # Without affecting the original map of the handler
@@ -261,9 +261,9 @@ def test_copy_modify_and_set_map(mc_with_fsoe):
         "Item                                     | Position bytes..bits | Size bytes..bits    \n"
         "FSOE_STO                                 | 0..0                 | 0..1                \n"
         "FSOE_SS1_1                               | 0..1                 | 0..1                \n"
-        "Padding                                  | 0..2                 | 0..7                \n"
-        "FSOE_SAFE_INPUTS_VALUE                   | 1..1                 | 0..1                \n"
-        "Padding                                  | 1..2                 | 0..6                "
+        "Padding                                  | 0..2                 | 0..6                \n"
+        "FSOE_SAFE_INPUTS_VALUE                   | 1..0                 | 0..1                \n"
+        "Padding                                  | 1..1                 | 0..7                "
     )
 
     # The new map can be set to the handler


### PR DESCRIPTION
Fixes INGM-643

### Type of change

- [x] Fix inputs map

### Tests
Used test_safe_inputs_value as a helper, with a physical setup
Without HW control to the rack this automated test is not possible for now...

```
@pytest.mark.fsoe
def test_safe_inputs_value(mc_state_data):
    mc = mc_state_data

    value = mc.fsoe.get_safety_inputs_value()

    # Assume safe inputs are disconnected on the setup
    assert value == 0
```

- [x] Run test with STOs switches at 0 -> Test passes
- [x] Run test with STOs switches at 1 -> Test fails with `assert 1 == 0`

Without HW control to the rack this automated test is not possible for now...

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
