### PR TITLE
Ingm 702 safety items metadata number not updating

### DIFF
--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -464,12 +464,12 @@ def test_detect_safety_functions_ph1():
     for metadata, parameter in ss1.parameters.items():
         assert parameter == ss1.time_to_sto
         assert metadata.display_name == "Time to STO"
-        assert metadata.uid == "FSOE_SS1_TIME_TO_STO_{i}"
+        assert metadata.uid == "FSOE_SS1_TIME_TO_STO_1"
     assert len(ss1.ios) == 1
     for metadata, io in ss1.ios.items():
         assert io == ss1.command
         assert metadata.display_name == "Command"
-        assert metadata.uid == "FSOE_SS1_{i}"
+        assert metadata.uid == "FSOE_SS1_1"
 
     # Safe inputs
     si = sf[2]


### PR DESCRIPTION
### Description

Added names and number of instances to the safety functions and properly updating the metadata for each field.

Fixes INGM-702 and INGM-695

### Type of change

Please add a description and delete options that are not relevant.

- [x] Added SF name as classvar and instance attribute
- [x] Added SF n_instance as instance attribute
- [x] Save the instance uid to the to the metadata dictionary

### Tests
- [x] Adapted tests to verify that the names and n_instances are being set correctly
- [x] Adapted tests to new uid value of the metadata

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
