### PR TITLE
Ingm 704 add ss 1 and sto optional parameters

### DIFF
--- a/ingeniamotion/fsoe_master/safety_functions.py
+++ b/ingeniamotion/fsoe_master/safety_functions.py
@@ -288,6 +288,9 @@ class SS1Function(SafetyFunction):
     time_to_sto: SafetyParameter = safety_field(
         uid="FSOE_SS1_TIME_TO_STO_{i}", display_name="Time to STO"
     )
+    time_for_velocity_zero: Optional[SafetyParameter] = safety_field(
+        uid="FSOE_SS1_TIME_FOR_VEL_ZERO_{i}", display_name="Time for Velocity Zero"
+    )
 
 
 @dataclass()

--- a/ingeniamotion/fsoe_master/safety_functions.py
+++ b/ingeniamotion/fsoe_master/safety_functions.py
@@ -63,7 +63,12 @@ def safety_field(uid: str, display_name: str):  # type: ignore[no-untyped-def]
 
 
 def is_optional(field_type: type) -> tuple[bool, type]:
-    """Check if a field type is Optional and get the internal type."""
+    """Check if a field type is Optional and get the internal type.
+
+    Returns:
+        A tuple with a boolean indicating if the field is Optional,
+        and the internal type if it is Optional, or the original type if not.
+    """
     is_optional = get_origin(field_type) is Optional or (
         get_origin(field_type) is Union and type(None) in get_args(field_type)
     )
@@ -204,7 +209,8 @@ class SafetyFunction:
                 raise KeyError(f"Dictionary item {uid} not found in the handler's dictionary")
             if not isinstance(item, FSoEDictionaryItemInputOutput):
                 raise TypeError(
-                    f"Expected DictionaryItemInputOutput {uid} on the safe dictionary, got {type(item)}"
+                    f"Expected DictionaryItemInputOutput {uid} "
+                    f"on the safe dictionary, got {type(item)}"
                 )
         return item
 

