### PR TITLE
Ingm 664 make slave address and connection id of fsoe master optional

### DIFF
--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -67,12 +67,10 @@ class FSoEMaster:
         node = self.__mc.servos[servo]
         if not isinstance(node, EthercatServo):
             raise TypeError("Functional Safety over Ethercat is only available for Ethercat servos")
-        slave_address = self._get_safety_address_from_drive(servo)
 
         master_handler = FSoEMasterHandler(
             node,
             use_sra=use_sra,
-            slave_address=slave_address,
             connection_id=self.__next_connection_id,
             watchdog_timeout=fsoe_master_watchdog_timeout,
             report_error_callback=partial(self._notify_errors, servo=servo),
@@ -80,26 +78,6 @@ class FSoEMaster:
         self._handlers[servo] = master_handler
         self.__next_connection_id += 1
         return master_handler
-
-    def _get_safety_address_from_drive(self, servo: str = DEFAULT_SERVO) -> int:
-        """Get the drive's FSoE slave address configured in the drive.
-
-        Args:
-            servo: servo alias to reference it. ``default`` by default.
-
-        Raises:
-            ValueError: On unexpected safety address value type.
-
-        Returns:
-            The FSoE slave address.
-
-        """
-        value = self.__mc.communication.get_register(
-            FSoEMasterHandler.FSOE_MANUF_SAFETY_ADDRESS, servo
-        )
-        if not isinstance(value, int):
-            raise ValueError(f"Wrong safety address value type. Expected int, got {type(value)}")
-        return value
 
     def configure_pdos(self, start_pdos: bool = False) -> None:
         """Configure the PDOs used for the Safety PDUs.

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -74,8 +74,8 @@ class FSoEMasterHandler:
         servo: EthercatServo,
         *,
         use_sra: bool,
-        slave_address: int,
-        connection_id: int,
+        slave_address: Optional[int] = None,
+        connection_id: Optional[int] = None,
         watchdog_timeout: float = DEFAULT_WATCHDOG_TIMEOUT_S,
         report_error_callback: Callable[[str, str], None],
     ):
@@ -128,6 +128,11 @@ class FSoEMasterHandler:
         self.dictionary = self.create_safe_dictionary(servo.dictionary)
 
         self.safety_functions = tuple(SafetyFunction.for_handler(self))
+
+        if slave_address is not None:
+            self.set_safety_address(slave_address)
+        if slave_address is None:
+            slave_address = self.get_safety_address_from_slave()
 
         self._master_handler = BaseMasterHandler(
             dictionary=self.dictionary,
@@ -492,6 +497,14 @@ class FSoEMasterHandler:
         """
         self.__servo.write(self.FSOE_MANUF_SAFETY_ADDRESS, address)
         self._master_handler.set_slave_address(address)
+
+    def get_safety_address_from_slave(self) -> int:
+        """Get the FSoE slave address configured on the slave.
+
+        Returns:
+            The FSoE slave address.
+        """
+        return cast("int", self.__servo.read(self.FSOE_MANUF_SAFETY_ADDRESS))
 
     def is_sto_active(self) -> bool:
         """Check the STO state.

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -1,5 +1,6 @@
 import threading
 from collections.abc import Iterator
+from random import randint
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union, cast, overload
 
 import ingenialogger
@@ -133,6 +134,9 @@ class FSoEMasterHandler:
             self.set_safety_address(slave_address)
         if slave_address is None:
             slave_address = self.get_safety_address_from_slave()
+
+        if connection_id is None:
+            connection_id = randint(1, 0xFFFF_FFFF)
 
         self._master_handler = BaseMasterHandler(
             dictionary=self.dictionary,

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -1,14 +1,18 @@
 import logging
+import random
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Union
 
 import pytest
-from ingenialink import RegAccess, RegDtype
-from ingenialink.dictionary import DictionarySafetyModule, DictionaryV3, Interface
+from ingenialink import RegAccess, RegDtype, Servo
+from ingenialink.dictionary import CanOpenObject, DictionarySafetyModule, DictionaryV3, Interface
 from ingenialink.enums.register import RegCyclicType
 from ingenialink.ethercat.register import EthercatRegister
+from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.pdo import RPDOMap, TPDOMap
+from ingenialink.register import Register
 from ingenialink.servo import DictionaryFactory
+from ingenialink.utils._utils import convert_dtype_to_bytes
 
 from ingeniamotion.enums import FSoEState
 from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED, FSoEError, FSoEMaster
@@ -196,6 +200,42 @@ class MockSafetyParameter:
         pass
 
 
+class MockServo(Servo):
+    interface = Interface.ECAT
+
+    def __init__(self, dictionary_path: str):
+        super().__init__(target=1, dictionary_path=dictionary_path)
+
+        self.current_values = {
+            register: convert_dtype_to_bytes(register.default, register.dtype)
+            for register in self.dictionary.all_registers()
+        }
+
+    def _write_raw(self, register: Register, data: bytes, **kwargs: Any):
+        self.current_values[register] = data
+
+    def _read_raw(self, reg: Register, **kwargs: Any) -> bytes:
+        return self.current_values[reg]
+
+    def read_complete_access(
+        self, reg: Union[str, Register, CanOpenObject], *args, **kwargs
+    ) -> bytes:
+        if not isinstance(reg, CanOpenObject):
+            raise NotImplementedError
+
+        value = bytearray()
+
+        for register in reg:
+            value += self.current_values[register]
+            if register.subidx == 0:
+                value += b"\00"  # Padding after first u8 element
+
+        return bytes(value)
+
+    read_rpdo_map_from_slave = EthercatServo.read_rpdo_map_from_slave
+    read_tpdo_map_from_slave = EthercatServo.read_tpdo_map_from_slave
+
+
 class MockHandler:
     def __init__(self, dictionary: str, module_uid: int):
         xdf = DictionaryFactory.create_dictionary(dictionary, interface=Interface.ECAT)
@@ -205,6 +245,65 @@ class MockHandler:
             app_parameter.uid: MockSafetyParameter()
             for app_parameter in xdf.get_safety_module(module_uid).application_parameters
         }
+
+
+@pytest.mark.fsoe
+def test_constructor_set_slave_address():
+    mock_servo = MockServo(SAMPLE_SAFE_PH1_XDFV3_DICTIONARY)
+    try:
+        handler = FSoEMasterHandler(
+            mock_servo, use_sra=True, slave_address=0x7412, report_error_callback=error_handler
+        )
+
+        assert mock_servo.read(FSoEMasterHandler.FSOE_MANUF_SAFETY_ADDRESS) == 0x7412
+        assert handler._master_handler.get_slave_address() == 0x7412
+    finally:
+        handler.delete()
+
+
+@pytest.mark.fsoe
+def test_constructor_inherit_slave_address():
+    mock_servo = MockServo(SAMPLE_SAFE_PH1_XDFV3_DICTIONARY)
+    try:
+        # Set the slave address in the servo
+        mock_servo.write(FSoEMasterHandler.FSOE_MANUF_SAFETY_ADDRESS, 0x4986)
+
+        handler = FSoEMasterHandler(mock_servo, use_sra=True, report_error_callback=error_handler)
+
+        assert mock_servo.read(FSoEMasterHandler.FSOE_MANUF_SAFETY_ADDRESS) == 0x4986
+    finally:
+        handler.delete()
+
+
+@pytest.mark.fsoe
+def test_constructor_set_connection_id():
+    mock_servo = MockServo(SAMPLE_SAFE_PH1_XDFV3_DICTIONARY)
+    try:
+        handler = FSoEMasterHandler(
+            mock_servo,
+            use_sra=True,
+            connection_id=0x3742,
+            report_error_callback=error_handler,
+        )
+        assert handler._master_handler.master.session.connection_id.value == 0x3742
+    finally:
+        handler.delete()
+
+
+@pytest.mark.fsoe
+def test_constructor_random_connection_id():
+    mock_servo = MockServo(SAMPLE_SAFE_PH1_XDFV3_DICTIONARY)
+
+    random.seed(0x1234)
+    try:
+        handler = FSoEMasterHandler(
+            mock_servo,
+            use_sra=True,
+            report_error_callback=error_handler,
+        )
+        assert handler._master_handler.master.session.connection_id.value == 0xED9A
+    finally:
+        handler.delete()
 
 
 @pytest.mark.fsoe


### PR DESCRIPTION
Fixes INGM-664

### Type of change

Please add a description and delete options that are not relevant.

- [x] Make FSOE slave address optional on constructor. When indicated it is written to the slave. When not, it is taken from the current slave value (ML3 behaviour)
- [x] Make connection id optional on constructor. When indicated it is set to the handler, when not a valid random value is generated

### Tests
- [x] Added unit tests for each constructor case
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
