### PR TITLE
INGM-711 change safety parameters for an ordereddict

### DIFF
--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -384,7 +384,11 @@ class FSoEMasterHandler:
         self.__maps = maps
 
     def configure_pdo_maps(self) -> None:
-        """Configure the PDOMaps used for the Safety PDUs according to the map."""
+        """Configure the PDOMaps used for the Safety PDUs according to the map.
+
+        Raises:
+            ValueError: If a register in the PDOMap has no identifier.
+        """
         if self.__maps.editable:
             # Fill the RPDOMap and TPDOMap with the items from the maps
             self.__maps.fill_rpdo_map(self.safety_master_pdu_map, self.__servo.dictionary)
@@ -398,6 +402,8 @@ class FSoEMasterHandler:
         # Update the pdo maps elements that are safe parameters
         for pdu_map in (self.safety_master_pdu_map, self.safety_slave_pdu_map):
             for register, mapping_value in pdu_map.map_register_values().items():
+                if register.identifier is None:
+                    raise ValueError("Register in PDOMap has no identifier")
                 if register.identifier in self.safety_parameters:
                     if mapping_value is None:
                         # Set parameter to zero if it is not mapped

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -1,4 +1,5 @@
 import threading
+from collections import OrderedDict
 from collections.abc import Iterator
 from pathlib import Path
 from random import randint
@@ -108,7 +109,7 @@ class FSoEMasterHandler:
 
         # Parameters that are part of the system
         # UID as key
-        self.safety_parameters: dict[str, SafetyParameter] = {}
+        self.safety_parameters = OrderedDict[str, SafetyParameter]()
 
         # Parameters that will be transmitted during the fsoe parameter state
         fsoe_application_parameters: list[FSoEApplicationParameter] = []


### PR DESCRIPTION
### Description

The implementation of safe parameters might look that the order of them is not relevant, while it truly is for direct parameter validation or CRC calculation.
Using OrderedDict Container now: https://docs.python.org/3/library/collections.html#collections.OrderedDict
It was not failing because latest python version the dictionary implementation seems to be ordered, but is just an implementation detail for https://peps.python.org/pep-0468/. Should not be relying on that

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [x] Change safety parameters for a ordereddict


### Tests
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [ ] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [ ] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
