### PR TITLE
INGM-650 update safety parameters when reconfiguring pdo maps

### DIFF
--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -100,7 +100,7 @@ class FSoEMaster:
                 the PDO exchange should be started after. ``False`` by default.
 
         """
-        self._set_pdo_maps_to_slaves()
+        self._configure_and_set_pdo_maps_to_slaves()
         self._subscribe_to_pdo_thread_events()
         if start_pdos:
             self.__mc.capture.pdo.start_pdos()
@@ -340,9 +340,10 @@ class FSoEMaster:
         self.__mc.capture.pdo.unsubscribe_to_receive_process_data(self._set_reply)
         self.__mc.capture.pdo.unsubscribe_to_exceptions(self._pdo_thread_exception_handler)
 
-    def _set_pdo_maps_to_slaves(self) -> None:
-        """Set the PDOMaps to be used by the Safety PDUs to the slaves."""
+    def _configure_and_set_pdo_maps_to_slaves(self) -> None:
+        """Configure the PDOMaps used by the Safety PDUs in the slaves."""
         for master_handler in self._handlers.values():
+            master_handler.configure_pdo_maps()
             master_handler.set_pdo_maps_to_slave()
 
     def _remove_pdo_maps_from_slaves(self) -> None:

--- a/ingeniamotion/fsoe_master/parameters.py
+++ b/ingeniamotion/fsoe_master/parameters.py
@@ -6,8 +6,8 @@ from typing_extensions import override
 from ingeniamotion.fsoe_master.fsoe import FSoEApplicationParameter
 
 if TYPE_CHECKING:
+    from ingenialink.ethercat.register import EthercatRegister
     from ingenialink.ethercat.servo import EthercatServo
-    from ingenialink.register import Register
 
 __all__ = ["SafetyParameter", "SafetyParameterDirectValidation"]
 
@@ -20,11 +20,16 @@ class SafetyParameter:
     Base class is used for modules that use SRA CRC Check mechanism.
     """
 
-    def __init__(self, register: "Register", servo: "EthercatServo"):
+    def __init__(self, register: "EthercatRegister", servo: "EthercatServo"):
         self.__register = register
         self.__servo = servo
 
         self.__value = servo.read(register)
+
+    @property
+    def register(self) -> "EthercatRegister":
+        """Get the register associated with the safety parameter."""
+        return self.__register
 
     def get(self) -> Union[int, float, str, bytes]:
         """Get the value of the safety parameter."""
@@ -43,7 +48,7 @@ class SafetyParameterDirectValidation(SafetyParameter):
      state instead of SRA CRC Check
     """
 
-    def __init__(self, register: "Register", drive: "EthercatServo"):
+    def __init__(self, register: "EthercatRegister", drive: "EthercatServo"):
         super().__init__(register, drive)
 
         self.fsoe_application_parameter = FSoEApplicationParameter(

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list = coverage, build, docs, format, type, py{39,310,311,312}, virtual
 # It should be empty in production.
 # Use full commit hash
 [develop]
-ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@6959c23dc3370629de987fc4ca8d81c27dee7141}
+ingenialink = {env:INGENIALINK_INSTALL_PATH:git+https://github.com/ingeniamc/ingenialink-python@4db782762849a4aa955118c686c8d3e93d8b7bbd}
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
### Description

Updating the pdo items parameters when they are part of safety parameters when calling configure_pdo_maps.
I think the pdo maps were being filled when the the master started, which did not make much sense.
Now since the configure_pdo_maps even modifies the application parameters it makes a lot of sense to do it a lot before.

Also: https://github.com/ingeniamc/ingenialink-python/pull/590

Fixes INGM-650

### Type of change

Please add a description and delete options that are not relevant.

- [x] Update pdo safety parameters
- [x] Move pdo configuration to before starting pdos.

### Tests
Not possible to actually test since we don't have a FW version or dictionary that contains pdos as safe params yet.
Phase I still works and does not update anything

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
