### PR TITLE
Force sto in inputs

### DIFF
--- a/ingeniamotion/fsoe_master/maps_validator.py
+++ b/ingeniamotion/fsoe_master/maps_validator.py
@@ -304,7 +304,8 @@ class SafeDataBlocksValidator(FSoEFrameRuleValidator):
                             rule=FSoEFrameRules.OBJECTS_SPLIT_RESTRICTED,
                             exception=(
                                 f"Make sure that 8 bit objects belong to the same data block. "
-                                f"Data slot {data_slot_i} contains split object {item.item.name}."
+                                f"Data slot {data_slot_i} contains split object "
+                                f"{item.item.name if item.item is not None else 'PADDING'}."
                             ),
                             items=[item],
                         )

--- a/ingeniamotion/fsoe_master/maps_validator.py
+++ b/ingeniamotion/fsoe_master/maps_validator.py
@@ -8,7 +8,6 @@ from typing_extensions import override
 
 from ingeniamotion.fsoe_master.frame import FSoEFrame
 from ingeniamotion.fsoe_master.fsoe import (
-    FSoEDictionaryItemOutput,
     FSoEDictionaryMap,
     FSoEDictionaryMappedItem,
 )
@@ -386,7 +385,7 @@ class ObjectsAlignedValidator(FSoEFrameRuleValidator):
 class STOCommandFirstValidator(FSoEFrameRuleValidator):
     """Validator for the STO command position in FSoE frames.
 
-    Validates that the STO command is always mapped to the first position in Safe Outputs.
+    Validates that the STO command is always mapped to the first position.
     """
 
     def __init__(self) -> None:
@@ -397,15 +396,11 @@ class STOCommandFirstValidator(FSoEFrameRuleValidator):
         self, dictionary_map: FSoEDictionaryMap, rules: list[FSoEFrameRules]
     ) -> FSoEFrameRuleValidatorOutput:
         exceptions: dict[FSoEFrameRules, InvalidFSoEFrameRule] = {}
-        # Only validate if the dictionary map contains outputs
-        if FSoEDictionaryItemOutput not in dictionary_map.item_types_accepted:
-            return FSoEFrameRuleValidatorOutput(rules=rules, exceptions=exceptions)
-
         first_item = dictionary_map._items[0]
         if first_item.item is None or first_item.item.name != STOFunction.COMMAND_UID:
             exceptions[FSoEFrameRules.STO_COMMAND_FIRST] = InvalidFSoEFrameRule(
                 rule=FSoEFrameRules.STO_COMMAND_FIRST,
-                exception="STO command must be mapped to the first position in Safe Outputs",
+                exception="STO command must be mapped to the first position",
                 items=[first_item] if first_item is not None else [],
             )
 

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -1454,36 +1454,43 @@ class TestPduMapper:
 
     @pytest.mark.fsoe
     def test_validate_sto_command_first_in_outputs(self, sample_safe_dictionary):
-        """Test that STO command is the first item in the outputs map."""
+        """Test that STO command is the first item in the maps."""
         _, fsoe_dict = sample_safe_dictionary
         maps = PDUMaps.empty(fsoe_dict)
-        ss1_item = maps.outputs.add(fsoe_dict.name_map[SS1Function.COMMAND_UID.format(i=1)])
+        ss1_item_outputs = maps.outputs.add(fsoe_dict.name_map[SS1Function.COMMAND_UID.format(i=1)])
         maps.outputs.add(fsoe_dict.name_map[STOFunction.COMMAND_UID])
         # STO command can be anywhere in the inputs map
-        maps.inputs.add(fsoe_dict.name_map[SS1Function.COMMAND_UID.format(i=1)])
+        ss1_item_inputs = maps.inputs.add(fsoe_dict.name_map[SS1Function.COMMAND_UID.format(i=1)])
         maps.inputs.add(fsoe_dict.name_map[STOFunction.COMMAND_UID])
 
-        # Rule fails when validating the outputs
         output = maps.are_outputs_valid(rules=[FSoEFrameRules.STO_COMMAND_FIRST])
         assert len(output.exceptions) == 1
         assert FSoEFrameRules.STO_COMMAND_FIRST in output.exceptions
         exception = output.exceptions[FSoEFrameRules.STO_COMMAND_FIRST]
         assert isinstance(exception, InvalidFSoEFrameRule)
-        assert (
-            "STO command must be mapped to the first position in Safe Outputs"
-            in exception.exception
-        )
-        assert exception.items == [ss1_item]
+        assert "STO command must be mapped to the first position" in exception.exception
+        assert exception.items == [ss1_item_outputs]
         assert output.is_rule_valid(FSoEFrameRules.STO_COMMAND_FIRST) is False
-        # Check that rule passes when validating the inputs
+
         output = maps.are_inputs_valid(rules=[FSoEFrameRules.STO_COMMAND_FIRST])
-        assert not output.exceptions
-        assert output.is_rule_valid(FSoEFrameRules.STO_COMMAND_FIRST) is True
+        assert len(output.exceptions) == 1
+        assert FSoEFrameRules.STO_COMMAND_FIRST in output.exceptions
+        exception = output.exceptions[FSoEFrameRules.STO_COMMAND_FIRST]
+        assert isinstance(exception, InvalidFSoEFrameRule)
+        assert "STO command must be mapped to the first position" in exception.exception
+        assert output.is_rule_valid(FSoEFrameRules.STO_COMMAND_FIRST) is False
 
         maps.outputs.clear()
         maps.outputs.add(fsoe_dict.name_map[STOFunction.COMMAND_UID])
         maps.outputs.add(fsoe_dict.name_map[SS1Function.COMMAND_UID.format(i=1)])
         output = maps.are_outputs_valid(rules=[FSoEFrameRules.STO_COMMAND_FIRST])
+        assert not output.exceptions
+        assert output.is_rule_valid(FSoEFrameRules.STO_COMMAND_FIRST) is True
+
+        maps.inputs.clear()
+        maps.inputs.add(fsoe_dict.name_map[STOFunction.COMMAND_UID])
+        maps.inputs.add(fsoe_dict.name_map[SS1Function.COMMAND_UID.format(i=1)])
+        output = maps.are_inputs_valid(rules=[FSoEFrameRules.STO_COMMAND_FIRST])
         assert not output.exceptions
         assert output.is_rule_valid(FSoEFrameRules.STO_COMMAND_FIRST) is True
 

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -1478,6 +1478,7 @@ class TestPduMapper:
         exception = output.exceptions[FSoEFrameRules.STO_COMMAND_FIRST]
         assert isinstance(exception, InvalidFSoEFrameRule)
         assert "STO command must be mapped to the first position" in exception.exception
+        assert exception.items == [ss1_item_inputs]
         assert output.is_rule_valid(FSoEFrameRules.STO_COMMAND_FIRST) is False
 
         maps.outputs.clear()


### PR DESCRIPTION
### Description

Force STO to be mapped in first position in Safe Inputs. 

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Check STO position first in Safe Inputs.

### Tests
- [X] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [X] Update docstrings of every function, method or class that change.
- [X] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [ ] Set fix version field in the Jira issue.