--- a/ingeniamotion/fsoe_master/safety_functions.py
+++ b/ingeniamotion/fsoe_master/safety_functions.py
@@ -124,8 +124,8 @@ class SafetyFunction:
         Yields:
             Iterator[SafetyFunction]: An iterator yielding the safety function instance.
         """
-        ios: dict[SafetyFieldMetadata, FSoEDictionaryItem] = {}
-        parameters: dict[SafetyFieldMetadata, SafetyParameter] = {}
+        ios: dict[SafetyFieldMetadata, Optional[FSoEDictionaryItem]] = {}
+        parameters: dict[SafetyFieldMetadata, Optional[SafetyParameter]] = {}
         for field in dataclasses.fields(cls):
             if "uid" not in field.metadata:
                 continue
@@ -145,8 +145,12 @@ class SafetyFunction:
                 parameters[metadata] = cls._get_parameter(handler, uid, required)
 
         yield cls(
-            ios=ios,  # TODO Filter
-            parameters=parameters,  # TODO Filter
+            ios={metadata: io for metadata, io in ios.items() if io is not None},
+            parameters={
+                metadata: parameter
+                for metadata, parameter in parameters.items()
+                if parameter is not None
+            },
             **{field.attr_name: io for field, io in ios.items()},
             **{field.attr_name: parameter for field, parameter in parameters.items()},
         )

--- a/tests/dictionaries/__init__.py
+++ b/tests/dictionaries/__init__.py
@@ -9,3 +9,4 @@ SAMPLE_SAFE_PH1_XDFV3_DICTIONARY = (
 SAMPLE_SAFE_PH2_XDFV3_DICTIONARY = (
     __dictionaries_root_path / "evs-s-net-e_2.9.0.004_v3.xdf"
 ).as_posix()
+SAMPLE_SAFE_PH2_MODULE_IDENT_NO_SRA_MODULE_IDENT = 0x3B00003

--- a/tests/dictionaries/__init__.py
+++ b/tests/dictionaries/__init__.py
@@ -7,5 +7,5 @@ SAMPLE_SAFE_PH1_XDFV3_DICTIONARY = (
     __dictionaries_root_path / "den-s-net-e_devf13ab4_v3.xdf"
 ).as_posix()
 SAMPLE_SAFE_PH2_XDFV3_DICTIONARY = (
-    __dictionaries_root_path / "evs-s-net-e_safety_1.1.0.014_v3.xdf"
+    __dictionaries_root_path / "evs-s-net-e_2.9.0.004_v3.xdf"
 ).as_posix()

--- a/tests/dictionaries/evs-s-net-e_2.9.0.004_v3.xdf
+++ b/tests/dictionaries/evs-s-net-e_2.9.0.004_v3.xdf
@@ -113,7 +113,7 @@
       </Category>
     </Categories>
     <Devices>
-      <ETHDevice firmwareVersion="safety_1.1.0.014" ProductCode="61936641" PartNumber="EVS-S-NET-E" RevisionNumber="327680">
+      <ETHDevice firmwareVersion="2.9.0.004" ProductCode="61936641" PartNumber="EVS-S-NET-E" RevisionNumber="327680">
         <Subnodes>
           <Subnode index="0">Communication</Subnode>
           <Subnode index="1">Motion</Subnode>
@@ -3411,7 +3411,7 @@
               <Label lang="en_US">Revision number</Label>
             </Labels>
           </MCBRegister>
-          <MCBRegister address="0x06E4" subnode="1" address_type="NVM_NONE" access="r" dtype="str" id="DRV_ID_SOFTWARE_VERSION" units="none" pdo_access="CONFIG" desc="Public software release version" default="7361666574795f312e312e302e303134" cat_id="IDENTIFICATION" axis="1">
+          <MCBRegister address="0x06E4" subnode="1" address_type="NVM_NONE" access="r" dtype="str" id="DRV_ID_SOFTWARE_VERSION" units="none" pdo_access="CONFIG" desc="Public software release version" default="322e392e302e303034" cat_id="IDENTIFICATION" axis="1">
             <Labels>
               <Label lang="en_US">Software version</Label>
             </Labels>
@@ -4127,7 +4127,7 @@
           </Error>
         </Errors>
       </ETHDevice>
-      <ECATDevice firmwareVersion="safety_1.1.0.014" ProductCode="61936641" PartNumber="EVS-S-NET-E" RevisionNumber="327680">
+      <ECATDevice firmwareVersion="2.9.0.004" ProductCode="61936641" PartNumber="EVS-S-NET-E" RevisionNumber="327680">
         <CANopenObjects>
           <CANopenObject id="ETG_DRV_ID_DEVICE_TYPE" index="0x1000" datatype="VAR">
             <Labels>
@@ -11159,7 +11159,7 @@
               <Label lang="en_US">Software version</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="str" id="DRV_ID_SOFTWARE_VERSION" pdo_access="CONFIG" desc="Public software release version" units="none" default="7361666574795f312e312e302e303134" cat_id="IDENTIFICATION" axis="1">
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="str" id="DRV_ID_SOFTWARE_VERSION" pdo_access="CONFIG" desc="Public software release version" units="none" default="322e392e302e303034" cat_id="IDENTIFICATION" axis="1">
                 <Labels>
                   <Label lang="en_US">Software version</Label>
                 </Labels>
@@ -12039,7 +12039,7 @@
               <Label lang="en_US">Software version</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="str" id="FSOE_SOFTWARE_VERSION" pdo_access="CONFIG" desc="Indicates the firmware version of the safety subnode" units="none" default="312e302e302e303030" cat_id="FSOE" axis="1">
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="str" id="FSOE_SOFTWARE_VERSION" pdo_access="CONFIG" desc="Indicates the firmware version of the safety subnode" units="none" default="322e302e302e303030" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">Software version</Label>
                 </Labels>
@@ -12054,6 +12054,30 @@
               <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u32" id="FSOE_SERIAL_NUMBER" pdo_access="CONFIG" desc="Indicates the unique serial number of the safe drive" units="none" default="00000000" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">Serial number</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SOUT_DISABLE" index="0x46EE" datatype="VAR" axis="1">
+            <Labels>
+              <Label lang="en_US">SOUT Disable</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="u16" id="FSOE_SOUT_DISABLE" pdo_access="CONFIG" desc="Disables the SOUT functionality" units="none" default="0000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SOUT Disable</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_USER_OVER_TEMPERATURE" index="0x46EF" datatype="VAR" axis="1">
+            <Labels>
+              <Label lang="en_US">User Over Temperature</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="float" id="FSOE_USER_OVER_TEMPERATURE" pdo_access="CONFIG" desc="Configurable user over temperature limit" units="none" default="0000aa42" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">User Over Temperature</Label>
                 </Labels>
               </Subitem>
             </Subitems>
@@ -14106,7 +14130,7 @@
               <Label lang="en_US">Time Unit</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u32" id="FSOE_TIME_UNIT" pdo_access="CONFIG" desc="Time unit of the configuration parameters of the safety functions.&#10; Format specified in ETG.1004" units="none" default="000003fd" cat_id="FSOE" axis="1">
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u32" id="FSOE_TIME_UNIT" pdo_access="CONFIG" desc="Time unit of the configuration parameters of the safety functions.Format specified in ETG.1004" units="none" default="000003fd" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">Time Unit</Label>
                 </Labels>
@@ -14169,10 +14193,26 @@
               <Label lang="en_US">STO Command</Label>
             </Labels>
             <Subitems>
-              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_STO" pdo_access="CYCLIC_SISO" desc="Safe Torque Off Safety function. &#10;Commands the STO when writing. Reports the STO status when reading." units="none" default="01" cat_id="FSOE" axis="1">
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_STO" pdo_access="CYCLIC_SISO" desc="Safe Torque Off Safety function.Commands the STO when writing. Reports the STO status when reading." units="none" default="01" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">STO Command</Label>
                 </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_STO_ACTIVATE_SOUT" index="0x6643" datatype="VAR" axis="1">
+            <Labels>
+              <Label lang="en_US">STO Activate SOUT</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_STO_ACTIVATE_SOUT" pdo_access="CONFIG" desc="Safe Output Unit instance to be activated simultaneously with the STO safety function." units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">STO Activate SOUT</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No SOUT used with STO</Enum>
+                  <Enum value="1717567488">SOUT instance activated with STO</Enum>
+                </Enumerations>
               </Subitem>
             </Subitems>
           </CANopenObject>
@@ -14186,7 +14226,7 @@
                   <Label lang="en_US">SubIndex 000</Label>
                 </Labels>
               </Subitem>
-              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SS1_1" pdo_access="CYCLIC_SISO" desc="SS1 Safety function. &#10;Commands the SS1 when writing. Reports the SS1 status when reading." units="none" default="01" cat_id="FSOE" axis="1">
+              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SS1_1" pdo_access="CYCLIC_SISO" desc="SS1 Safety function.Commands the SS1 when writing. Reports the SS1 status when reading." units="none" default="01" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">SS1 Command</Label>
                 </Labels>
@@ -14278,6 +14318,51 @@
               </Subitem>
             </Subitems>
           </CANopenObject>
+          <CANopenObject id="FSOE_SS1_ACTIVATE_SOUT" index="0x6658" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SS1 Activate SOUT</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SS1_ACTIVATE_SOUT_TOTAL" pdo_access="CONFIG" desc="" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">Subindex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SS1_ACTIVATE_SOUT_1" pdo_access="CONFIG" desc="SOUT instance to be activated simultaneously with the SS1 safety function." units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SS1 Activate SOUT</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No SOUT used with SS1</Enum>
+                  <Enum value="1717567488">SOUT instance activated with SS1</Enum>
+                </Enumerations>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SOUT" index="0x6660" datatype="VAR" axis="1">
+            <Labels>
+              <Label lang="en_US">SOUT Command</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SOUT" pdo_access="CYCLIC_SISO" desc="SOUT Safety Function.Commands the SOUT when writing. Reports the SOUT status when reading." units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SOUT Command</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SOUT_BRAKE_TIME_DELAY" index="0x6661" datatype="VAR" axis="1">
+            <Labels>
+              <Label lang="en_US">SOUT Brake Time Delay</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="u16" id="FSOE_SOUT_BRAKE_TIME_DELAY" pdo_access="CONFIG" desc="Electromechanical delay for a brake" units="none" default="0000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SOUT Brake Time Delay</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
           <CANopenObject id="FSOE_SOS" index="0x6668" datatype="ARRAY" axis="1">
             <Labels>
               <Label lang="en_US">SOS Command</Label>
@@ -14288,7 +14373,7 @@
                   <Label lang="en_US">SubIndex 000</Label>
                 </Labels>
               </Subitem>
-              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SOS_1" pdo_access="CYCLIC_SISO" desc="SOS Safety function. &#10;Commands the SOS when writing. Reports the SOS status when reading." units="none" default="01" cat_id="FSOE" axis="1">
+              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SOS_1" pdo_access="CYCLIC_SISO" desc="SOS Safety function.Commands the SOS when writing. Reports the SOS status when reading." units="none" default="01" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">SOS Command</Label>
                 </Labels>
@@ -14339,7 +14424,7 @@
                   <Label lang="en_US">SubIndex 000</Label>
                 </Labels>
               </Subitem>
-              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SS2_1" pdo_access="CYCLIC_SISO" desc="SS2 Safety function. &#10;Commands the SS2 when writing. Reports the SS2 status when reading." units="none" default="01" cat_id="FSOE" axis="1">
+              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SS2_1" pdo_access="CYCLIC_SISO" desc="SS2 Safety function.Commands the SS2 when writing. Reports the SS2 status when reading." units="none" default="01" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">SS2 Command</Label>
                 </Labels>
@@ -15040,36 +15125,78 @@
                 <Labels>
                   <Label lang="en_US">SLP 1 Error Reaction</Label>
                 </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                  <Enum value="1718616321">SS2</Enum>
+                </Enumerations>
               </Subitem>
               <Subitem subindex="2" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_2" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 2" units="none" default="01004066" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">SLP 2 Error Reaction</Label>
                 </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                  <Enum value="1718616321">SS2</Enum>
+                </Enumerations>
               </Subitem>
               <Subitem subindex="3" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_3" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 3" units="none" default="01004066" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">SLP 3 Error Reaction</Label>
                 </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                  <Enum value="1718616321">SS2</Enum>
+                </Enumerations>
               </Subitem>
               <Subitem subindex="4" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_4" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 4" units="none" default="01004066" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">SLP 4 Error Reaction</Label>
                 </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                  <Enum value="1718616321">SS2</Enum>
+                </Enumerations>
               </Subitem>
               <Subitem subindex="5" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_5" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 5" units="none" default="01004066" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">SLP 5 Error Reaction</Label>
                 </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                  <Enum value="1718616321">SS2</Enum>
+                </Enumerations>
               </Subitem>
               <Subitem subindex="6" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_6" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 6" units="none" default="01004066" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">SLP 6 Error Reaction</Label>
                 </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                  <Enum value="1718616321">SS2</Enum>
+                </Enumerations>
               </Subitem>
               <Subitem subindex="7" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_7" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 7" units="none" default="01004066" cat_id="FSOE" axis="1">
                 <Labels>
                   <Label lang="en_US">SLP 7 Error Reaction</Label>
                 </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                  <Enum value="1718616321">SS2</Enum>
+                </Enumerations>
               </Subitem>
               <Subitem subindex="8" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLP_ERROR_REACTION_8" pdo_access="CONFIG" desc="Error reaction for Safely-Limited Position instance 8" units="none" default="01004066" cat_id="FSOE" axis="1">
                 <Labels>
@@ -15079,7 +15206,117 @@
                   <Enum value="0">No reaction</Enum>
                   <Enum value="1715470337">STO</Enum>
                   <Enum value="1716519169">SS1</Enum>
+                  <Enum value="1718616321">SS2</Enum>
                 </Enumerations>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SLI_COMMAND" index="0x66B8" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SLI Command</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SLI_TOTAL" pdo_access="CONFIG" desc="" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SLI_COMMAND_1" pdo_access="CYCLIC_SISO" desc="SLI Command" units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLI Command</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SLI_UPPER_LIMIT" index="0x66BA" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SLI Position Relative Upper Limit</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SLI_UPPER_LIMIT_TOTAL" pdo_access="CONFIG" desc="" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLI_UPPER_LIMIT_1" pdo_access="CONFIG" desc="Maximum allowed relative position while SLI is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLI Position Relative Upper Limit</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SLI_LOWER_LIMIT" index="0x66BC" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SLI Position Relative Lower Limit</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SLI_LOWER_LIMIT_TOTAL" pdo_access="CONFIG" desc="" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="s32" id="FSOE_SLI_LOWER_LIMIT_1" pdo_access="CONFIG" desc="Minimum allowed relative position while SLI is active" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLI Position Relative Lower Limit</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SLI_ERROR_REACTION" index="0x66BD" datatype="ARRAY" axis="1">
+            <Labels>
+              <Label lang="en_US">SLI Error Reaction</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="FSOE_SLI_ERROR_REACTION_TOTAL" pdo_access="CONFIG" desc="" units="none" default="01" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SubIndex 000</Label>
+                </Labels>
+              </Subitem>
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SLI_ERROR_REACTION_1" pdo_access="CONFIG" desc="Error reaction to a violation of SLI limits" units="none" default="01004066" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SLI Error Reaction</Label>
+                </Labels>
+                <Enumerations>
+                  <Enum value="0">No reaction</Enum>
+                  <Enum value="1715470337">STO</Enum>
+                  <Enum value="1716519169">SS1</Enum>
+                </Enumerations>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SDI_P" index="0x66D0" datatype="VAR" axis="1">
+            <Labels>
+              <Label lang="en_US">SDI positive direction command</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SDI_P" pdo_access="CYCLIC_SISO" desc="Safe Direction positive direction Safety function.Activates/deactivates movement in positive direction when writing.Reports movement in positive direction if active." units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SDI positive direction command</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SDI_N" index="0x66D1" datatype="VAR" axis="1">
+            <Labels>
+              <Label lang="en_US">SDI negative direction command</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="bit" id="FSOE_SDI_N" pdo_access="CYCLIC_SISO" desc="Safe Direction negative direction Safety function.Activates/deactivates movement in negative direction when writing.Reports movement in negative direction if active." units="none" default="00" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SDI negative direction command</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+          <CANopenObject id="FSOE_SDI_POS_ZERO_WINDOW" index="0x66D3" datatype="VAR" axis="1">
+            <Labels>
+              <Label lang="en_US">SDI Position zero window</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="u32" id="FSOE_SDI_POS_ZERO_WINDOW" pdo_access="CONFIG" desc="Position window for SDI instance" units="none" default="00000000" cat_id="FSOE" axis="1">
+                <Labels>
+                  <Label lang="en_US">SDI Position zero window</Label>
+                </Labels>
               </Subitem>
             </Subitems>
           </CANopenObject>
@@ -15292,7 +15529,7 @@
                   <Label lang="en_US">SubIndex 000</Label>
                 </Labels>
               </Subitem>
-              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u32" id="MDP_CONFIGURED_MODULE_1" pdo_access="CONFIG" desc="" units="none" default="00008003" cat_id="MDP">
+              <Subitem subindex="1" address_type="NVM_NONE" access="rw" dtype="u32" id="MDP_CONFIGURED_MODULE_1" pdo_access="CONFIG" desc="" units="none" default="03008003" cat_id="MDP">
                 <Labels>
                   <Label lang="en_US">Configured module ident of the module 1</Label>
                 </Labels>
@@ -15309,17 +15546,17 @@
                   <Label lang="en_US">Subindex 000</Label>
                 </Labels>
               </Subitem>
-              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="u32" id="MDP_DETECTED_MODULE_1" pdo_access="CONFIG" desc="" units="none" default="00008003" cat_id="MDP">
+              <Subitem subindex="1" address_type="NVM_NONE" access="r" dtype="u32" id="MDP_DETECTED_MODULE_1" pdo_access="CONFIG" desc="" units="none" default="03008003" cat_id="MDP">
                 <Labels>
                   <Label lang="en_US">Module ident of the module detected on position 1</Label>
                 </Labels>
               </Subitem>
-              <Subitem subindex="2" address_type="NVM_NONE" access="r" dtype="u32" id="MDP_DETECTED_MODULE_2" pdo_access="CONFIG" desc="" units="none" default="01008003" cat_id="MDP">
+              <Subitem subindex="2" address_type="NVM_NONE" access="r" dtype="u32" id="MDP_DETECTED_MODULE_2" pdo_access="CONFIG" desc="" units="none" default="04008003" cat_id="MDP">
                 <Labels>
                   <Label lang="en_US">Module ident of the module detected on position 2</Label>
                 </Labels>
               </Subitem>
-              <Subitem subindex="3" address_type="NVM_NONE" access="r" dtype="u32" id="MDP_DETECTED_MODULE_3" pdo_access="CONFIG" desc="" units="none" default="02008003" cat_id="MDP">
+              <Subitem subindex="3" address_type="NVM_NONE" access="r" dtype="u32" id="MDP_DETECTED_MODULE_3" pdo_access="CONFIG" desc="" units="none" default="05008003" cat_id="MDP">
                 <Labels>
                   <Label lang="en_US">Module ident of the module detected on position 3</Label>
                 </Labels>
@@ -15767,106 +16004,8 @@
           </Error>
         </Errors>
         <SafetyModules>
-          <SafetyModule uses_sra="false" module_ident="0x3b00000">
+          <SafetyModule uses_sra="false" module_ident="0x3b00003">
             <ApplicationParameters>
-              <ApplicationParameter id="FSOE_SS1_TIME_TO_STO_1"/>
-              <ApplicationParameter id="FSOE_SS1_VEL_ZERO_WINDOW_1"/>
-              <ApplicationParameter id="FSOE_SS1_TIME_FOR_VEL_ZERO_1"/>
-              <ApplicationParameter id="FSOE_SS1_DEC_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SS1_TIME_DELAY_DEC_1"/>
-              <ApplicationParameter id="FSOE_SOS_POS_ZERO_WINDOW_1"/>
-              <ApplicationParameter id="FSOE_SOS_VEL_ZERO_WINDOW_1"/>
-              <ApplicationParameter id="FSOE_SS2_TIME_TO_SOS_1"/>
-              <ApplicationParameter id="FSOE_SS2_TIME_FOR_VEL_ZERO_1"/>
-              <ApplicationParameter id="FSOE_SS2_DEC_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SS2_TIME_DELAY_DEC_1"/>
-              <ApplicationParameter id="FSOE_SS2_ERROR_REACTION_1"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_2"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_3"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_4"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_5"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_6"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_7"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_8"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_2"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_3"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_4"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_5"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_6"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_7"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_8"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_1"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_2"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_3"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_4"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_5"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_6"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_7"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_8"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_2"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_3"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_4"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_5"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_6"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_7"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_8"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_1"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_2"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_3"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_4"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_5"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_6"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_7"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_8"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_2"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_3"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_4"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_5"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_6"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_7"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_8"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_2"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_3"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_4"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_5"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_6"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_7"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_8"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_1"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_2"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_3"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_4"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_5"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_6"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_7"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_8"/>
-              <ApplicationParameter id="FSOE_SAFE_INPUTS_MAP"/>
-              <ApplicationParameter id="FSOE_SAFE_HOMING_REFERENCE"/>
-              <ApplicationParameter id="FSOE_FEEDBACK_SCENARIO"/>
-              <ApplicationParameter id="FSOE_POSITION_TOLERANCE"/>
-              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_REDUNDANT_TURNS"/>
-              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_MAIN_TURNS"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_FSIZE"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POL"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POSBITS"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_STURN"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_BAUD"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_TOUT"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_FSIZE"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_POL"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_PBITS"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_STURN"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_BAUD"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_TOUT"/>
-              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_RESOLUTION"/>
-              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_POLARITY"/>
-              <ApplicationParameter id="FSOE_HALL_POLEPAIRS"/>
-              <ApplicationParameter id="FSOE_HALL_POLARITY"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_TOTAL"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_1"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_2"/>
@@ -15959,113 +16098,122 @@
               <ApplicationParameter id="ETG_COMMS_TPDO_MAP256_43"/>
               <ApplicationParameter id="ETG_COMMS_TPDO_MAP256_44"/>
               <ApplicationParameter id="ETG_COMMS_TPDO_MAP256_45"/>
+              <ApplicationParameter id="FSOE_SS1_TIME_TO_STO_1"/>
+              <ApplicationParameter id="FSOE_SS1_VEL_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SS1_TIME_FOR_VEL_ZERO_1"/>
+              <ApplicationParameter id="FSOE_SS1_DEC_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SS1_TIME_DELAY_DEC_1"/>
+              <ApplicationParameter id="FSOE_SOS_POS_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SOS_VEL_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_TO_SOS_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_FOR_VEL_ZERO_1"/>
+              <ApplicationParameter id="FSOE_SS2_DEC_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_DELAY_DEC_1"/>
+              <ApplicationParameter id="FSOE_SS2_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SLI_UPPER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLI_LOWER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLI_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SDI_POS_ZERO_WINDOW"/>
+              <ApplicationParameter id="FSOE_SAFE_INPUTS_MAP"/>
+              <ApplicationParameter id="FSOE_USER_OVER_TEMPERATURE"/>
+              <ApplicationParameter id="FSOE_SAFE_HOMING_REFERENCE"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_SCENARIO"/>
+              <ApplicationParameter id="FSOE_POSITION_TOLERANCE"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_REDUNDANT_TURNS"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_MAIN_TURNS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_FSIZE"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POL"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POSBITS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_STURN"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_BAUD"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_TOUT"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_FSIZE"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_POL"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_PBITS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_STURN"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_BAUD"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_TOUT"/>
+              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_RESOLUTION"/>
+              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_POLARITY"/>
+              <ApplicationParameter id="FSOE_HALL_POLEPAIRS"/>
+              <ApplicationParameter id="FSOE_HALL_POLARITY"/>
+              <ApplicationParameter id="FSOE_STO_ACTIVATE_SOUT"/>
+              <ApplicationParameter id="FSOE_SS1_ACTIVATE_SOUT_1"/>
+              <ApplicationParameter id="FSOE_SOUT_BRAKE_TIME_DELAY"/>
+              <ApplicationParameter id="FSOE_SOUT_DISABLE"/>
             </ApplicationParameters>
           </SafetyModule>
-          <SafetyModule uses_sra="false" module_ident="0x3b00002">
+          <SafetyModule uses_sra="false" module_ident="0x3b00005">
             <ApplicationParameters>
               <ApplicationParameter id="FSOE_SAFETY_PROJECT_CRC"/>
             </ApplicationParameters>
           </SafetyModule>
-          <SafetyModule uses_sra="true" module_ident="0x3b00001">
+          <SafetyModule uses_sra="true" module_ident="0x3b00004">
             <ApplicationParameters>
-              <ApplicationParameter id="FSOE_SS1_TIME_TO_STO_1"/>
-              <ApplicationParameter id="FSOE_SS1_VEL_ZERO_WINDOW_1"/>
-              <ApplicationParameter id="FSOE_SS1_TIME_FOR_VEL_ZERO_1"/>
-              <ApplicationParameter id="FSOE_SS1_DEC_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SS1_TIME_DELAY_DEC_1"/>
-              <ApplicationParameter id="FSOE_SOS_POS_ZERO_WINDOW_1"/>
-              <ApplicationParameter id="FSOE_SOS_VEL_ZERO_WINDOW_1"/>
-              <ApplicationParameter id="FSOE_SS2_TIME_TO_SOS_1"/>
-              <ApplicationParameter id="FSOE_SS2_TIME_FOR_VEL_ZERO_1"/>
-              <ApplicationParameter id="FSOE_SS2_DEC_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SS2_TIME_DELAY_DEC_1"/>
-              <ApplicationParameter id="FSOE_SS2_ERROR_REACTION_1"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_2"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_3"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_4"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_5"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_6"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_7"/>
-              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_8"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_2"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_3"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_4"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_5"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_6"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_7"/>
-              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_8"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_1"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_2"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_3"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_4"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_5"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_6"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_7"/>
-              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_8"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_2"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_3"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_4"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_5"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_6"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_7"/>
-              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_8"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_1"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_2"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_3"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_4"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_5"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_6"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_7"/>
-              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_8"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_2"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_3"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_4"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_5"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_6"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_7"/>
-              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_8"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_1"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_2"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_3"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_4"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_5"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_6"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_7"/>
-              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_8"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_1"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_2"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_3"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_4"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_5"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_6"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_7"/>
-              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_8"/>
-              <ApplicationParameter id="FSOE_SAFE_INPUTS_MAP"/>
-              <ApplicationParameter id="FSOE_SAFE_HOMING_REFERENCE"/>
-              <ApplicationParameter id="FSOE_FEEDBACK_SCENARIO"/>
-              <ApplicationParameter id="FSOE_POSITION_TOLERANCE"/>
-              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_REDUNDANT_TURNS"/>
-              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_MAIN_TURNS"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_FSIZE"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POL"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POSBITS"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_STURN"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_BAUD"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_TOUT"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_FSIZE"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_POL"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_PBITS"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_STURN"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_BAUD"/>
-              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_TOUT"/>
-              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_RESOLUTION"/>
-              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_POLARITY"/>
-              <ApplicationParameter id="FSOE_HALL_POLEPAIRS"/>
-              <ApplicationParameter id="FSOE_HALL_POLARITY"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_TOTAL"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_1"/>
               <ApplicationParameter id="ETG_COMMS_RPDO_MAP256_2"/>
@@ -16158,6 +16306,113 @@
               <ApplicationParameter id="ETG_COMMS_TPDO_MAP256_43"/>
               <ApplicationParameter id="ETG_COMMS_TPDO_MAP256_44"/>
               <ApplicationParameter id="ETG_COMMS_TPDO_MAP256_45"/>
+              <ApplicationParameter id="FSOE_SS1_TIME_TO_STO_1"/>
+              <ApplicationParameter id="FSOE_SS1_VEL_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SS1_TIME_FOR_VEL_ZERO_1"/>
+              <ApplicationParameter id="FSOE_SS1_DEC_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SS1_TIME_DELAY_DEC_1"/>
+              <ApplicationParameter id="FSOE_SOS_POS_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SOS_VEL_ZERO_WINDOW_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_TO_SOS_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_FOR_VEL_ZERO_1"/>
+              <ApplicationParameter id="FSOE_SS2_DEC_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SS2_TIME_DELAY_DEC_1"/>
+              <ApplicationParameter id="FSOE_SS2_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SSR_UPPER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SSR_LOWER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SSR_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLS_VELOCITY_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SLS_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLP_UPPER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_2"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_3"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_4"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_5"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_6"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_7"/>
+              <ApplicationParameter id="FSOE_SLP_LOWER_LIMIT_8"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_2"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_3"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_4"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_5"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_6"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_7"/>
+              <ApplicationParameter id="FSOE_SLP_ERROR_REACTION_8"/>
+              <ApplicationParameter id="FSOE_SLI_UPPER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLI_LOWER_LIMIT_1"/>
+              <ApplicationParameter id="FSOE_SLI_ERROR_REACTION_1"/>
+              <ApplicationParameter id="FSOE_SDI_POS_ZERO_WINDOW"/>
+              <ApplicationParameter id="FSOE_SAFE_INPUTS_MAP"/>
+              <ApplicationParameter id="FSOE_USER_OVER_TEMPERATURE"/>
+              <ApplicationParameter id="FSOE_SAFE_HOMING_REFERENCE"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_SCENARIO"/>
+              <ApplicationParameter id="FSOE_POSITION_TOLERANCE"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_REDUNDANT_TURNS"/>
+              <ApplicationParameter id="FSOE_FEEDBACK_RATIO_MAIN_TURNS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_FSIZE"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POL"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_POSBITS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_STURN"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_BAUD"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_PRIM1_TOUT"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_FSIZE"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_POL"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_PBITS"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_STURN"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_BAUD"/>
+              <ApplicationParameter id="FSOE_ABS_SSI_SECOND1_TOUT"/>
+              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_RESOLUTION"/>
+              <ApplicationParameter id="FSOE_INCREMENTAL_ENC_POLARITY"/>
+              <ApplicationParameter id="FSOE_HALL_POLEPAIRS"/>
+              <ApplicationParameter id="FSOE_HALL_POLARITY"/>
+              <ApplicationParameter id="FSOE_STO_ACTIVATE_SOUT"/>
+              <ApplicationParameter id="FSOE_SS1_ACTIVATE_SOUT_1"/>
+              <ApplicationParameter id="FSOE_SOUT_BRAKE_TIME_DELAY"/>
+              <ApplicationParameter id="FSOE_SOUT_DISABLE"/>
             </ApplicationParameters>
           </SafetyModule>
         </SafetyModules>

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -538,7 +538,7 @@ def test_optional_parameter_not_present():
     sto: STOFunction = next(STOFunction.for_handler(handler))
 
     assert sto.activate_sout is None
-    # TODO check that list does not contain the nones
+    assert sto.parameters == {}
 
 
 @pytest.mark.fsoe
@@ -549,7 +549,12 @@ def test_optional_parameter_present():
 
     sto: STOFunction = next(STOFunction.for_handler(handler))
 
-    sto.activate_sout is not None
+    assert sto.activate_sout is not None
+    assert len(sto.parameters) == 1
+    metadata, parameter = next(iter(sto.parameters.items()))
+    assert metadata.uid == "FSOE_STO_ACTIVATE_SOUT"
+    assert metadata.display_name == "Activate SOUT"
+    assert parameter is not None
 
 
 @pytest.mark.fsoe

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -39,6 +39,7 @@ if FSOE_MASTER_INSTALLED:
         SSRFunction,
         STOFunction,
         SVFunction,
+        SafetyParameter,
     )
     from ingeniamotion.fsoe_master.frame import FSoEFrame
     from ingeniamotion.fsoe_master.fsoe import (
@@ -522,6 +523,23 @@ def test_detect_safety_functions_ph2():
         SLPFunction,
         SLPFunction,
     ]
+
+@pytest.mark.fsoe
+def test_optional_parameter_not_present():
+    handler = MockHandler(SAMPLE_SAFE_PH1_XDFV3_DICTIONARY, 0x3800000)
+
+    sto: STOFunction = next(STOFunction.for_handler(handler))
+
+    assert sto.activate_sout is None
+    # TODO check that list does not contain the nones
+
+@pytest.mark.fsoe
+def test_optional_parameter_present():
+    handler = MockHandler(SAMPLE_SAFE_PH2_XDFV3_DICTIONARY, 0x3B00000)
+
+    sto: STOFunction = next(STOFunction.for_handler(handler))
+
+    assert isinstance(sto.activate_sout, SafetyParameter)
 
 
 @pytest.mark.fsoe

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -19,7 +19,11 @@ from ingeniamotion.enums import FSoEState
 from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED, FSoEError, FSoEMaster
 from ingeniamotion.motion_controller import MotionController
 from tests.conftest import add_fixture_error_checker, timeout_loop
-from tests.dictionaries import SAMPLE_SAFE_PH1_XDFV3_DICTIONARY, SAMPLE_SAFE_PH2_XDFV3_DICTIONARY
+from tests.dictionaries import (
+    SAMPLE_SAFE_PH1_XDFV3_DICTIONARY,
+    SAMPLE_SAFE_PH2_MODULE_IDENT_NO_SRA_MODULE_IDENT,
+    SAMPLE_SAFE_PH2_XDFV3_DICTIONARY,
+)
 
 if FSOE_MASTER_INSTALLED:
     from fsoe_master import fsoe_master
@@ -33,13 +37,13 @@ if FSOE_MASTER_INSTALLED:
         SLPFunction,
         SLSFunction,
         SOSFunction,
+        SOutFunction,
         SPFunction,
         SS1Function,
         SS2Function,
         SSRFunction,
         STOFunction,
         SVFunction,
-        SafetyParameter,
     )
     from ingeniamotion.fsoe_master.frame import FSoEFrame
     from ingeniamotion.fsoe_master.fsoe import (
@@ -481,7 +485,9 @@ def test_detect_safety_functions_ph1():
 
 @pytest.mark.fsoe
 def test_detect_safety_functions_ph2():
-    handler = MockHandler(SAMPLE_SAFE_PH2_XDFV3_DICTIONARY, 0x3B00000)
+    handler = MockHandler(
+        SAMPLE_SAFE_PH2_XDFV3_DICTIONARY, SAMPLE_SAFE_PH2_MODULE_IDENT_NO_SRA_MODULE_IDENT
+    )
 
     sf_types = [type(sf) for sf in SafetyFunction.for_handler(handler)]
 
@@ -491,7 +497,7 @@ def test_detect_safety_functions_ph2():
         SafeInputsFunction,
         SOSFunction,
         SS2Function,
-        # SOutFunction, Not implemented yet
+        SOutFunction,
         SPFunction,
         SVFunction,
         SafeHomingFunction,
@@ -524,6 +530,7 @@ def test_detect_safety_functions_ph2():
         SLPFunction,
     ]
 
+
 @pytest.mark.fsoe
 def test_optional_parameter_not_present():
     handler = MockHandler(SAMPLE_SAFE_PH1_XDFV3_DICTIONARY, 0x3800000)
@@ -533,13 +540,16 @@ def test_optional_parameter_not_present():
     assert sto.activate_sout is None
     # TODO check that list does not contain the nones
 
+
 @pytest.mark.fsoe
 def test_optional_parameter_present():
-    handler = MockHandler(SAMPLE_SAFE_PH2_XDFV3_DICTIONARY, 0x3B00000)
+    handler = MockHandler(
+        SAMPLE_SAFE_PH2_XDFV3_DICTIONARY, SAMPLE_SAFE_PH2_MODULE_IDENT_NO_SRA_MODULE_IDENT
+    )
 
     sto: STOFunction = next(STOFunction.for_handler(handler))
 
-    assert isinstance(sto.activate_sout, SafetyParameter)
+    sto.activate_sout is not None
 
 
 @pytest.mark.fsoe
@@ -563,7 +573,7 @@ def test_getter_of_safety_functions(mc_with_fsoe):
     _mc, handler = mc_with_fsoe
 
     # ruff: noqa: ERA001
-    sto_function = STOFunction(command=None, ios=None, parameters=None)
+    sto_function = STOFunction(command=None, activate_sout=None, ios=None, parameters=None)
     ss1_function_1 = SS1Function(
         command=None,
         time_to_sto=None,

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -577,19 +577,21 @@ def test_mandatory_safety_functions(mc_with_fsoe):
 def test_getter_of_safety_functions(mc_with_fsoe):
     _mc, handler = mc_with_fsoe
 
-    # ruff: noqa: ERA001
+    # ruff: noqa: ERA001ñ
     sto_function = STOFunction(command=None, activate_sout=None, ios=None, parameters=None)
     ss1_function_1 = SS1Function(
         command=None,
         time_to_sto=None,
         ios=None,
         parameters=None,
+        time_for_velocity_zero=None
     )
     ss1_function_2 = SS1Function(
         command=None,
         time_to_sto=None,
         ios=None,
         parameters=None,
+        time_for_velocity_zero=None
     )
 
     handler.safety_functions = (sto_function, ss1_function_1, ss1_function_2)

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -577,21 +577,12 @@ def test_mandatory_safety_functions(mc_with_fsoe):
 def test_getter_of_safety_functions(mc_with_fsoe):
     _mc, handler = mc_with_fsoe
 
-    # ruff: noqa: ERA001ñ
     sto_function = STOFunction(command=None, activate_sout=None, ios=None, parameters=None)
     ss1_function_1 = SS1Function(
-        command=None,
-        time_to_sto=None,
-        ios=None,
-        parameters=None,
-        time_for_velocity_zero=None
+        command=None, time_to_sto=None, ios=None, parameters=None, time_for_velocity_zero=None
     )
     ss1_function_2 = SS1Function(
-        command=None,
-        time_to_sto=None,
-        ios=None,
-        parameters=None,
-        time_for_velocity_zero=None
+        command=None, time_to_sto=None, ios=None, parameters=None, time_for_velocity_zero=None
     )
 
     handler.safety_functions = (sto_function, ss1_function_1, ss1_function_2)


### PR DESCRIPTION
### Pull request name 

On the STO and SS1 safety functions (from phase I), now phase II has additional parameters for them.
Thus these parameters are optional, which is new to the model of safety functions.
With this change it optional parameters can be indicated with type hints Optional[X]

### Description

Please include a summary of the change and which issue is fixed. 

Fixes #INGM-704

### Type of change

Please add a description and delete options that are not relevant.

- [x] Handle optionality of safety fields
- [x] Add optional parameters for ss1 and sto

### Tests
- [x] Update to PH2 test dictionary to latest one that contains the example
- [x] Update affected tests
- [x] Add test for optional parameter not present on PH1
- [x] Add test for optional parameter present on PH2

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
