### PR TITLE
Ingm 694 fix jenkins for python != 3 9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,12 +175,8 @@ pipeline {
                             DEFAULT_PYTHON_VERSION = PYTHON_VERSION_MAX
                         } else if (env.PYTHON_VERSIONS == "All") {
                             RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
-                        } else { // Branch-indexing/timer
-                            if (env.BRANCH_NAME == 'develop') {
-                                RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
-                            } else {
-                                RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
-                            }
+                        } else { // Branch-indexing
+                            RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
                         }
                     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,15 +165,22 @@ pipeline {
                         RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
                     } else {
                         if (env.PYTHON_VERSIONS == "MIN_MAX") {
-                          RUN_PYTHON_VERSIONS = "${PYTHON_VERSION_MIN},${PYTHON_VERSION_MAX}"
+                            RUN_PYTHON_VERSIONS = "${PYTHON_VERSION_MIN},${PYTHON_VERSION_MAX}"
                         } else if (env.PYTHON_VERSIONS == "MIN") {
-                          RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
+                            RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
                         } else if (env.PYTHON_VERSIONS == "MAX") {
-                          RUN_PYTHON_VERSIONS = PYTHON_VERSION_MAX
+                            RUN_PYTHON_VERSIONS = PYTHON_VERSION_MAX
+                            // Change the default python version so that virtual environments will match
+                            // the selected python version
+                            DEFAULT_PYTHON_VERSION = PYTHON_VERSION_MAX
                         } else if (env.PYTHON_VERSIONS == "All") {
-                          RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
-                        } else { // Branch-indexing
-                          RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
+                            RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
+                        } else { // Branch-indexing/timer
+                            if (env.BRANCH_NAME == 'develop') {
+                                RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
+                            } else {
+                                RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
+                            }
                         }
                     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,6 +91,10 @@ def createVirtualEnvironments(String pythonVersionList = "") {
     runPython("pip install poetry==2.1.3", DEFAULT_PYTHON_VERSION)
     def versions = pythonVersionList?.trim() ? pythonVersionList : RUN_PYTHON_VERSIONS
     def pythonVersions = versions.split(',')
+    // Ensure DEFAULT_PYTHON_VERSION is included if not already present
+    if (!pythonVersions.contains(DEFAULT_PYTHON_VERSION)) {
+        pythonVersions = pythonVersions + [DEFAULT_PYTHON_VERSION]
+    }
     pythonVersions.each { version ->
         def venvName = ".venv${version}"
         if (isUnix()) {
@@ -170,9 +174,6 @@ pipeline {
                             RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
                         } else if (env.PYTHON_VERSIONS == "MAX") {
                             RUN_PYTHON_VERSIONS = PYTHON_VERSION_MAX
-                            // Change the default python version so that virtual environments will match
-                            // the selected python version
-                            DEFAULT_PYTHON_VERSION = PYTHON_VERSION_MAX
                         } else if (env.PYTHON_VERSIONS == "All") {
                             RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
                         } else { // Branch-indexing


### PR DESCRIPTION
### Description

Jenkins fixes for different python versions.

Right now all the docker environment activations are supposed to run with the default python version, which is the minimum one. However, since the python version can be selected, the maximum one may run, leading to an error:
http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingeniamotion/job/develop/746/

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X]  Always include default version when creating the virtual environments


### Tests
- [ ] Add new unit tests if it applies.
- [ ] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [ ] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [ ] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [X] Set fix version field in the Jira issue.
