### PR TITLE
Ingm 676 allow to subscribe to fsoe state changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dist/
 
 # JetBrains IDE
 .idea/
+.run/
 
 # Unit tests reports
 TEST*.xml

--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -48,6 +48,7 @@ class FSoEMaster:
         use_sra: bool,
         servo: str = DEFAULT_SERVO,
         fsoe_master_watchdog_timeout: Optional[float] = None,
+        state_change_callback: Optional[Callable[[FSoEState], None]] = None,
     ) -> "FSoEMasterHandler":
         """Create an FSoE Master handler linked to a Safe servo drive.
 
@@ -58,6 +59,8 @@ class FSoEMaster:
             use_sra: True to use SRA, False otherwise.
             servo: servo alias to reference it. ``default`` by default.
             fsoe_master_watchdog_timeout: The FSoE master watchdog timeout in seconds.
+            state_change_callback: Optional callback to be called when the
+                FSoE master handler state changes.
 
         Returns:
             An instance of FSoEMasterHandler.
@@ -74,6 +77,7 @@ class FSoEMaster:
             connection_id=self.__next_connection_id,
             watchdog_timeout=fsoe_master_watchdog_timeout,
             report_error_callback=partial(self._notify_errors, servo=servo),
+            state_change_callback=state_change_callback,
         )
         self._handlers[servo] = master_handler
         self.__next_connection_id += 1

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -79,11 +79,13 @@ class FSoEMasterHandler:
         connection_id: Optional[int] = None,
         watchdog_timeout: float = DEFAULT_WATCHDOG_TIMEOUT_S,
         report_error_callback: Callable[[str, str], None],
+        state_change_callback: Optional[Callable[[State], None]] = None,
     ):
         if not FSOE_MASTER_INSTALLED:
             return
         self.logger = ingenialogger.get_logger(__name__)
 
+        self.__state_change_callback = state_change_callback
         self.__servo = servo
         self.__running: bool = False
         self.__uses_sra: bool = use_sra
@@ -167,7 +169,7 @@ class FSoEMasterHandler:
             watchdog_timeout_s=watchdog_timeout,
             application_parameters=fsoe_application_parameters,
             report_error_callback=report_error_callback,
-            state_change_callback=self.__state_change_callback,
+            state_change_callback=self.__internal_state_change_callback,
         )
 
         # If anything else fails on the constructor, ensure the master handler is deleted
@@ -570,11 +572,14 @@ class FSoEMasterHandler:
             raise ValueError(f"Wrong value type. Expected type bool, got {type(sto_command)}")
         return sto_command
 
-    def __state_change_callback(self, state: "State") -> None:
+    def __internal_state_change_callback(self, state: "State") -> None:
         if state == StateData:
             self.__state_is_data.set()
         else:
             self.__state_is_data.clear()
+
+        if self.__state_change_callback:
+            self.__state_change_callback(state)
 
     def wait_for_data_state(self, timeout: Optional[float] = None) -> None:
         """Wait the FSoE master handler to reach the Data state.

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -79,7 +79,7 @@ class FSoEMasterHandler:
         connection_id: Optional[int] = None,
         watchdog_timeout: float = DEFAULT_WATCHDOG_TIMEOUT_S,
         report_error_callback: Callable[[str, str], None],
-        state_change_callback: Optional[Callable[[State], None]] = None,
+        state_change_callback: Optional[Callable[[FSoEState], None]] = None,
     ):
         if not FSOE_MASTER_INSTALLED:
             return
@@ -584,7 +584,7 @@ class FSoEMasterHandler:
             self.__state_is_data.clear()
 
         if self.__state_change_callback:
-            self.__state_change_callback(state)
+            self.__state_change_callback(FSoEState(state.id))
 
     def wait_for_data_state(self, timeout: Optional[float] = None) -> None:
         """Wait the FSoE master handler to reach the Data state.

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -542,9 +542,9 @@ def mc_state_data(mc_with_fsoe):
     mc.fsoe.stop_master(stop_pdos=True)
 
 
+@pytest.mark.fsoe
 def test_pass_through_states(mc_state_data, fsoe_states):  # noqa: ARG001
     assert fsoe_states == [
-        FSoEState.RESET,
         FSoEState.SESSION,
         FSoEState.CONNECTION,
         FSoEState.PARAMETER,


### PR DESCRIPTION
### Description

Exposed callback of fsoe state transitions in IM

Fixes INGM-676

### Type of change

Please add a description and delete options that are not relevant.

- [x] Add callback that indicates when a FSoE transition happens

### Tests
- [x] Added fixture that allows to see the states the fsoe passes through
- [x] Added test that checks the state data fixture passes through regular steps, without taking detours.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
