### PR TITLE
Update safety version

### DIFF
--- a/examples/safety_mapping_example.py
+++ b/examples/safety_mapping_example.py
@@ -90,7 +90,7 @@ def main(interface_ip, slave_id, dict_path) -> None:
     mc.capture.pdo.start_pdos()
 
     # Wait for the master to reach the Data state
-    mc.fsoe.wait_for_state_data(timeout=20)
+    mc.fsoe.wait_for_state_data(timeout=30)
 
     # Remove fail-safe mode. Output commands will be applied by the slaves
     mc.fsoe.set_fail_safe(False)

--- a/examples/safety_mapping_example.py
+++ b/examples/safety_mapping_example.py
@@ -7,7 +7,6 @@ from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED
 if FSOE_MASTER_INSTALLED:
     from ingeniamotion.fsoe_master import (
         SafeInputsFunction,
-        SAFunction,
         SOSFunction,
         SS1Function,
         SS2Function,
@@ -41,7 +40,6 @@ def main(interface_ip, slave_id, dict_path) -> None:
     safe_inputs = handler.get_function_instance(SafeInputsFunction)
     ss1 = handler.get_function_instance(SS1Function)
     ss2 = handler.get_function_instance(SS2Function, instance=1)
-    sa = handler.get_function_instance(SAFunction)
     sv = handler.get_function_instance(SVFunction)
     sos = handler.get_function_instance(SOSFunction)
 

--- a/examples/safety_mapping_example.py
+++ b/examples/safety_mapping_example.py
@@ -90,7 +90,7 @@ def main(interface_ip, slave_id, dict_path) -> None:
     mc.capture.pdo.start_pdos()
 
     # Wait for the master to reach the Data state
-    mc.fsoe.wait_for_state_data(timeout=10)
+    mc.fsoe.wait_for_state_data(timeout=20)
 
     # Remove fail-safe mode. Output commands will be applied by the slaves
     mc.fsoe.set_fail_safe(False)

--- a/ingeniamotion/fsoe_master/parameters.py
+++ b/ingeniamotion/fsoe_master/parameters.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Union
 
-from ingenialink.utils._utils import dtype_value
+from ingenialink import RegDtype
 from typing_extensions import override
 
-from ingeniamotion.fsoe_master.fsoe import FSoEApplicationParameter
+from ingeniamotion.fsoe_master.fsoe import FSoEApplicationParameter, FSoEDataType
 
 if TYPE_CHECKING:
     from ingenialink.ethercat.register import EthercatRegister
@@ -65,6 +65,18 @@ class SafetyParameter:
         self.__servo.write(self.__register, self.__value)
 
 
+IL_TO_FSOE_DATATYPES = {
+    RegDtype.BOOL: FSoEDataType.BOOL,
+    RegDtype.FLOAT: FSoEDataType.FLOAT,
+    RegDtype.U8: FSoEDataType.UINT8,
+    RegDtype.U16: FSoEDataType.UINT16,
+    RegDtype.U32: FSoEDataType.UINT32,
+    RegDtype.S8: FSoEDataType.INT8,
+    RegDtype.S16: FSoEDataType.INT16,
+    RegDtype.S32: FSoEDataType.INT32,
+}
+
+
 class SafetyParameterDirectValidation(SafetyParameter):
     """Safety Parameter with direct validation via FSoE.
 
@@ -78,8 +90,7 @@ class SafetyParameterDirectValidation(SafetyParameter):
         self.fsoe_application_parameter = FSoEApplicationParameter(
             name=register.identifier,
             initial_value=self.get(),
-            # https://novantamotion.atlassian.net/browse/INGK-1104
-            n_bytes=dtype_value[register.dtype][0],
+            data_type=IL_TO_FSOE_DATATYPES[register.dtype],
         )
 
     @override

--- a/ingeniamotion/fsoe_master/safety_functions.py
+++ b/ingeniamotion/fsoe_master/safety_functions.py
@@ -157,7 +157,7 @@ class SS1Function(SafetyFunction):
     TIME_TO_STO_UID = "FSOE_SS1_TIME_TO_STO_{i}"
 
     command: "FSoEDictionaryItemInputOutput"
-    # time_to_sto: SafetyParameter
+    time_to_sto: SafetyParameter
 
     @override
     @classmethod
@@ -165,14 +165,12 @@ class SS1Function(SafetyFunction):
         for i in cls._explore_instances():
             try:
                 ss1_command = cls._get_required_input_output(handler, cls.COMMAND_UID.format(i=i))
-                # time_to_sto =
-                # cls._get_required_parameter(handler, cls.TIME_TO_STO_UID.format(i=i))
+                time_to_sto = cls._get_required_parameter(handler, cls.TIME_TO_STO_UID.format(i=i))
                 yield cls(
                     command=ss1_command,
-                    # time_to_sto=time_to_sto,
+                    time_to_sto=time_to_sto,
                     io=(ss1_command,),
-                    parameters=(),
-                    # parameters=(time_to_sto,),
+                    parameters=(time_to_sto,),
                 )
             except KeyError:  # noqa: PERF203
                 break
@@ -206,8 +204,8 @@ class SOSFunction(SafetyFunction):
     VELOCITY_ZERO_WINDOW_UID = "FSOE_SOS_VEL_ZERO_WINDOW_{i}"
 
     command: "FSoEDictionaryItemInputOutput"
-    # position_zero_window: SafetyParameter
-    # velocity_zero_window: SafetyParameter
+    position_zero_window: SafetyParameter
+    velocity_zero_window: SafetyParameter
 
     @override
     @classmethod
@@ -215,19 +213,18 @@ class SOSFunction(SafetyFunction):
         for i in cls._explore_instances():
             try:
                 command = cls._get_required_input_output(handler, cls.COMMAND_UID.format(i=i))
-                # position_zero_window = cls._get_required_parameter(
-                #    handler, cls.POSITION_ZERO_WINDOW_UID.format(i=i)
-                # )
-                # velocity_zero_window = cls._get_required_parameter(
-                #    handler, cls.VELOCITY_ZERO_WINDOW_UID.format(i=i)
-                # )
+                position_zero_window = cls._get_required_parameter(
+                    handler, cls.POSITION_ZERO_WINDOW_UID.format(i=i)
+                )
+                velocity_zero_window = cls._get_required_parameter(
+                    handler, cls.VELOCITY_ZERO_WINDOW_UID.format(i=i)
+                )
                 yield cls(
                     command=command,
-                    # position_zero_window=position_zero_window,
-                    # velocity_zero_window=velocity_zero_window,
+                    position_zero_window=position_zero_window,
+                    velocity_zero_window=velocity_zero_window,
                     io=(command,),
-                    parameters=(),
-                    # parameters=(position_zero_window, velocity_zero_window),
+                    parameters=(position_zero_window, velocity_zero_window),
                 )
             except KeyError:  # noqa: PERF203
                 break
@@ -244,10 +241,10 @@ class SS2Function(SafetyFunction):
     ERROR_REACTION_UID = "FSOE_SS2_ERROR_REACTION_{i}"
 
     command: "FSoEDictionaryItemInputOutput"
-    # time_to_sos: "SafetyParameter"
-    # deceleration_limit: "SafetyParameter"
-    # time_delay_deceleration_limit: "SafetyParameter"
-    # error_reaction: "SafetyParameter"
+    time_to_sos: "SafetyParameter"
+    deceleration_limit: "SafetyParameter"
+    time_delay_deceleration_limit: "SafetyParameter"
+    error_reaction: "SafetyParameter"
 
     @override
     @classmethod
@@ -255,31 +252,29 @@ class SS2Function(SafetyFunction):
         for i in cls._explore_instances():
             try:
                 command = cls._get_required_input_output(handler, cls.COMMAND_UID.format(i=i))
-                # time_to_sos =
-                # cls._get_required_parameter(handler, cls.TIME_TO_SOS_UID.format(i=i))
-                # deceleration_limit = cls._get_required_parameter(
-                #    handler, cls.DECELERATION_LIMIT_UID.format(i=i)
-                # )
-                # time_delay_deceleration_limit = cls._get_required_parameter(
-                #    handler, cls.TIME_DELAY_DECELERATION_LIMIT_UID.format()
-                # )
-                # error_reaction = cls._get_required_parameter(
-                #    handler, cls.ERROR_REACTION_UID.format(i=i)
-                # )
+                time_to_sos = cls._get_required_parameter(handler, cls.TIME_TO_SOS_UID.format(i=i))
+                deceleration_limit = cls._get_required_parameter(
+                    handler, cls.DECELERATION_LIMIT_UID.format(i=i)
+                )
+                time_delay_deceleration_limit = cls._get_required_parameter(
+                    handler, cls.TIME_DELAY_DECELERATION_LIMIT_UID.format(i=i)
+                )
+                error_reaction = cls._get_required_parameter(
+                    handler, cls.ERROR_REACTION_UID.format(i=i)
+                )
                 yield cls(
                     command=command,
-                    # time_to_sos=time_to_sos,
-                    # deceleration_limit=deceleration_limit,
-                    # time_delay_deceleration_limit=time_delay_deceleration_limit,
-                    # error_reaction=error_reaction,
+                    time_to_sos=time_to_sos,
+                    deceleration_limit=deceleration_limit,
+                    time_delay_deceleration_limit=time_delay_deceleration_limit,
+                    error_reaction=error_reaction,
                     io=(command,),
-                    parameters=(),
-                    # parameters=(
-                    #    time_to_sos,
-                    #    deceleration_limit,
-                    #    time_delay_deceleration_limit,
-                    #    error_reaction,
-                    # ),
+                    parameters=(
+                        time_to_sos,
+                        deceleration_limit,
+                        time_delay_deceleration_limit,
+                        error_reaction,
+                    ),
                 )
             except KeyError:  # noqa: PERF203
                 break
@@ -293,7 +288,7 @@ class SOutFunction(SafetyFunction):
     TIME_DELAY_UID = "FSOE_SBC_BRAKE_TIME_DELAY"
 
     command: FSoEDictionaryItemInputOutput
-    # time_delay: SafetyParameter
+    time_delay: SafetyParameter
 
     @override
     @classmethod
@@ -301,14 +296,13 @@ class SOutFunction(SafetyFunction):
         for _ in cls._explore_instances():
             try:
                 command = cls._get_required_input_output(handler, cls.COMMAND_UID)
-                # time_delay = cls._get_required_parameter(handler, cls.TIME_DELAY_UID)
+                time_delay = cls._get_required_parameter(handler, cls.TIME_DELAY_UID)
 
                 yield cls(
                     command=command,
-                    # time_delay=time_delay,
+                    time_delay=time_delay,
                     io=(command,),
-                    parameters=(),
-                    # parameters=(time_delay,),
+                    parameters=(time_delay,),
                 )
             except KeyError:  # noqa: PERF203
                 break
@@ -322,21 +316,15 @@ class SPFunction(SafetyFunction):
     TOLERANCE_UID = "FSOE_POSITION_TOLERANCE"
 
     value: FSoEDictionaryItemInput
-    # tolerance: SafetyParameter
+    tolerance: SafetyParameter
 
     @classmethod
     @override
     def for_handler(cls, handler: "FSoEMasterHandler") -> Iterator["SPFunction"]:
         try:
             value = cls._get_required_input(handler, cls.ACTUAL_VALUE_UID)
-            # tolerance = cls._get_required_parameter(handler, cls.TOLERANCE_UID)
-            yield cls(
-                value=value,
-                # tolerance=tolerance,
-                io=(value,),
-                parameters=(),
-                # parameters=(tolerance,)
-            )
+            tolerance = cls._get_required_parameter(handler, cls.TOLERANCE_UID)
+            yield cls(value=value, tolerance=tolerance, io=(value,), parameters=(tolerance,))
         except KeyError:  # noqa: PERF203
             return
 
@@ -367,20 +355,16 @@ class SafeHomingFunction(SafetyFunction):
     HOMING_REF_UID = "FSOE_SAFE_HOMING_REFERENCE"
 
     command: FSoEDictionaryItemInputOutput
-    # homing_ref: SafetyParameter
+    homing_ref: SafetyParameter
 
     @classmethod
     @override
     def for_handler(cls, handler: "FSoEMasterHandler") -> Iterator["SafeHomingFunction"]:
         try:
             command = cls._get_required_input_output(handler, cls.COMMAND_UID)
-            # homing_ref = cls._get_required_parameter(handler, cls.HOMING_REF_UID)
+            homing_ref = cls._get_required_parameter(handler, cls.HOMING_REF_UID)
             yield cls(
-                command=command,
-                # homing_ref=homing_ref,
-                io=(command,),
-                parameters=(),
-                # parameters=(homing_ref,)
+                command=command, homing_ref=homing_ref, io=(command,), parameters=(homing_ref,)
             )
         except KeyError:
             return
@@ -395,8 +379,8 @@ class SLSFunction(SafetyFunction):
     ERROR_REACTION_UID = "FSOE_SLS_ERROR_REACTION_{i}"
 
     command: FSoEDictionaryItemInputOutput
-    # speed_limit: SafetyParameter
-    # error_reaction: SafetyParameter
+    speed_limit: SafetyParameter
+    error_reaction: SafetyParameter
 
     @classmethod
     @override
@@ -404,19 +388,18 @@ class SLSFunction(SafetyFunction):
         for i in cls._explore_instances():
             try:
                 command = cls._get_required_input_output(handler, cls.COMMAND_UID.format(i=i))
-                # velocity_limit = cls._get_required_parameter(
-                #    handler, cls.VELOCITY_LIMIT_UID.format(i=i)
-                # )
-                # error_reaction = cls._get_required_parameter(
-                #    handler, cls.ERROR_REACTION_UID.format(i=i)
-                # )
+                velocity_limit = cls._get_required_parameter(
+                    handler, cls.VELOCITY_LIMIT_UID.format(i=i)
+                )
+                error_reaction = cls._get_required_parameter(
+                    handler, cls.ERROR_REACTION_UID.format(i=i)
+                )
                 yield cls(
                     command=command,
-                    # speed_limit=velocity_limit,
-                    # error_reaction=error_reaction,
+                    speed_limit=velocity_limit,
+                    error_reaction=error_reaction,
                     io=(command,),
-                    parameters=(),
-                    # parameters=(velocity_limit, error_reaction),
+                    parameters=(velocity_limit, error_reaction),
                 )
             except KeyError:
                 return
@@ -432,9 +415,9 @@ class SSRFunction(SafetyFunction):
     ERROR_REACTION_UID = "FSOE_SSR_ERROR_REACTION_{i}"
 
     command: FSoEDictionaryItemInputOutput
-    # upper_limit: SafetyParameter
-    # lower_limit: SafetyParameter
-    # error_reaction: SafetyParameter
+    upper_limit: SafetyParameter
+    lower_limit: SafetyParameter
+    error_reaction: SafetyParameter
 
     @classmethod
     @override
@@ -442,21 +425,18 @@ class SSRFunction(SafetyFunction):
         for i in cls._explore_instances():
             try:
                 command = cls._get_required_input_output(handler, cls.COMMAND_UID.format(i=i))
-                # upper_limit =
-                # cls._get_required_parameter(handler, cls.UPPER_LIMIT_UID.format(i=i))
-                # lower_limit =
-                # cls._get_required_parameter(handler, cls.LOWER_LIMIT_UID.format(i=i))
-                # error_reaction = cls._get_required_parameter(
-                # handler, cls.ERROR_REACTION_UID.format(i=i)
-                # )
+                upper_limit = cls._get_required_parameter(handler, cls.UPPER_LIMIT_UID.format(i=i))
+                lower_limit = cls._get_required_parameter(handler, cls.LOWER_LIMIT_UID.format(i=i))
+                error_reaction = cls._get_required_parameter(
+                    handler, cls.ERROR_REACTION_UID.format(i=i)
+                )
                 yield cls(
                     command=command,
-                    # upper_limit=upper_limit,
-                    # lower_limit=lower_limit,
-                    # error_reaction=error_reaction,
+                    upper_limit=upper_limit,
+                    lower_limit=lower_limit,
+                    error_reaction=error_reaction,
                     io=(command,),
-                    parameters=(),
-                    # parameters=(upper_limit, lower_limit, error_reaction),
+                    parameters=(upper_limit, lower_limit, error_reaction),
                 )
             except KeyError:
                 return
@@ -472,9 +452,9 @@ class SLPFunction(SafetyFunction):
     ERROR_REACTION_UID = "FSOE_SLP_ERROR_REACTION_{i}"
 
     command: FSoEDictionaryItemInputOutput
-    # upper_limit: SafetyParameter
-    # lower_limit: SafetyParameter
-    # error_reaction: SafetyParameter
+    upper_limit: SafetyParameter
+    lower_limit: SafetyParameter
+    error_reaction: SafetyParameter
 
     @classmethod
     @override
@@ -482,21 +462,18 @@ class SLPFunction(SafetyFunction):
         for i in cls._explore_instances():
             try:
                 command = cls._get_required_input_output(handler, cls.COMMAND_UID.format(i=i))
-                # upper_limit =
-                # cls._get_required_parameter(handler, cls.UPPER_LIMIT_UID.format(i=i))
-                # lower_limit =
-                # cls._get_required_parameter(handler, cls.LOWER_LIMIT_UID.format(i=i))
-                # error_reaction = cls._get_required_parameter(
-                # handler, cls.ERROR_REACTION_UID.format(i=i)
-                # )
+                upper_limit = cls._get_required_parameter(handler, cls.UPPER_LIMIT_UID.format(i=i))
+                lower_limit = cls._get_required_parameter(handler, cls.LOWER_LIMIT_UID.format(i=i))
+                error_reaction = cls._get_required_parameter(
+                    handler, cls.ERROR_REACTION_UID.format(i=i)
+                )
                 yield cls(
                     command=command,
-                    # upper_limit=upper_limit,
-                    # lower_limit=lower_limit,
-                    # error_reaction=error_reaction,
+                    upper_limit=upper_limit,
+                    lower_limit=lower_limit,
+                    error_reaction=error_reaction,
                     io=(command,),
-                    parameters=(),
-                    # parameters=(upper_limit, lower_limit, error_reaction),
+                    parameters=(upper_limit, lower_limit, error_reaction),
                 )
             except KeyError:
                 return

--- a/ingeniamotion/fsoe_master/safety_functions.py
+++ b/ingeniamotion/fsoe_master/safety_functions.py
@@ -19,7 +19,6 @@ __all__ = [
     "SafeHomingFunction",
     "SafeInputsFunction",
     "SafetyFunction",
-    "SAFunction",
     "SLPFunction",
     "SLSFunction",
     "SOSFunction",
@@ -58,7 +57,6 @@ class SafetyFunction:
         yield from SOutFunction.for_handler(handler)
         yield from SPFunction.for_handler(handler)
         yield from SVFunction.for_handler(handler)
-        yield from SAFunction.for_handler(handler)
         yield from SafeHomingFunction.for_handler(handler)
         yield from SLSFunction.for_handler(handler)
         yield from SSRFunction.for_handler(handler)
@@ -362,24 +360,6 @@ class SVFunction(SafetyFunction):
 
 
 @dataclass()
-class SAFunction(SafetyFunction):
-    """Safe Acceleration Safety Function."""
-
-    ACTUAL_VALUE_UID = "FSOE_SAFE_ACCELERATION"
-
-    value: FSoEDictionaryItemInput
-
-    @classmethod
-    @override
-    def for_handler(cls, handler: "FSoEMasterHandler") -> Iterator["SAFunction"]:
-        try:
-            value = cls._get_required_input(handler, cls.ACTUAL_VALUE_UID)
-            yield cls(value=value, io=(value,), parameters=())
-        except KeyError:
-            return
-
-
-@dataclass()
 class SafeHomingFunction(SafetyFunction):
     """Safe Homing Safety Function."""
 
@@ -446,7 +426,7 @@ class SLSFunction(SafetyFunction):
 class SSRFunction(SafetyFunction):
     """Safe Speed Range Safety Function."""
 
-    COMMAND_UID = "FSOE_SSR_CMD_{i}"
+    COMMAND_UID = "FSOE_SSR_COMMAND_{i}"
     UPPER_LIMIT_UID = "FSOE_SSR_UPPER_LIMIT_{i}"
     LOWER_LIMIT_UID = "FSOE_SSR_LOWER_LIMIT_{i}"
     ERROR_REACTION_UID = "FSOE_SSR_ERROR_REACTION_{i}"

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
         "ifaddr==0.1.7",
     ],
     extras_require={
-        "FSoE": ["fsoe_master==0.1.4+pr72b4"],
+        "FSoE": ["fsoe_master==0.1.4+pr75b2"],
     },
     python_requires=">=3.9",
 )

--- a/tests/dictionaries/__init__.py
+++ b/tests/dictionaries/__init__.py
@@ -7,5 +7,5 @@ SAMPLE_SAFE_PH1_XDFV3_DICTIONARY = (
     __dictionaries_root_path / "den-s-net-e_devf13ab4_v3.xdf"
 ).as_posix()
 SAMPLE_SAFE_PH2_XDFV3_DICTIONARY = (
-    __dictionaries_root_path / "evs-s-net-e_dev354d94_v3.xdf"
+    __dictionaries_root_path / "evs-s-net-e_safety_1.1.0.014_v3.xdf"
 ).as_posix()

--- a/tests/dictionaries/evs-s-net-e_safety_1.1.0.014_v3.xdf
+++ b/tests/dictionaries/evs-s-net-e_safety_1.1.0.014_v3.xdf
@@ -6,29 +6,19 @@
   </Header>
   <Body>
     <Categories>
-      <Category id="OTHERS">
+      <Category id="CIA402">
         <Labels>
-          <Label lang="en_US">Others</Label>
+          <Label lang="en_US">CiA402</Label>
         </Labels>
       </Category>
-      <Category id="IDENTIFICATION">
+      <Category id="COMMUNICATIONS">
         <Labels>
-          <Label lang="en_US">Product Identification</Label>
+          <Label lang="en_US">Communications</Label>
         </Labels>
       </Category>
       <Category id="COMMUTATION">
         <Labels>
           <Label lang="en_US">Commutation</Label>
-        </Labels>
-      </Category>
-      <Category id="PROTECTIONS">
-        <Labels>
-          <Label lang="en_US">Protections</Label>
-        </Labels>
-      </Category>
-      <Category id="INTERNAL">
-        <Labels>
-          <Label lang="en_US">Internal</Label>
         </Labels>
       </Category>
       <Category id="CONTROL">
@@ -41,49 +31,14 @@
           <Label lang="en_US">Feedback</Label>
         </Labels>
       </Category>
-      <Category id="COMMUNICATIONS">
-        <Labels>
-          <Label lang="en_US">Communications</Label>
-        </Labels>
-      </Category>
-      <Category id="MOTOR">
-        <Labels>
-          <Label lang="en_US">Motor and Brake</Label>
-        </Labels>
-      </Category>
-      <Category id="REPORTING">
-        <Labels>
-          <Label lang="en_US">Reporting</Label>
-        </Labels>
-      </Category>
       <Category id="FILTERS">
         <Labels>
           <Label lang="en_US">Filters</Label>
         </Labels>
       </Category>
-      <Category id="PROFILER">
+      <Category id="FSOE">
         <Labels>
-          <Label lang="en_US">Profiler</Label>
-        </Labels>
-      </Category>
-      <Category id="LIMITS">
-        <Labels>
-          <Label lang="en_US">Limits</Label>
-        </Labels>
-      </Category>
-      <Category id="THRESHOLDS">
-        <Labels>
-          <Label lang="en_US">Thresholds</Label>
-        </Labels>
-      </Category>
-      <Category id="TARGET">
-        <Labels>
-          <Label lang="en_US">Targets</Label>
-        </Labels>
-      </Category>
-      <Category id="IN_OUT">
-        <Labels>
-          <Label lang="en_US">Inputs / Outputs</Label>
+          <Label lang="en_US">Functional Safety over Ethercat</Label>
         </Labels>
       </Category>
       <Category id="HOMING">
@@ -91,19 +46,74 @@
           <Label lang="en_US">Homing</Label>
         </Labels>
       </Category>
+      <Category id="IDENTIFICATION">
+        <Labels>
+          <Label lang="en_US">Product Identification</Label>
+        </Labels>
+      </Category>
+      <Category id="INTERNAL">
+        <Labels>
+          <Label lang="en_US">Internal</Label>
+        </Labels>
+      </Category>
+      <Category id="IN_OUT">
+        <Labels>
+          <Label lang="en_US">Inputs / Outputs</Label>
+        </Labels>
+      </Category>
+      <Category id="LIMITS">
+        <Labels>
+          <Label lang="en_US">Limits</Label>
+        </Labels>
+      </Category>
+      <Category id="MDP">
+        <Labels>
+          <Label lang="en_US">Modular device profile</Label>
+        </Labels>
+      </Category>
       <Category id="MONITORING">
         <Labels>
           <Label lang="en_US">Monitoring</Label>
         </Labels>
       </Category>
-      <Category id="CIA402">
+      <Category id="MOTOR">
         <Labels>
-          <Label lang="en_US">CiA402</Label>
+          <Label lang="en_US">Motor and Brake</Label>
+        </Labels>
+      </Category>
+      <Category id="OTHERS">
+        <Labels>
+          <Label lang="en_US">Others</Label>
+        </Labels>
+      </Category>
+      <Category id="PROFILER">
+        <Labels>
+          <Label lang="en_US">Profiler</Label>
+        </Labels>
+      </Category>
+      <Category id="PROTECTIONS">
+        <Labels>
+          <Label lang="en_US">Protections</Label>
+        </Labels>
+      </Category>
+      <Category id="REPORTING">
+        <Labels>
+          <Label lang="en_US">Reporting</Label>
+        </Labels>
+      </Category>
+      <Category id="TARGET">
+        <Labels>
+          <Label lang="en_US">Targets</Label>
+        </Labels>
+      </Category>
+      <Category id="THRESHOLDS">
+        <Labels>
+          <Label lang="en_US">Thresholds</Label>
         </Labels>
       </Category>
     </Categories>
     <Devices>
-      <ETHDevice firmwareVersion="dev354d94" ProductCode="61936641" PartNumber="EVS-S-NET-E" RevisionNumber="327685">
+      <ETHDevice firmwareVersion="safety_1.1.0.014" ProductCode="61936641" PartNumber="EVS-S-NET-E" RevisionNumber="327680">
         <Subnodes>
           <Subnode index="0">Communication</Subnode>
           <Subnode index="1">Motion</Subnode>
@@ -200,22 +210,22 @@
               <Label lang="en_US">Number of axes</Label>
             </Labels>
           </MCBRegister>
-          <MCBRegister address="0x00A1" subnode="0" address_type="NVM" access="rw" dtype="u32" id="COMMS_ETH_IP" units="none" pdo_access="CONFIG" desc="" default="1602a8c0" cat_id="COMMUNICATIONS">
+          <MCBRegister address="0x00A1" subnode="0" address_type="NVM" access="r" dtype="u32" id="COMMS_ETH_IP" units="none" pdo_access="CONFIG" desc="" default="1602a8c0" cat_id="COMMUNICATIONS">
             <Labels>
               <Label lang="en_US">IP address</Label>
             </Labels>
           </MCBRegister>
-          <MCBRegister address="0x00A2" subnode="0" address_type="NVM" access="rw" dtype="u32" id="COMMS_ETH_NET_MASK" units="none" pdo_access="CONFIG" desc="" default="00ffffff" cat_id="COMMUNICATIONS">
+          <MCBRegister address="0x00A2" subnode="0" address_type="NVM" access="r" dtype="u32" id="COMMS_ETH_NET_MASK" units="none" pdo_access="CONFIG" desc="" default="00ffffff" cat_id="COMMUNICATIONS">
             <Labels>
               <Label lang="en_US">Netmask</Label>
             </Labels>
           </MCBRegister>
-          <MCBRegister address="0x00A3" subnode="0" address_type="NVM" access="rw" dtype="u32" id="COMMS_ETH_GW" units="none" pdo_access="CONFIG" desc="" default="0102a8c0" cat_id="COMMUNICATIONS">
+          <MCBRegister address="0x00A3" subnode="0" address_type="NVM" access="r" dtype="u32" id="COMMS_ETH_GW" units="none" pdo_access="CONFIG" desc="" default="0102a8c0" cat_id="COMMUNICATIONS">
             <Labels>
               <Label lang="en_US">Gateway address</Label>
             </Labels>
           </MCBRegister>
-          <MCBRegister address="0x00A4" subnode="0" address_type="NVM" access="rw" dtype="u64" id="COMMS_ETH_MAC" units="none" pdo_access="CONFIG" desc="" default="494e470302010000" cat_id="COMMUNICATIONS">
+          <MCBRegister address="0x00A4" subnode="0" address_type="NVM" access="r" dtype="u64" id="COMMS_ETH_MAC" units="none" pdo_access="CONFIG" desc="" default="010203474e490000" cat_id="COMMUNICATIONS">
             <Labels>
               <Label lang="en_US">MAC address</Label>
             </Labels>
@@ -596,7 +606,7 @@
               <Label lang="en_US">Product code</Label>
             </Labels>
           </MCBRegister>
-          <MCBRegister address="0x06E2" subnode="0" address_type="NVM_NONE" access="r" dtype="u32" id="DRV_ID_REVISION_NUMBER_COCO" units="none" pdo_access="CONFIG" desc="Indicates the revision number of the firmware version on the drive with coco" default="05000500" cat_id="IDENTIFICATION">
+          <MCBRegister address="0x06E2" subnode="0" address_type="NVM_NONE" access="r" dtype="u32" id="DRV_ID_REVISION_NUMBER_COCO" units="none" pdo_access="CONFIG" desc="Indicates the revision number of the firmware version on the drive with coco" default="00000500" cat_id="IDENTIFICATION">
             <Labels>
               <Label lang="en_US">Revision number</Label>
             </Labels>
@@ -3396,12 +3406,12 @@
               <Label lang="en_US">Product code</Label>
             </Labels>
           </MCBRegister>
-          <MCBRegister address="0x06E2" subnode="1" address_type="NVM_NONE" access="r" dtype="u32" id="DRV_ID_REVISION_NUMBER" units="none" pdo_access="CONFIG" desc="Indicates the revision number of the firmware version on the drive" default="05000500" cat_id="IDENTIFICATION" axis="1">
+          <MCBRegister address="0x06E2" subnode="1" address_type="NVM_NONE" access="r" dtype="u32" id="DRV_ID_REVISION_NUMBER" units="none" pdo_access="CONFIG" desc="Indicates the revision number of the firmware version on the drive" default="00000500" cat_id="IDENTIFICATION" axis="1">
             <Labels>
               <Label lang="en_US">Revision number</Label>
             </Labels>
           </MCBRegister>
-          <MCBRegister address="0x06E4" subnode="1" address_type="NVM_NONE" access="r" dtype="str" id="DRV_ID_SOFTWARE_VERSION" units="none" pdo_access="CONFIG" desc="Public software release version" default="646576333534643934" cat_id="IDENTIFICATION" axis="1">
+          <MCBRegister address="0x06E4" subnode="1" address_type="NVM_NONE" access="r" dtype="str" id="DRV_ID_SOFTWARE_VERSION" units="none" pdo_access="CONFIG" desc="Public software release version" default="7361666574795f312e312e302e303134" cat_id="IDENTIFICATION" axis="1">
             <Labels>
               <Label lang="en_US">Software version</Label>
             </Labels>
@@ -3697,7 +3707,7 @@
         <Errors>
           <Error id="0x00003280" affected_module="Power stage" error_type="cyclic">
             <Labels>
-              <Label lang="en_US">STO is active and could have disabled the power stage disabled</Label>
+              <Label lang="en_US">STO is active and could have disabled the power stage</Label>
             </Labels>
           </Error>
           <Error id="0x00002280" affected_module="Power stage" error_type="cyclic">
@@ -4117,7 +4127,7 @@
           </Error>
         </Errors>
       </ETHDevice>
-      <ECATDevice firmwareVersion="dev354d94" ProductCode="61936641" PartNumber="EVS-S-NET-E" RevisionNumber="327685">
+      <ECATDevice firmwareVersion="safety_1.1.0.014" ProductCode="61936641" PartNumber="EVS-S-NET-E" RevisionNumber="327680">
         <CANopenObjects>
           <CANopenObject id="ETG_DRV_ID_DEVICE_TYPE" index="0x1000" datatype="VAR">
             <Labels>
@@ -11137,7 +11147,7 @@
               <Label lang="en_US">Revision number</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u32" id="DRV_ID_REVISION_NUMBER" pdo_access="CONFIG" desc="Indicates the revision number of the firmware version on the drive" units="none" default="05000500" cat_id="IDENTIFICATION" axis="1">
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u32" id="DRV_ID_REVISION_NUMBER" pdo_access="CONFIG" desc="Indicates the revision number of the firmware version on the drive" units="none" default="00000500" cat_id="IDENTIFICATION" axis="1">
                 <Labels>
                   <Label lang="en_US">Revision number</Label>
                 </Labels>
@@ -11149,7 +11159,7 @@
               <Label lang="en_US">Software version</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="str" id="DRV_ID_SOFTWARE_VERSION" pdo_access="CONFIG" desc="Public software release version" units="none" default="646576333534643934" cat_id="IDENTIFICATION" axis="1">
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="str" id="DRV_ID_SOFTWARE_VERSION" pdo_access="CONFIG" desc="Public software release version" units="none" default="7361666574795f312e312e302e303134" cat_id="IDENTIFICATION" axis="1">
                 <Labels>
                   <Label lang="en_US">Software version</Label>
                 </Labels>
@@ -12070,6 +12080,30 @@
               </Subitem>
             </Subitems>
           </CANopenObject>
+          <CANopenObject id="FSOE_SAFE_HOMING" index="0x46F1" datatype="VAR" axis="1">
+            <Labels>
+              <Label lang="en_US">Safe Homing</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SAFE_HOMING" pdo_access="CYCLIC_SISO" desc="" units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">Safe Homing</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SAFE_HOMING_REFERENCE" index="0x46F2" datatype="VAR" axis="1">
+            <Labels>
+              <Label lang="en_US">Safe Homing Reference</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SAFE_HOMING_REFERENCE" pdo_access="CONFIG" desc="" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">Safe Homing Reference</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
           <CANopenObject id="FSOE_FEEDBACK_SCENARIO" index="0x46FA" datatype="VAR" axis="1">
             <Labels>
               <Label lang="en_US">Feedback scenario</Label>
@@ -12091,6 +12125,30 @@
                 <Labels>
                   <Label lang="en_US">Position tolerance</Label>
                 </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_FEEDBACK_RATIO" index="0x46FC" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">Redundant to main feedback ratio</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_FEEDBACK_RATIO" pdo_access="CONFIG" desc="" units="none" default="02" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u16" id="FSOE_FEEDBACK_RATIO_REDUNDANT_TURNS" pdo_access="CONFIG" desc="Number of redundant feedback turns (motor-side) per gear ratio cycle" units="none" default="0100" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">Redundant feedback turns</Label>
+                </Labels>
+                <Range min="1" max="65535"/>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="rw" dtype="u16" id="FSOE_FEEDBACK_RATIO_MAIN_TURNS" pdo_access="CONFIG" desc="Number of main feedback turns (output-side) per gear ratio cycle" units="none" default="0100" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">Main feedback turns</Label>
+                </Labels>
+                <Range min="1" max="65535"/>
               </Subitem>
             </Subitems>
           </CANopenObject>
@@ -12339,7 +12397,7 @@
               <Label lang="en_US">Safety core digital hall feedback - Position</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="FSOE_HALL_POSITION" pdo_access="CONFIG" desc="displays the actual position of the hall feedback read by the safety core" units="none" default="00000000" cat_id="FSOE" axis="1">
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="FSOE_HALL_POSITION" pdo_access="CONFIG" desc="Actual position of the hall feedback read by the safety core" units="none" default="00000000" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">Safety core digital hall feedback - Position</Label>
                 </Labels>
@@ -12351,7 +12409,7 @@
               <Label lang="en_US">Safety core digital hall feedback - Status</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="FSOE_HALL_STATUS" pdo_access="CONFIG" desc="displays the actual position of the hall feedback read by the safety core" units="none" default="0000" cat_id="FSOE" axis="1">
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="FSOE_HALL_STATUS" pdo_access="CONFIG" desc="Status of the hall feedback read by the safety core" units="none" default="0000" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">Safety core digital hall feedback - Status</Label>
                 </Labels>
@@ -12360,12 +12418,12 @@
           </CANopenObject>
           <CANopenObject id="FSOE_HALL_POLEPAIRS" index="0x4732" datatype="VAR" axis="1">
             <Labels>
-              <Label lang="en_US">Safety core digital hall feedback - Polepairs</Label>
+              <Label lang="en_US">Safety core digital hall feedback - Pole pairs</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="u16" id="FSOE_HALL_POLEPAIRS" pdo_access="CONFIG" desc="number of pole pairs - typically equal to number of motor pole pairs" units="none" default="0100" cat_id="FSOE" axis="1">
+              <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="u16" id="FSOE_HALL_POLEPAIRS" pdo_access="CONFIG" desc="Number of pole pairs of the hall feedback - typically equal to number of motor pole pairs" units="none" default="0100" cat_id="FSOE" axis="1">
                 <Labels>
-                  <Label lang="en_US">Safety core digital hall feedback - Polepairs</Label>
+                  <Label lang="en_US">Safety core digital hall feedback - Pole pairs</Label>
                 </Labels>
                 <Range min="1" max="65535"/>
               </Subitem>
@@ -12376,7 +12434,7 @@
               <Label lang="en_US">Safety core digital hall feedback - Polarity</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="u16" id="FSOE_HALL_POLARITY" pdo_access="CONFIG" desc="number of pole pairs - typically equal to number of motor pole pairs" units="none" default="0000" cat_id="FSOE" axis="1">
+              <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="u16" id="FSOE_HALL_POLARITY" pdo_access="CONFIG" desc="Polarity of the hall feedback" units="none" default="0000" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">Safety core digital hall feedback - Polarity</Label>
                 </Labels>
@@ -12609,7 +12667,7 @@
               <Label lang="en_US">IP address</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM" access="rw" dtype="u32" id="COMMS_ETH_IP" pdo_access="CONFIG" desc="" units="none" default="1602a8c0" cat_id="COMMUNICATIONS">
+              <Subitem subindex="0" address_type="NVM" access="r" dtype="u32" id="COMMS_ETH_IP" pdo_access="CONFIG" desc="" units="none" default="1602a8c0" cat_id="COMMUNICATIONS">
                 <Labels>
                   <Label lang="en_US">IP address</Label>
                 </Labels>
@@ -12621,7 +12679,7 @@
               <Label lang="en_US">Netmask</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM" access="rw" dtype="u32" id="COMMS_ETH_NET_MASK" pdo_access="CONFIG" desc="" units="none" default="00ffffff" cat_id="COMMUNICATIONS">
+              <Subitem subindex="0" address_type="NVM" access="r" dtype="u32" id="COMMS_ETH_NET_MASK" pdo_access="CONFIG" desc="" units="none" default="00ffffff" cat_id="COMMUNICATIONS">
                 <Labels>
                   <Label lang="en_US">Netmask</Label>
                 </Labels>
@@ -12633,7 +12691,7 @@
               <Label lang="en_US">Gateway address</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM" access="rw" dtype="u32" id="COMMS_ETH_GW" pdo_access="CONFIG" desc="" units="none" default="0102a8c0" cat_id="COMMUNICATIONS">
+              <Subitem subindex="0" address_type="NVM" access="r" dtype="u32" id="COMMS_ETH_GW" pdo_access="CONFIG" desc="" units="none" default="0102a8c0" cat_id="COMMUNICATIONS">
                 <Labels>
                   <Label lang="en_US">Gateway address</Label>
                 </Labels>
@@ -12645,7 +12703,7 @@
               <Label lang="en_US">MAC address</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM" access="rw" dtype="u64" id="COMMS_ETH_MAC" pdo_access="CONFIG" desc="" units="none" default="494e470302010000" cat_id="COMMUNICATIONS">
+              <Subitem subindex="0" address_type="NVM" access="r" dtype="u64" id="COMMS_ETH_MAC" pdo_access="CONFIG" desc="" units="none" default="010203474e490000" cat_id="COMMUNICATIONS">
                 <Labels>
                   <Label lang="en_US">MAC address</Label>
                 </Labels>
@@ -13505,7 +13563,7 @@
               <Label lang="en_US">Revision number</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u32" id="DRV_ID_REVISION_NUMBER_COCO" pdo_access="CONFIG" desc="Indicates the revision number of the firmware version on the drive with coco" units="none" default="05000500" cat_id="IDENTIFICATION">
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u32" id="DRV_ID_REVISION_NUMBER_COCO" pdo_access="CONFIG" desc="Indicates the revision number of the firmware version on the drive with coco" units="none" default="00000500" cat_id="IDENTIFICATION">
                 <Labels>
                   <Label lang="en_US">Revision number</Label>
                 </Labels>
@@ -13954,7 +14012,7 @@
               <Label lang="en_US">Velocity offset</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="s32" id="DS402_CL_VEL_CMD_OFFSET" pdo_access="CYCLIC_RX" desc="User input offset added at the input of the velocity PID controller" units="rev/s" default="00000000" cat_id="CIA402" axis="1">
+              <Subitem subindex="0" address_type="NVM_INDIRECT" access="rw" dtype="s32" id="DS402_CL_VEL_CMD_OFFSET" pdo_access="CYCLIC_RX" desc="User input offset added at the input of the velocity PID controller" units="rev/s" default="00000000" cat_id="CIA402" axis="1">
                 <Labels>
                   <Label lang="en_US">Velocity offset</Label>
                 </Labels>
@@ -13983,12 +14041,12 @@
                   <Label lang="en_US">Subindex 000</Label>
                 </Labels>
               </Subitem>
-              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u8" id="DS402_PROF_IP_TIME_MANTISSA" pdo_access="CYCLIC_RX" desc="It is used to indicate the interpolation time period between set-point values (mantissa value)." units="none" default="01" cat_id="CIA402" axis="1">
+              <Subitem subindex="1" address_type="NVM_INDIRECT" access="rw" dtype="u8" id="DS402_PROF_IP_TIME_MANTISSA" pdo_access="CYCLIC_RX" desc="It is used to indicate the interpolation time period between set-point values (mantissa value)." units="none" default="01" cat_id="CIA402" axis="1">
                 <Labels>
                   <Label lang="en_US">Interpolation time period value</Label>
                 </Labels>
               </Subitem>
-              <Subitem subindex="2" address_type="NVM_NONE" access="rw" dtype="s8" id="DS402_PROF_IP_TIME_EXP" pdo_access="CYCLIC_RX" desc="It is used to indicate the interpolation time period between set-point values (exponent value)." units="none" default="fd" cat_id="CIA402" axis="1">
+              <Subitem subindex="2" address_type="NVM_INDIRECT" access="rw" dtype="s8" id="DS402_PROF_IP_TIME_EXP" pdo_access="CYCLIC_RX" desc="It is used to indicate the interpolation time period between set-point values (exponent value)." units="none" default="fd" cat_id="CIA402" axis="1">
                 <Labels>
                   <Label lang="en_US">Interpolation time index</Label>
                 </Labels>
@@ -14082,18 +14140,6 @@
               </Subitem>
             </Subitems>
           </CANopenObject>
-          <CANopenObject id="FSOE_ACCELERATION_UNIT" index="0x6603" datatype="VAR" axis="1">
-            <Labels>
-              <Label lang="en_US">Acceleration unit</Label>
-            </Labels>
-            <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u32" id="FSOE_ACCELERATION_UNIT" pdo_access="CONFIG" desc="Unit definition for Acceleration and Deceleration parameter" units="none" default="0057b4fd" cat_id="FSOE" axis="1">
-                <Labels>
-                  <Label lang="en_US">Acceleration unit</Label>
-                </Labels>
-              </Subitem>
-            </Subitems>
-          </CANopenObject>
           <CANopenObject id="FSOE_SAFE_POSITION" index="0x6611" datatype="VAR" axis="1">
             <Labels>
               <Label lang="en_US">Safe Position Actual Value</Label>
@@ -14114,18 +14160,6 @@
               <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="FSOE_SAFE_VELOCITY" pdo_access="CYCLIC_SI" desc="Actual value of Safe Velocity" units="mrev/s" default="00000000" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">Safe Velocity Actual Value</Label>
-                </Labels>
-              </Subitem>
-            </Subitems>
-          </CANopenObject>
-          <CANopenObject id="FSOE_SAFE_ACCELERATION" index="0x6615" datatype="VAR" axis="1">
-            <Labels>
-              <Label lang="en_US">Safe Acceleration Actual Value</Label>
-            </Labels>
-            <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="FSOE_SAFE_ACCELERATION" pdo_access="CYCLIC_SI" desc="Actual value of Safe Acceleration" units="mrev/s2" default="00000000" cat_id="FSOE" axis="1">
-                <Labels>
-                  <Label lang="en_US">Safe Acceleration Actual Value</Label>
                 </Labels>
               </Subitem>
             </Subitems>
@@ -14172,6 +14206,74 @@
               <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u16" id="FSOE_SS1_TIME_TO_STO_1" pdo_access="CONFIG" desc="Time that will take a SS1 function to transition to STO" units="none" default="0000" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">SS1 Time to STO</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SS1_VEL_ZERO" index="0x6653" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SS1 Velocity zero window</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SS1_VEL_ZERO_WINDOW_TOTAL" pdo_access="CONFIG" desc="" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SS1_VEL_ZERO_WINDOW_1" pdo_access="CONFIG" desc="Velocity window for Safe Stop 1 instance 1." units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SS1 Velocity zero window</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SS1_TIME_FOR_VEL_ZERO" index="0x6654" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SS1 Time for velocity zero</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SS1_TIME_FOR_VEL_ZERO_TOTAL" pdo_access="CONFIG" desc="" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u16" id="FSOE_SS1_TIME_FOR_VEL_ZERO_1" pdo_access="CONFIG" desc="Time required to be within the velocity zero window before transitioning to STO for SS1 instance 1" units="none" default="0000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SS1 Time for velocity zero</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SS1_DEC_LIMIT" index="0x6656" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SS1 Deceleration limit</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SS1_DEC_LIMIT_TOTAL" pdo_access="CONFIG" desc="" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SS1_DEC_LIMIT_1" pdo_access="CONFIG" desc="Deceleration limit for Safe Stop 1 instance 1." units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SS1 Deceleration limit</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SS1_TIME_DELAY_DEC" index="0x6657" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SS1 Time delay deceleration monitoring</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SS1_TIME_DELAY_DEC_TOTAL" pdo_access="CONFIG" desc="" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u16" id="FSOE_SS1_TIME_DELAY_DEC_1" pdo_access="CONFIG" desc="Time delay before deceleration mointoring is started for Safe Stop 1 instance 1" units="none" default="0000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SS1 Time delay for deceleration monitoring</Label>
                 </Labels>
               </Subitem>
             </Subitems>
@@ -14326,6 +14428,658 @@
                 <Labels>
                   <Label lang="en_US">SS2 Error reaction</Label>
                 </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SSR_COMMAND" index="0x6680" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SSR Command</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SSR_COMMAND_TOTAL" pdo_access="CONFIG" desc="" units="none" default="08" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SSR_COMMAND_1" pdo_access="CYCLIC_SISO" desc="SSR-1 Command" units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-1 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SSR_COMMAND_2" pdo_access="CYCLIC_SISO" desc="SSR-2 Command" units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-2 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="3" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SSR_COMMAND_3" pdo_access="CYCLIC_SISO" desc="SSR-3 Command" units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-3 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="4" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SSR_COMMAND_4" pdo_access="CYCLIC_SISO" desc="SSR-4 Command" units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-4 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="5" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SSR_COMMAND_5" pdo_access="CYCLIC_SISO" desc="SSR-5 Command" units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-5 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="6" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SSR_COMMAND_6" pdo_access="CYCLIC_SISO" desc="SSR-6 Command" units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-6 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="7" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SSR_COMMAND_7" pdo_access="CYCLIC_SISO" desc="SSR-7 Command" units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-7 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="8" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SSR_COMMAND_8" pdo_access="CYCLIC_SISO" desc="SSR-8 Command" units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-8 Command</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SSR_UPPER_LIMIT" index="0x6683" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SSR Velocity Upper Limit</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SSR_UPPER_LIMIT_TOTAL" pdo_access="CONFIG" desc="" units="none" default="08" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_UPPER_LIMIT_1" pdo_access="CONFIG" desc="Maximum allowed velocity while SSR-1 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-1 Velocity Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_UPPER_LIMIT_2" pdo_access="CONFIG" desc="Maximum allowed velocity while SSR-2 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-2 Velocity Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="3" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_UPPER_LIMIT_3" pdo_access="CONFIG" desc="Maximum allowed velocity while SSR-3 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-3 Velocity Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="4" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_UPPER_LIMIT_4" pdo_access="CONFIG" desc="Maximum allowed velocity while SSR-4 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-4 Velocity Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="5" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_UPPER_LIMIT_5" pdo_access="CONFIG" desc="Maximum allowed velocity while SSR-5 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-5 Velocity Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="6" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_UPPER_LIMIT_6" pdo_access="CONFIG" desc="Maximum allowed velocity while SSR-6 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-6 Velocity Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="7" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_UPPER_LIMIT_7" pdo_access="CONFIG" desc="Maximum allowed velocity while SSR-7 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-7 Velocity Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="8" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_UPPER_LIMIT_8" pdo_access="CONFIG" desc="Maximum allowed velocity while SSR-8 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-8 Velocity Upper Limit</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SSR_LOWER_LIMIT" index="0x6685" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SSR Velocity Lower Limit</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SSR_LOWER_LIMIT_TOTAL" pdo_access="CONFIG" desc="" units="none" default="08" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_LOWER_LIMIT_1" pdo_access="CONFIG" desc="Minimum allowed velocity while SSR-1 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-1 Velocity Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_LOWER_LIMIT_2" pdo_access="CONFIG" desc="Minimum allowed velocity while SSR-2 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-2 Velocity Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="3" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_LOWER_LIMIT_3" pdo_access="CONFIG" desc="Minimum allowed velocity while SSR-3 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-3 Velocity Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="4" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_LOWER_LIMIT_4" pdo_access="CONFIG" desc="Minimum allowed velocity while SSR-4 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-4 Velocity Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="5" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_LOWER_LIMIT_5" pdo_access="CONFIG" desc="Minimum allowed velocity while SSR-5 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-5 Velocity Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="6" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_LOWER_LIMIT_6" pdo_access="CONFIG" desc="Minimum allowed velocity while SSR-6 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-6 Velocity Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="7" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_LOWER_LIMIT_7" pdo_access="CONFIG" desc="Minimum allowed velocity while SSR-7 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-7 Velocity Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="8" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SSR_LOWER_LIMIT_8" pdo_access="CONFIG" desc="Minimum allowed velocity while SSR-8 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-8 Velocity Lower Limit</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SSR_ERROR_REACTION" index="0x668A" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SSR Error Reaction</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SSR_ERROR_REACTION_TOTAL" pdo_access="CONFIG" desc="" units="none" default="08" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SSR_ERROR_REACTION_1" pdo_access="CONFIG" desc="Error reaction to a violation of SSR-1 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-1 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SSR_ERROR_REACTION_2" pdo_access="CONFIG" desc="Error reaction to a violation of SSR-2 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-2 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="3" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SSR_ERROR_REACTION_3" pdo_access="CONFIG" desc="Error reaction to a violation of SSR-3 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-3 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="4" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SSR_ERROR_REACTION_4" pdo_access="CONFIG" desc="Error reaction to a violation of SSR-4 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-4 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="5" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SSR_ERROR_REACTION_5" pdo_access="CONFIG" desc="Error reaction to a violation of SSR-5 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-5 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="6" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SSR_ERROR_REACTION_6" pdo_access="CONFIG" desc="Error reaction to a violation of SSR-6 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-6 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="7" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SSR_ERROR_REACTION_7" pdo_access="CONFIG" desc="Error reaction to a violation of SSR-7 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-7 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="8" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SSR_ERROR_REACTION_8" pdo_access="CONFIG" desc="Error reaction to a violation of SSR-8 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SSR-8 Error Reaction</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SLS_CMD" index="0x6690" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SLS Command</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SLS_CMD_TOTAL" pdo_access="CONFIG" desc="" units="none" default="08" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">Subindex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLS_CMD_1" pdo_access="CYCLIC_SISO" desc="SLS-1 Command" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-1 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLS_CMD_2" pdo_access="CYCLIC_SISO" desc="SLS-2 Command" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-2 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="3" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLS_CMD_3" pdo_access="CYCLIC_SISO" desc="SLS-3 Command" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-3 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="4" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLS_CMD_4" pdo_access="CYCLIC_SISO" desc="SLS-4 Command" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-4 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="5" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLS_CMD_5" pdo_access="CYCLIC_SISO" desc="SLS-5 Command" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-5 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="6" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLS_CMD_6" pdo_access="CYCLIC_SISO" desc="SLS-6 Command" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-6 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="7" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLS_CMD_7" pdo_access="CYCLIC_SISO" desc="SLS-7 Command" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-7 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="8" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLS_CMD_8" pdo_access="CYCLIC_SISO" desc="SLS-8 Command" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-8 Command</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SLS_VELOCITY_LIMIT" index="0x6693" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SLS Velocity Limit</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SLS_VELOCITY_LIMIT_TOTAL" pdo_access="CONFIG" desc="" units="none" default="08" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">Subindex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLS_VELOCITY_LIMIT_1" pdo_access="CONFIG" desc="Maximum velocity while SLS-1 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-1 Velocity Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLS_VELOCITY_LIMIT_2" pdo_access="CONFIG" desc="Maximum velocity while SLS-2 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-2 Velocity Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="3" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLS_VELOCITY_LIMIT_3" pdo_access="CONFIG" desc="Maximum velocity while SLS-3 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-3 Velocity Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="4" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLS_VELOCITY_LIMIT_4" pdo_access="CONFIG" desc="Maximum velocity while SLS-4 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-4 Velocity Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="5" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLS_VELOCITY_LIMIT_5" pdo_access="CONFIG" desc="Maximum velocity while SLS-5 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-5 Velocity Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="6" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLS_VELOCITY_LIMIT_6" pdo_access="CONFIG" desc="Maximum velocity while SLS-6 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-6 Velocity Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="7" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLS_VELOCITY_LIMIT_7" pdo_access="CONFIG" desc="Maximum velocity while SLS-7 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-7 Velocity Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="8" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLS_VELOCITY_LIMIT_8" pdo_access="CONFIG" desc="Maximum velocity while SLS-8 is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-8 Velocity Limit</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SLS_ERROR_REACTION" index="0x6698" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SLS Error Reaction</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SLS_ERROR_REACTION_TOTAL" pdo_access="CONFIG" desc="" units="none" default="08" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">Subindex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLS_ERROR_REACTION_1" pdo_access="CONFIG" desc="Error reaction to a violation of SLS-1 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-1 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLS_ERROR_REACTION_2" pdo_access="CONFIG" desc="Error reaction to a violation of SLS-2 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-2 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="3" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLS_ERROR_REACTION_3" pdo_access="CONFIG" desc="Error reaction to a violation of SLS-3 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-3 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="4" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLS_ERROR_REACTION_4" pdo_access="CONFIG" desc="Error reaction to a violation of SLS-4 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-4 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="5" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLS_ERROR_REACTION_5" pdo_access="CONFIG" desc="Error reaction to a violation of SLS-5 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-5 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="6" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLS_ERROR_REACTION_6" pdo_access="CONFIG" desc="Error reaction to a violation of SLS-6 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-6 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="7" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLS_ERROR_REACTION_7" pdo_access="CONFIG" desc="Error reaction to a violation of SLS-7 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-7 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+              <Subitem subindex="8" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLS_ERROR_REACTION_8" pdo_access="CONFIG" desc="Error reaction to a violation of SLS-8 limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLS-8 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SLP_COMMAND" index="0x66A0" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SLP Command</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SLP_COMMAND_TOTAL" pdo_access="CONFIG" desc="" units="none" default="08" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLP_COMMAND_1" pdo_access="CYCLIC_SISO" desc="Safely-Limited Position command for instance 1" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 1 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLP_COMMAND_2" pdo_access="CYCLIC_SISO" desc="Safely-Limited Position command for instance 2" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 2 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="3" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLP_COMMAND_3" pdo_access="CYCLIC_SISO" desc="Safely-Limited Position command for instance 3" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 3 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="4" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLP_COMMAND_4" pdo_access="CYCLIC_SISO" desc="Safely-Limited Position command for instance 4" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 4 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="5" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLP_COMMAND_5" pdo_access="CYCLIC_SISO" desc="Safely-Limited Position command for instance 5" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 5 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="6" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLP_COMMAND_6" pdo_access="CYCLIC_SISO" desc="Safely-Limited Position command for instance 6" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 6 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="7" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLP_COMMAND_7" pdo_access="CYCLIC_SISO" desc="Safely-Limited Position command for instance 7" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 7 Command</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="8" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLP_COMMAND_8" pdo_access="CYCLIC_SISO" desc="Safely-Limited Position command for instance 8" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 8 Command</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SLP_UPPER_LIMIT" index="0x66A2" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SLP Position Upper Limit</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SLP_UPPER_LIMIT_TOTAL" pdo_access="CONFIG" desc="" units="none" default="08" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_UPPER_LIMIT_1" pdo_access="CONFIG" desc="Safely-Limited Position upper limit for instance 1" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 1 Position Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_UPPER_LIMIT_2" pdo_access="CONFIG" desc="Safely-Limited Position upper limit for instance 2" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 2 Position Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="3" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_UPPER_LIMIT_3" pdo_access="CONFIG" desc="Safely-Limited Position upper limit for instance 3" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 3 Position Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="4" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_UPPER_LIMIT_4" pdo_access="CONFIG" desc="Safely-Limited Position upper limit for instance 4" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 4 Position Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="5" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_UPPER_LIMIT_5" pdo_access="CONFIG" desc="Safely-Limited Position upper limit for instance 5" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 5 Position Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="6" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_UPPER_LIMIT_6" pdo_access="CONFIG" desc="Safely-Limited Position upper limit for instance 6" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 6 Position Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="7" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_UPPER_LIMIT_7" pdo_access="CONFIG" desc="Safely-Limited Position upper limit for instance 7" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 7 Position Upper Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="8" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_UPPER_LIMIT_8" pdo_access="CONFIG" desc="Safely-Limited Position upper limit for instance 8" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 8 Position Upper Limit</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SLP_LOWER_LIMIT" index="0x66A4" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SLP Position Lower Limit</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SLP_LOWER_LIMIT_TOTAL" pdo_access="CONFIG" desc="" units="none" default="08" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_LOWER_LIMIT_1" pdo_access="CONFIG" desc="Safely-Limited Position lower limit for instance 1" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 1 Position Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_LOWER_LIMIT_2" pdo_access="CONFIG" desc="Safely-Limited Position lower limit for instance 2" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 2 Position Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="3" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_LOWER_LIMIT_3" pdo_access="CONFIG" desc="Safely-Limited Position lower limit for instance 3" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 3 Position Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="4" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_LOWER_LIMIT_4" pdo_access="CONFIG" desc="Safely-Limited Position lower limit for instance 4" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 4 Position Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="5" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_LOWER_LIMIT_5" pdo_access="CONFIG" desc="Safely-Limited Position lower limit for instance 5" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 5 Position Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="6" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_LOWER_LIMIT_6" pdo_access="CONFIG" desc="Safely-Limited Position lower limit for instance 6" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 6 Position Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="7" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_LOWER_LIMIT_7" pdo_access="CONFIG" desc="Safely-Limited Position lower limit for instance 7" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 7 Position Lower Limit</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="8" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLP_LOWER_LIMIT_8" pdo_access="CONFIG" desc="Safely-Limited Position lower limit for instance 8" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 8 Position Lower Limit</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SLP_ERROR_REACTION" index="0x66A5" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SLP Error Reaction</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SLP_ERROR_REACTION_TOTAL" pdo_access="CONFIG" desc="" units="none" default="08" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_1" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 1" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 1 Error Reaction</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="2" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_2" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 2" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 2 Error Reaction</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="3" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_3" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 3" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 3 Error Reaction</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="4" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_4" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 4" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 4 Error Reaction</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="5" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_5" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 5" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 5 Error Reaction</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="6" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_6" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 6" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 6 Error Reaction</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="7" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_7" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 7" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 7 Error Reaction</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="8" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_8" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 8" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLP 8 Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
               </Subitem>
             </Subitems>
           </CANopenObject>
@@ -14593,7 +15347,7 @@
         <Errors>
           <Error id="0x00003280" affected_module="Power stage" error_type="cyclic">
             <Labels>
-              <Label lang="en_US">STO is active and could have disabled the power stage disabled</Label>
+              <Label lang="en_US">STO is active and could have disabled the power stage</Label>
             </Labels>
           </Error>
           <Error id="0x00002280" affected_module="Power stage" error_type="cyclic">
@@ -15015,8 +15769,104 @@
         <SafetyModules>
           <SafetyModule uses_sra="false" module_ident="0x3b00000">
             <ApplicationParameters>
-              <ApplicationParameter id="FSOE_SAFE_INPUTS_MAP"/>
               <ApplicationParameter id="FSOE_SS1_TIME_TO_STO_1"/>
+              <ApplicationParameter id="FSOE_SS1_VEL_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SS1_TIME_FOR_VEL_ZERO_1"/>
+              <ApplicationParameter id="FSOE_SS1_DEC_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SS1_TIME_DELAY_DEC_1"/>
+              <ApplicationParameter id="FSOE_SOS_POS_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SOS_VEL_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_TO_SOS_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_FOR_VEL_ZERO_1"/>
+              <ApplicationParameter id="FSOE_SS2_DEC_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_DELAY_DEC_1"/>
+              <ApplicationParameter id="FSOE_SS2_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SAFE_INPUTS_MAP"/>
+              <ApplicationParameter id="FSOE_SAFE_HOMING_REFERENCE"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_SCENARIO"/>
+              <ApplicationParameter id="FSOE_POSITION_TOLERANCE"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_REDUNDANT_TURNS"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_MAIN_TURNS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_FSIZE"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POL"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POSBITS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_STURN"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_BAUD"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_TOUT"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_FSIZE"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_POL"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_PBITS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_STURN"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_BAUD"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_TOUT"/>
+              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_RESOLUTION"/>
+              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_POLARITY"/>
+              <ApplicationParameter id="FSOE_HALL_POLEPAIRS"/>
+              <ApplicationParameter id="FSOE_HALL_POLARITY"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_TOTAL"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_1"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_2"/>
@@ -15118,8 +15968,104 @@
           </SafetyModule>
           <SafetyModule uses_sra="true" module_ident="0x3b00001">
             <ApplicationParameters>
-              <ApplicationParameter id="FSOE_SAFE_INPUTS_MAP"/>
               <ApplicationParameter id="FSOE_SS1_TIME_TO_STO_1"/>
+              <ApplicationParameter id="FSOE_SS1_VEL_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SS1_TIME_FOR_VEL_ZERO_1"/>
+              <ApplicationParameter id="FSOE_SS1_DEC_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SS1_TIME_DELAY_DEC_1"/>
+              <ApplicationParameter id="FSOE_SOS_POS_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SOS_VEL_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_TO_SOS_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_FOR_VEL_ZERO_1"/>
+              <ApplicationParameter id="FSOE_SS2_DEC_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_DELAY_DEC_1"/>
+              <ApplicationParameter id="FSOE_SS2_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SAFE_INPUTS_MAP"/>
+              <ApplicationParameter id="FSOE_SAFE_HOMING_REFERENCE"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_SCENARIO"/>
+              <ApplicationParameter id="FSOE_POSITION_TOLERANCE"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_REDUNDANT_TURNS"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_MAIN_TURNS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_FSIZE"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POL"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POSBITS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_STURN"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_BAUD"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_TOUT"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_FSIZE"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_POL"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_PBITS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_STURN"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_BAUD"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_TOUT"/>
+              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_RESOLUTION"/>
+              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_POLARITY"/>
+              <ApplicationParameter id="FSOE_HALL_POLEPAIRS"/>
+              <ApplicationParameter id="FSOE_HALL_POLARITY"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_TOTAL"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_1"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_2"/>

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -55,10 +55,10 @@ ECAT_DEN_S_PHASE2_SETUP = RackServiceConfigSpecifier.from_firmware(
     interface=Interface.ECAT,
     config_file=None,
     firmware=Path(
-        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_2.8.0.lfu"
+        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.13/den-s-net-e_2.8.0.lfu"
     ),
     dictionary=Path(
-        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.4/den-s-net-e_safety_1.1.0.004_v3.xdf"
+        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/safety_1.1.0.13/den-s-net-e_safety_1.1.0.013_v3.xdf"
     ),
 )
 

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -544,7 +544,7 @@ def mc_state_data_with_sra(mc_with_fsoe_with_sra):
 
     mc.fsoe.configure_pdos(start_pdos=True)
     # Wait for the master to reach the Data state
-    mc.fsoe.wait_for_state_data(timeout=300)
+    mc.fsoe.wait_for_state_data(timeout=3)
 
     # Remove fail-safe state
     mc.fsoe.set_fail_safe(False)
@@ -561,7 +561,7 @@ def mc_state_data(mc_with_fsoe):
 
     mc.fsoe.configure_pdos(start_pdos=True)
     # Wait for the master to reach the Data state
-    mc.fsoe.wait_for_state_data(timeout=300)
+    mc.fsoe.wait_for_state_data(timeout=20)
 
     # Remove fail-safe state
     mc.fsoe.set_fail_safe(False)
@@ -591,7 +591,7 @@ def test_start_and_stop_multiple_times(mc_with_fsoe):
 
     for i in range(4):
         mc.fsoe.configure_pdos(start_pdos=True)
-        mc.fsoe.wait_for_state_data(timeout=300)
+        mc.fsoe.wait_for_state_data(timeout=20)
         assert handler.state == FSoEState.DATA
         time.sleep(1)
         assert handler.state == FSoEState.DATA

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -108,6 +108,7 @@ def mc_with_fsoe(mc, fsoe_states):
     # https://novantamotion.atlassian.net/browse/INGM-624
     mc.fsoe._delete_master_handler()
     # Ensure the PDOs are stopped
+    # https://novantamotion.atlassian.net/browse/CIT-494
     if mc.capture.pdo.is_active:
         mc.capture.pdo.stop_pdos()
 

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -26,13 +26,16 @@ if FSOE_MASTER_INSTALLED:
     from ingeniamotion.fsoe_master import (
         FSoEMasterHandler,
         PDUMaps,
+        SafeHomingFunction,
         SafeInputsFunction,
         SafetyFunction,
-        SAFunction,
+        SLPFunction,
+        SLSFunction,
         SOSFunction,
         SPFunction,
         SS1Function,
         SS2Function,
+        SSRFunction,
         STOFunction,
         SVFunction,
     )
@@ -374,11 +377,34 @@ def test_detect_safety_functions_ph2():
         # SOutFunction, Not implemented yet
         SPFunction,
         SVFunction,
-        SAFunction,
-        # SafeHomingFunction, Not Implemented yet
-        # SLSFunction,  Not Implemented yet
-        # SSRFunction,  Not Implemented yet
-        # SLPFunction, Not Implemented yet
+        SafeHomingFunction,
+        # SLS
+        SLSFunction,
+        SLSFunction,
+        SLSFunction,
+        SLSFunction,
+        SLSFunction,
+        SLSFunction,
+        SLSFunction,
+        SLSFunction,
+        # SSR
+        SSRFunction,
+        SSRFunction,
+        SSRFunction,
+        SSRFunction,
+        SSRFunction,
+        SSRFunction,
+        SSRFunction,
+        SSRFunction,
+        # SLP
+        SLPFunction,
+        SLPFunction,
+        SLPFunction,
+        SLPFunction,
+        SLPFunction,
+        SLPFunction,
+        SLPFunction,
+        SLPFunction,
     ]
 
 
@@ -531,7 +557,7 @@ def mc_state_data(mc_with_fsoe):
 
     mc.fsoe.configure_pdos(start_pdos=True)
     # Wait for the master to reach the Data state
-    mc.fsoe.wait_for_state_data(timeout=10)
+    mc.fsoe.wait_for_state_data(timeout=300)
 
     # Remove fail-safe state
     mc.fsoe.set_fail_safe(False)

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -107,6 +107,9 @@ def mc_with_fsoe(mc, fsoe_states):
     # IM should be notified and clear references when a servo is disconnected from ingenialink
     # https://novantamotion.atlassian.net/browse/INGM-624
     mc.fsoe._delete_master_handler()
+    # Ensure the PDOs are stopped
+    if mc.capture.pdo.is_active:
+        mc.capture.pdo.stop_pdos()
 
 
 @pytest.fixture()
@@ -432,13 +435,13 @@ def test_getter_of_safety_functions(mc_with_fsoe):
     sto_function = STOFunction(command=None, io=None, parameters=None)
     ss1_function_1 = SS1Function(
         command=None,
-        # time_to_sto=None,
+        time_to_sto=None,
         io=None,
         parameters=None,
     )
     ss1_function_2 = SS1Function(
         command=None,
-        # time_to_sto=None,
+        time_to_sto=None,
         io=None,
         parameters=None,
     )
@@ -540,7 +543,7 @@ def mc_state_data_with_sra(mc_with_fsoe_with_sra):
 
     mc.fsoe.configure_pdos(start_pdos=True)
     # Wait for the master to reach the Data state
-    mc.fsoe.wait_for_state_data(timeout=10)
+    mc.fsoe.wait_for_state_data(timeout=300)
 
     # Remove fail-safe state
     mc.fsoe.set_fail_safe(False)
@@ -587,7 +590,7 @@ def test_start_and_stop_multiple_times(mc_with_fsoe):
 
     for i in range(4):
         mc.fsoe.configure_pdos(start_pdos=True)
-        mc.fsoe.wait_for_state_data(timeout=10)
+        mc.fsoe.wait_for_state_data(timeout=300)
         assert handler.state == FSoEState.DATA
         time.sleep(1)
         assert handler.state == FSoEState.DATA

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -538,13 +538,17 @@ def test_mapping_locked(dictionary, editable):
         handler.delete()
 
 
+TIMEOUT_FOR_DATA_SRA = 3
+TIMEOUT_FOR_DATA = 30
+
+
 @pytest.fixture()
 def mc_state_data_with_sra(mc_with_fsoe_with_sra):
     mc, _handler = mc_with_fsoe_with_sra
 
     mc.fsoe.configure_pdos(start_pdos=True)
     # Wait for the master to reach the Data state
-    mc.fsoe.wait_for_state_data(timeout=3)
+    mc.fsoe.wait_for_state_data(timeout=TIMEOUT_FOR_DATA_SRA)
 
     # Remove fail-safe state
     mc.fsoe.set_fail_safe(False)
@@ -561,7 +565,7 @@ def mc_state_data(mc_with_fsoe):
 
     mc.fsoe.configure_pdos(start_pdos=True)
     # Wait for the master to reach the Data state
-    mc.fsoe.wait_for_state_data(timeout=20)
+    mc.fsoe.wait_for_state_data(timeout=TIMEOUT_FOR_DATA)
 
     # Remove fail-safe state
     mc.fsoe.set_fail_safe(False)
@@ -591,7 +595,7 @@ def test_start_and_stop_multiple_times(mc_with_fsoe):
 
     for i in range(4):
         mc.fsoe.configure_pdos(start_pdos=True)
-        mc.fsoe.wait_for_state_data(timeout=20)
+        mc.fsoe.wait_for_state_data(timeout=TIMEOUT_FOR_DATA)
         assert handler.state == FSoEState.DATA
         time.sleep(1)
         assert handler.state == FSoEState.DATA

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list = coverage, build, docs, format, type, py{39,310,311,312}, virtual
 # For instance, to install ingenialink from a custom branch wheel
 # It should be empty in production.
 [develop]
-ingenialink = ingenialink==7.4.3+pr606b10
+ingenialink = ingenialink==7.4.3+gabce05ac
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
### Description
Update safety release candidate and corresponding upgrades fixes

### Type of change

Please add a description and delete options that are not relevant.

- [x] Update the release candidat used on rack
- [x] Fix conversion of data types of xdf safety parameters to app parameters of the fsoe master. Was already implemented but not used on IM (The new float safe parameters was not properly initialized)
- [x] Updated fsoe master with dynamic map fsoe fixes
- [x] Remove Safe Accceleration. It has been de-implemented from FW
- [x] De-commented safe parameters parsing from safety functions. They are now included in the dictionary

### Tests
- [x] Update xdf reference file for unit tests
- [x] Updated tests that check the safety functions of PH2

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [ ] Set fix version field in the Jira issue.
