### PR TITLE
INGM-660 add safety phase 2 specifier

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -332,13 +332,13 @@ pipeline {
                                 runTestHW("ethercat_capitan", "soem", "ECAT_CAP_SETUP", false, USE_WIRESHARK_LOGGING)
                             }
                         }
-                        stage("Safety Denali Phase 1") {
+                        stage("Safety Denali Phase I") {
                             steps {
                                 runTestHW("fsoe_phase1", "fsoe", "ECAT_DEN_S_PHASE1_SETUP", true, USE_WIRESHARK_LOGGING)
                            
                             }
                         }
-                        stage("Safety Denali Phase 2") {
+                        stage("Safety Denali Phase II") {
                             steps {
                                 runTestHW("fsoe_phase2", "fsoe", "ECAT_DEN_S_PHASE2_SETUP", true, USE_WIRESHARK_LOGGING)
                            

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -332,9 +332,16 @@ pipeline {
                                 runTestHW("ethercat_capitan", "soem", "ECAT_CAP_SETUP", false, USE_WIRESHARK_LOGGING)
                             }
                         }
-                        stage("Safety Denali") {
+                        stage("Safety Denali Phase 1") {
                             steps {
                                 runTestHW("fsoe_phase1", "fsoe", "ECAT_DEN_S_PHASE1_SETUP", true, USE_WIRESHARK_LOGGING)
+                           
+                            }
+                        }
+                        stage("Safety Denali Phase 2") {
+                            steps {
+                                runTestHW("fsoe_phase2", "fsoe", "ECAT_DEN_S_PHASE2_SETUP", true, USE_WIRESHARK_LOGGING)
+                           
                             }
                         }
                         stage("Ethercat Multislave") {

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -55,10 +55,10 @@ ECAT_DEN_S_PHASE2_SETUP = RackServiceConfigSpecifier.from_firmware(
     interface=Interface.ECAT,
     config_file=None,
     firmware=Path(
-        "/azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_2.8.0.lfu"
+        "\\\\azr-srv-ingfs1\\dist\\products\\i050_summit\\i056_den-s-net-e\\release_candidate\\safety_1.1.0.4\\den-s-net-e_2.8.0.lfu"
     ),
     dictionary=Path(
-        "/azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_safety_1.1.0.004_v3.xdf"
+        "\\\\azr-srv-ingfs1\\dist\\products\\i050_summit\\i056_den-s-net-e\\release_candidate\\safety_1.1.0.4\\den-s-net-e_safety_1.1.0.004_v3.xdf"
     ),
 )
 

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -55,10 +55,10 @@ ECAT_DEN_S_PHASE2_SETUP = RackServiceConfigSpecifier.from_firmware(
     interface=Interface.ECAT,
     config_file=None,
     firmware=Path(
-        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_2.8.0.lfu"
+        "/azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_2.8.0.lfu"
     ),
     dictionary=Path(
-        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_safety_1.1.0.004_v3.xdf"
+        "/azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_safety_1.1.0.004_v3.xdf"
     ),
 )
 

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -50,6 +50,18 @@ ECAT_DEN_S_PHASE1_SETUP = RackServiceConfigSpecifier.from_firmware(
     dictionary=DictionaryVersion("2.7.4", DictionaryType.XDF_V2),
 )
 
+ECAT_DEN_S_PHASE2_SETUP = RackServiceConfigSpecifier.from_firmware(
+    part_number=PartNumber.DEN_S_NET_E,
+    interface=Interface.ECAT,
+    config_file=None,
+    firmware=Path(
+        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_2.8.0.lfu"
+    ),
+    dictionary=Path(
+        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_safety_1.1.0.004_v3.xdf"
+    ),
+)
+
 CAN_EVE_SETUP = RackServiceConfigSpecifier.from_firmware(
     part_number=PartNumber.EVE_XCR_C,
     interface=Interface.CAN,

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -55,10 +55,10 @@ ECAT_DEN_S_PHASE2_SETUP = RackServiceConfigSpecifier.from_firmware(
     interface=Interface.ECAT,
     config_file=None,
     firmware=Path(
-        "\\\\azr-srv-ingfs1\\dist\\products\\i050_summit\\i056_den-s-net-e\\release_candidate\\safety_1.1.0.4\\den-s-net-e_2.8.0.lfu"
+        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_2.8.0.lfu"
     ),
     dictionary=Path(
-        "\\\\azr-srv-ingfs1\\dist\\products\\i050_summit\\i056_den-s-net-e\\release_candidate\\safety_1.1.0.4\\den-s-net-e_safety_1.1.0.004_v3.xdf"
+        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_safety_1.1.0.004_v3.xdf"
     ),
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     pytest-console-scripts==1.4.1
     matplotlib==3.8.2
     {env:FSOE_PACKAGE}
-    summit-testing-framework==0.1.4+pr30b62
+    summit-testing-framework==0.1.4+pr33b6
 commands =
     python -I -m pytest {posargs:tests} --import-mode=importlib --cov={envsitepackagesdir}/ingeniamotion --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
 # Pass the WINDIR environment variable (it is needed by matplotlib).


### PR DESCRIPTION
### Description

The goal of this PR is to verify that the FSoE tests that work for Safety Phase I also work for Safety Phase II:
<img width="290" height="74" alt="image" src="https://github.com/user-attachments/assets/8a519611-f0a8-4966-afed-c23430b35895" />


Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Add phase II setup for FSoE tests
- [X] Updated summit-testing-framework version


### Tests
- [ ] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [ ] Set fix version field in the Jira issue.
