### PR TITLE
Ingm 662 investigate adapters not appearing if only npcap is selected in adapter configuration

### DIFF
--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -507,7 +507,7 @@ class Communication:
                 6  # https://learn.microsoft.com/en-us/windows/win32/api/ifdef/ns-ifdef-net_luid_lh
             )
             for adapter in get_adapters_addresses(
-                adapter_families=AdapterFamily.INET,
+                adapter_families=AdapterFamily.UNSPEC,
                 scan_flags=[
                     ScanFlags.INCLUDE_PREFIX,
                     ScanFlags.INCLUDE_ALL_INTERFACES,

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -517,7 +517,7 @@ class Communication:
                             ScanFlags.INCLUDE_ALL_INTERFACES,
                         ],
                     )
-                    if adapter.IfType == ethernet_adapter_type and len(adapter.FirstUnicastAddress)
+                    if adapter.IfType == ethernet_adapter_type
                 ]
             )
         return {adapter.interface_name: adapter.interface_guid for adapter in network_adapters}


### PR DESCRIPTION
### Description

Fix adapters filters -> adapters should appear even if network adapter settings change.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Remove `FirstUnicastAddress` filter - it was filtering out adapters if IPv options were disabled
- [ ] Change 2 (description)


### Tests
- [ ] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [ ] Set fix version field in the Jira issue.
