### PR TITLE
INGM-684 added choice option and conditions for every stage to select…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -289,6 +289,14 @@ pipeline {
                 }
 
                 stage('HW Tests CanOpen and Ethernet') {
+                    when {
+                        beforeOptions true
+                        beforeAgent true
+                        expression {
+                            "canopen" ==~ params.run_test_stages ||
+                            "ethernet" ==~ params.run_test_stages
+                        }
+                    }
                     options {
                         lock(CAN_NODE_LOCK)
                     }
@@ -363,6 +371,14 @@ pipeline {
                     }
                 }
                 stage('Hw Tests Ethercat') {
+                    when {
+                        beforeOptions true
+                        beforeAgent true
+                        expression {
+                            "ethercat" ==~ params.run_test_stages ||
+                            "fsoe" ==~ params.run_test_stages
+                        }
+                    }
                     options {
                         lock(ECAT_NODE_LOCK)
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,6 +88,10 @@ pipeline {
     }
     parameters {
         choice(
+                choices: ['MIN', 'MAX', 'MIN_MAX', 'All'],
+                name: 'PYTHON_VERSIONS'
+        )
+        choice(
             choices: [
                 '.*',
                 'virtual_drive_tests',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -353,9 +353,8 @@ pipeline {
                         }
                         stage("Ethernet Capitan") {
                             when {
-                                expression {
-                                    "ethernet_capitan" ==~ params.run_test_stages
-                                }
+                                // Remove this after fixing INGK-982
+                                expression { false }
                             }
                             steps {
                                 runTestHW("ethernet_capitan", "ethernet", "ETH_CAP_SETUP", false, USE_WIRESHARK_LOGGING)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -293,8 +293,8 @@ pipeline {
                         beforeOptions true
                         beforeAgent true
                         expression {
-                            "canopen" ==~ params.run_test_stages ||
-                            "ethernet" ==~ params.run_test_stages
+                          params.run_test_stages.contains("canopen") ||
+                          params.run_test_stages.contains("ethernet")
                         }
                     }
                     options {
@@ -375,8 +375,8 @@ pipeline {
                         beforeOptions true
                         beforeAgent true
                         expression {
-                            "ethercat" ==~ params.run_test_stages ||
-                            "fsoe" ==~ params.run_test_stages
+                            params.run_test_stages.contains("ethercat") ||
+                            params.run_test_stages.contains("fsoe")
                         }
                     }
                     options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,13 +88,30 @@ pipeline {
     }
     parameters {
         choice(
-                choices: ['MIN', 'MAX', 'MIN_MAX', 'All'],
-                name: 'PYTHON_VERSIONS'
+            choices: [
+                '.*',
+                'virtual_drive_tests',
+                'canopen_.*',
+                'ethernet_.*',
+                'canopen_everest.*',
+                'canopen_capitan.*',
+                'ethernet_everest.*',
+                'ethernet_capitan.*',
+                'ethercat_.*',
+                'ethercat_everest.*',
+                'ethercat_capitan.*',
+                'ethercat_multislave.*',
+                'fsoe_.*',
+                'fsoe_phase1.*',
+                'fsoe_phase2.*'
+            ],
+            name: 'run_test_stages',
+            description: 'Regex pattern for which testing stage or substage to run (e.g. "fsoe_.*", "ethercat_everest", ".*" for all)'
         )
         booleanParam(name: 'WIRESHARK_LOGGING', defaultValue: true, description: 'Enable Wireshark logging')
         choice(
-                choices: ['function', 'module', 'session'],
-                name: 'WIRESHARK_LOGGING_SCOPE'
+            choices: ['function', 'module', 'session'],
+            name: 'WIRESHARK_LOGGING_SCOPE'
         )
         booleanParam(name: 'CLEAR_SUCCESSFUL_WIRESHARK_LOGS', defaultValue: true, description: 'Clears Wireshark logs if the test passed')
     }
@@ -132,6 +149,9 @@ pipeline {
         stage('Build and Tests') {
             parallel {
                 stage('Virtual drive tests on Linux') {
+                    when {
+                        expression { "virtual_drive_tests" ==~ params.run_test_stages }
+                    }
                     agent {
                         docker {
                             label "worker"
@@ -278,29 +298,63 @@ pipeline {
                             }
                         }
                         stage("CanOpen Everest") {
+                            when {
+                                expression {
+                                    "canopen_everest" ==~ params.run_test_stages
+                                }
+                            }
                             steps {
                                 runTestHW("canopen_everest", "canopen and not skip_testing_framework", "CAN_EVE_SETUP")
+                            }
+                        }
+                        stage("CanOpen Everest (skip_testing_framework)") {
+                            when {
+                                expression {
+                                    "canopen_everest_no_framework" ==~ params.run_test_stages
+                                }
+                            }
+                            steps {
                                 runTestHW("canopen_everest_no_framework", "canopen and skip_testing_framework", "CAN_EVE_SETUP")
                             }
                         }
                         stage("Ethernet Everest") {
+                            when {
+                                expression {
+                                    "ethernet_everest" ==~ params.run_test_stages
+                                }
+                            }
                             steps {
                                 runTestHW("ethernet_everest", "ethernet", "ETH_EVE_SETUP", false, USE_WIRESHARK_LOGGING)
                             }
                         }
                         stage("CanOpen Capitan") {
+                            when {
+                                expression {
+                                    "canopen_capitan" ==~ params.run_test_stages
+                                }
+                            }
                             steps {
                                 runTestHW("canopen_capitan", "canopen and not skip_testing_framework", "CAN_CAP_SETUP")
+                            }
+                        }
+                        stage("CanOpen Capitan (skip_testing_framework)") {
+                            when {
+                                expression {
+                                    "canopen_capitan_no_framework" ==~ params.run_test_stages
+                                }
+                            }
+                            steps {
                                 runTestHW("canopen_capitan_no_framework", "canopen and skip_testing_framework", "CAN_EVE_SETUP")
                             }
                         }
                         stage("Ethernet Capitan") {
                             when {
-                                // Remove this after fixing INGK-982
-                                expression { false }
+                                expression {
+                                    "ethernet_capitan" ==~ params.run_test_stages
+                                }
                             }
                             steps {
-                                runTestHW("ethernet capitan", "ethernet", "ETH_CAP_SETUP", false, USE_WIRESHARK_LOGGING)
+                                runTestHW("ethernet_capitan", "ethernet", "ETH_CAP_SETUP", false, USE_WIRESHARK_LOGGING)
                             }
                         }
                     }
@@ -320,31 +374,50 @@ pipeline {
                         }
                         stage("Ethercat Everest") {
                             when {
-                                // Remove this after fixing INGK-983
-                                expression { false }
+                                expression {
+                                    "ethercat_everest" ==~ params.run_test_stages
+                                }
                             }
                             steps {
                                 runTestHW("ethercat_everest", "soem", "ECAT_EVE_SETUP", false, USE_WIRESHARK_LOGGING)
                             }
                         }
                         stage("Ethercat Capitan") {
+                            when {
+                                expression {
+                                    "ethercat_capitan" ==~ params.run_test_stages
+                                }
+                            }
                             steps {
                                 runTestHW("ethercat_capitan", "soem", "ECAT_CAP_SETUP", false, USE_WIRESHARK_LOGGING)
                             }
                         }
                         stage("Safety Denali Phase I") {
+                            when {
+                                expression {
+                                    "fsoe_phase1" ==~ params.run_test_stages
+                                }
+                            }
                             steps {
                                 runTestHW("fsoe_phase1", "fsoe", "ECAT_DEN_S_PHASE1_SETUP", true, USE_WIRESHARK_LOGGING)
-                           
                             }
                         }
                         stage("Safety Denali Phase II") {
+                            when {
+                                expression {
+                                    "fsoe_phase2" ==~ params.run_test_stages
+                                }
+                            }
                             steps {
                                 runTestHW("fsoe_phase2", "fsoe or fsoe_phase2", "ECAT_DEN_S_PHASE2_SETUP", true, USE_WIRESHARK_LOGGING)
-
                             }
                         }
                         stage("Ethercat Multislave") {
+                            when {
+                                expression {
+                                    "ethercat_multislave" ==~ params.run_test_stages
+                                }
+                            }
                             steps {
                                 runTestHW("ethercat_multislave", "soem_multislave", "ECAT_MULTISLAVE_SETUP", false, USE_WIRESHARK_LOGGING)
                             }


### PR DESCRIPTION
### Pull request name 

Specially for safety development we are heavily using the rack to debug some issues, and this is causing long queues since we run all tests.
Having a selector of test stage/s will help reduce the rack time utilization

### Description

Please include a summary of the change and which issue is fixed. 

Fixes INGM-684

### Type of change

Please add a description and delete options that are not relevant.

- [x] Added pipeline choice parameter with relevant regex patterns
- [x] Separated skip_testing_framework into stages
- [x] Added conditional stages with regex pattern matching

### Tests
- [x] Run with default pattern .*^
<img width="2409" height="489" alt="image" src="https://github.com/user-attachments/assets/bc607127-848d-4330-8823-59e4298384fd" />

- [x] Run selecting fsoe_.* pattern
<img width="2231" height="526" alt="image" src="https://github.com/user-attachments/assets/90a41472-00f0-42a5-8ea6-c1f50a262ba8" />

- [x] Run selecting canopen_capitan.* pattern
<img width="2358" height="709" alt="image" src="https://github.com/user-attachments/assets/dbb341fd-97ae-48f7-a917-ce9c4a2a2870" />


Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [ ] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [ ] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
