### PR TITLE
INGM-645 Monitoring V1 is not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.2] - 2025-06-DD
+### Fixed
+- Restored Monitoring V1 functionality.
+
 ## [0.9.1] - 2025-05-07
 ### Added
 - Methods to scan Ethernet drives.

--- a/ingeniamotion/__init__.py
+++ b/ingeniamotion/__init__.py
@@ -1,7 +1,7 @@
 from . import enums
 from .motion_controller import MotionController
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 """ str: Library version. """
 
 __all__ = ["MotionController", "enums"]

--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -646,8 +646,9 @@ class Capture:
         ]:
             if self.mc.configuration.is_motor_enabled(servo=servo, axis=subnode):
                 raise IMStatusWordError("Motor is enabled")
-        self.enable_monitoring(servo=servo)
-        self.disable_monitoring(servo=servo)
+        drive = self.mc._get_drive(servo)
+        drive.monitoring_enable()
+        drive.monitoring_disable()
 
     def disturbance_max_sample_size(self, servo: str = DEFAULT_SERVO) -> int:
         """Return disturbance max size, in bytes.


### PR DESCRIPTION
### Description

To ensure Monitoring V1 works correctly, monitoring must be [enabled/disabled](https://github.com/ingeniamc/ingeniamotion/blob/master/ingeniamotion/capture.py#L630) upon initialization (before any register is mapped). A recent [check](https://github.com/ingeniamc/ingeniamotion/blob/master/ingeniamotion/capture.py#L348) was added to prevent users from enabling monitoring before mapping any registers, which inadvertently caused Monitoring V1 to fail. This issue has now been fixed.

Fixes # INGM-645

### Type of change

Please add a description and delete options that are not relevant.

- Enable/disable using the servo object to bypass the number of mapped registers check (Only on the Monitoring V1 initialization).


### Tests
- [x] Run tests.

Test:

- Create a monitoring V1.
- Check that it is successful. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
