### PR TITLE
Improve FSoE exceptions with error queues

### DIFF
--- a/examples/safety_mapping_example.py
+++ b/examples/safety_mapping_example.py
@@ -5,14 +5,7 @@ from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED
 from ingeniamotion.motion_controller import MotionController
 
 if FSOE_MASTER_INSTALLED:
-    from ingeniamotion.fsoe_master import (
-        SafeInputsFunction,
-        SOSFunction,
-        SS1Function,
-        SS2Function,
-        STOFunction,
-        SVFunction,
-    )
+    from ingeniamotion.fsoe_master import SafeInputsFunction, SS1Function, STOFunction
 
 
 def _error_callback(error):
@@ -43,9 +36,11 @@ def main(ifname, slave_id, dict_path) -> None:
     sto = handler.get_function_instance(STOFunction)
     safe_inputs = handler.get_function_instance(SafeInputsFunction)
     ss1 = handler.get_function_instance(SS1Function)
-    ss2 = handler.get_function_instance(SS2Function, instance=1)
-    sv = handler.get_function_instance(SVFunction)
-    sos = handler.get_function_instance(SOSFunction)
+
+    # Set feedback scenario to 0 and configure SS1 time controlled
+    # If Feedback scenario is set 0, no motion-dependent safety functions are allowed
+    handler.safety_parameters.get("FSOE_FEEDBACK_SCENARIO").set(0)
+    ss1.deceleration_limit.set(0)
 
     # The handler comes with a default mapping read from the drive.
     # Clear it to create a new one
@@ -56,9 +51,7 @@ def main(ifname, slave_id, dict_path) -> None:
     outputs = handler.maps.outputs
     outputs.add(sto.command)
     outputs.add(ss1.command)
-    outputs.add(sos.command)
-    outputs.add(ss2.command)
-    outputs.add_padding(4 + 8)
+    outputs.add_padding(6)
 
     # Configure Inputs Map
     inputs = handler.maps.inputs
@@ -76,9 +69,6 @@ def main(ifname, slave_id, dict_path) -> None:
     print(inputs.get_text_representation())
     print("Outputs Map:")
     print(outputs.get_text_representation())
-
-    # Configure Parameters
-    # safe_inputs.map.set(2)  # Linked to SS1 Instance
 
     # Configure the pdos the FSoE master handler
     if handler.sout_function():

--- a/examples/safety_mapping_example.py
+++ b/examples/safety_mapping_example.py
@@ -32,10 +32,10 @@ def main(ifname, slave_id, dict_path) -> None:
         FSoEFrameConstructionError: If the FSoE frame construction is invalid.
     """
     mc = MotionController()
-    # Connect to the servo drive
-    mc.communication.connect_servo_ethercat(ifname, slave_id, dict_path)
     # Configure error channel
     mc.fsoe.subscribe_to_errors(_error_callback)
+    # Connect to the servo drive
+    mc.communication.connect_servo_ethercat(ifname, slave_id, dict_path)
 
     # Create and start the FSoE master handler
     handler = mc.fsoe.create_fsoe_master_handler(use_sra=True)

--- a/examples/safety_mapping_example.py
+++ b/examples/safety_mapping_example.py
@@ -32,10 +32,10 @@ def main(ifname, slave_id, dict_path) -> None:
         FSoEFrameConstructionError: If the FSoE frame construction is invalid.
     """
     mc = MotionController()
-    # Configure error channel
-    mc.fsoe.subscribe_to_errors(_error_callback)
     # Connect to the servo drive
     mc.communication.connect_servo_ethercat(ifname, slave_id, dict_path)
+    # Configure error channel
+    mc.fsoe.subscribe_to_errors(_error_callback)
 
     # Create and start the FSoE master handler
     handler = mc.fsoe.create_fsoe_master_handler(use_sra=True)
@@ -110,6 +110,8 @@ def main(ifname, slave_id, dict_path) -> None:
             ss1.command.set(1)
             # And inputs can be read
             print(f"Safe Inputs Value: {safe_inputs.value.get()}")
+    except Exception as e:
+        print(e)
     finally:
         try:
             # Stop the FSoE master handler

--- a/examples/safety_torque_off.py
+++ b/examples/safety_torque_off.py
@@ -90,6 +90,8 @@ def main(ifname, slave_id, dict_path, config_file=None):
         mc.fsoe.sto_activate()
         # Restore fail safe
         mc.fsoe.set_fail_safe(True)
+    except Exception as e:
+        print(e)
     finally:
         try:
             # Stop the FSoE master handler

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -107,12 +107,8 @@ class FSoEMasterHandler:
         self.__state_is_data = threading.Event()
 
         # Error queues
-        self.__mcua_error_queue: Optional[ServoErrorQueue] = ServoErrorQueue(
-            MCUA_ERROR_QUEUE, self.__servo
-        )
-        self.__mcub_error_queue: Optional[ServoErrorQueue] = ServoErrorQueue(
-            MCUB_ERROR_QUEUE, self.__servo
-        )
+        self.__mcua_error_queue: ServoErrorQueue = ServoErrorQueue(MCUA_ERROR_QUEUE, self.__servo)
+        self.__mcub_error_queue: ServoErrorQueue = ServoErrorQueue(MCUB_ERROR_QUEUE, self.__servo)
 
         # The saco slave might take a while to answer with a valid command
         # During it's initialization it will respond with 0's, that are ignored

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -16,6 +16,11 @@ from ingenialink.utils._utils import convert_dtype_to_bytes
 from ingeniamotion._utils import weak_lru
 from ingeniamotion.enums import FSoEState
 from ingeniamotion.exceptions import IMTimeoutError
+from ingeniamotion.fsoe_master.errors import (
+    MCUA_ERROR_QUEUE,
+    MCUB_ERROR_QUEUE,
+    ServoErrorQueue,
+)
 from ingeniamotion.fsoe_master.fsoe import (
     FSOE_MASTER_INSTALLED,
     BaseMasterHandler,
@@ -100,6 +105,14 @@ class FSoEMasterHandler:
         self.net.pdo_manager.subscribe_to_exceptions(self._pdo_thread_exception_handler)
 
         self.__state_is_data = threading.Event()
+
+        # Error queues
+        self.__mcua_error_queue: Optional[ServoErrorQueue] = ServoErrorQueue(
+            MCUA_ERROR_QUEUE, self.__servo
+        )
+        self.__mcub_error_queue: Optional[ServoErrorQueue] = ServoErrorQueue(
+            MCUB_ERROR_QUEUE, self.__servo
+        )
 
         # The saco slave might take a while to answer with a valid command
         # During it's initialization it will respond with 0's, that are ignored
@@ -719,7 +732,11 @@ class FSoEMasterHandler:
 
         """
         if self.__state_is_data.wait(timeout=timeout) is False:
-            raise IMTimeoutError("The FSoE Master did not reach the Data state")
+            raise IMTimeoutError(
+                "The FSoE Master did not reach the Data state"
+                f"\nMCUA last error: {self.__mcua_error_queue.get_last_error()}"
+                f"\nMCUB last error: {self.__mcub_error_queue.get_last_error()}"
+            )
 
     @classmethod
     def create_safe_dictionary(cls, dictionary: "EthercatDictionary") -> "FSoEDictionary":

--- a/ingeniamotion/fsoe_master/parameters.py
+++ b/ingeniamotion/fsoe_master/parameters.py
@@ -97,3 +97,8 @@ class SafetyParameterDirectValidation(SafetyParameter):
     def set(self, value: Union[int, float, str, bytes]) -> None:
         super().set(value)
         self.fsoe_application_parameter.set(value)
+
+    @override
+    def set_without_updating(self, value: Union[int, float, str, bytes]) -> None:
+        super().set_without_updating(value)
+        self.fsoe_application_parameter.set(value)

--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -306,7 +306,11 @@ class PDONetworksTracker:
         if not self.is_network_tracked(alias):
             raise IMError(f"PDOs are not active yet for network '{alias}'.")
         net = self.__networks[alias]
-        net.network.deactivate_pdos()
+        # If the exception has happened when starting the PDOs, the PDOs are not active yet
+        if not net.network.pdo_manager.is_active:
+            logger.warning("PDOs are not active for this network.")
+        else:
+            net.network.deactivate_pdos()
         net.teardown()
         del self.__networks[alias]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1065,21 +1065,21 @@ woff = ["brotli (>=1.0.1) ; platform_python_implementation == \"CPython\"", "bro
 
 [[package]]
 name = "fsoe-master"
-version = "0.1.4+g9115368a2"
+version = "0.1.4+gfcfd7bd86"
 description = "FSoE Master Library"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"fsoe\""
 files = [
-    {file = "fsoe_master-0.1.4+g9115368a2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f404866bc0c06eaf162fb5d1c58415ae38045c617fc31019a02abfa4173a9088"},
-    {file = "fsoe_master-0.1.4+g9115368a2-cp310-cp310-win_amd64.whl", hash = "sha256:e539e315f6b8bc0b81c954cc473146db8d6da3abfcb08f73956b048fe7f1975a"},
-    {file = "fsoe_master-0.1.4+g9115368a2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fa4f7cd00c14e6270c4eee3f8758f6574067e9b83f9f8ccf2788d3ae4bf64eb"},
-    {file = "fsoe_master-0.1.4+g9115368a2-cp311-cp311-win_amd64.whl", hash = "sha256:f60cc52a33916cecf14f9a2095f47cf9fce5cdcded99ae78e833252d97ab9f02"},
-    {file = "fsoe_master-0.1.4+g9115368a2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61508b9994379f50b9f1c5fbcbb8b40502cc5c324552ed108a2b8cfe12093ba9"},
-    {file = "fsoe_master-0.1.4+g9115368a2-cp312-cp312-win_amd64.whl", hash = "sha256:cb34532b2565745cb8ce8714fbfc29626eaba33ed1f7a900f0a63570dd1bf93a"},
-    {file = "fsoe_master-0.1.4+g9115368a2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37e4efaf8ac0141ac33948256ddd100bff62b4439165ad1d899f6e9cbe6d2873"},
-    {file = "fsoe_master-0.1.4+g9115368a2-cp39-cp39-win_amd64.whl", hash = "sha256:91bba9833a653ffb384c164b0eafbdc03c91dac60f40ed60ab138ac32d62bc00"},
+    {file = "fsoe_master-0.1.4+gfcfd7bd86-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17a855b8043dabdce45faa49bba82b9c43aa8394d1aa8c9f2b5ae84b0746bf40"},
+    {file = "fsoe_master-0.1.4+gfcfd7bd86-cp310-cp310-win_amd64.whl", hash = "sha256:4edfd4131608845d4ad9edf23f903707a15674e7d6a13acafbc4822974886851"},
+    {file = "fsoe_master-0.1.4+gfcfd7bd86-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:931f52de92b39a18a1ea191a93df3c85cf533ee7945c5b99d7a2ef325308a48d"},
+    {file = "fsoe_master-0.1.4+gfcfd7bd86-cp311-cp311-win_amd64.whl", hash = "sha256:7ee65826453c11c117d66474f7d7faa3aa76c9629fd2fab856d20415bc35e8e2"},
+    {file = "fsoe_master-0.1.4+gfcfd7bd86-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:767373cb376a1eb04b3836baa91b4ff24ff2127dd5b3ec4a2f15160aecdae532"},
+    {file = "fsoe_master-0.1.4+gfcfd7bd86-cp312-cp312-win_amd64.whl", hash = "sha256:40e4861b0bea8c51bdb9b37ed2123517d35bea183b3c6b83e8e3a11a6800081c"},
+    {file = "fsoe_master-0.1.4+gfcfd7bd86-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4584dba3c172ac3ff5da91f263e00e5218ea62393401fb4db218d1b3a17219a2"},
+    {file = "fsoe_master-0.1.4+gfcfd7bd86-cp39-cp39-win_amd64.whl", hash = "sha256:4b33dcab435d4e3f08d14636e626e59457f35ef87b0eaa58ce4cd89c2806bc03"},
 ]
 
 [package.source]
@@ -4619,4 +4619,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "d38dd3747d56b65a110cfc7ae63bd59566fde3154f18e2d866af26ba60afde95"
+content-hash = "8ded9b04891cb3cc84f2d01580f23c987170b5dfe2d5cbecff6afa4b7ef878a2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-fsoe = ["fsoe_master==0.1.4+g9115368a2"]
+fsoe = ["fsoe_master==0.1.4+gfcfd7bd86"]
 
 [tool.poetry]
 version = "0.9.2"  # base version

--- a/tests/fsoe/conftest.py
+++ b/tests/fsoe/conftest.py
@@ -24,6 +24,8 @@ from tests.test_fsoe_master import (
     fsoe_states,  # noqa: F401
     mc_with_fsoe_factory,  # noqa: F401
     mc_with_fsoe_with_sra,  # noqa: F401
+    mcu_error_queue_a,  # noqa: F401
+    mcu_error_queue_b,  # noqa: F401
 )
 
 if FSOE_MASTER_INSTALLED:

--- a/tests/fsoe/test_safety_errors.py
+++ b/tests/fsoe/test_safety_errors.py
@@ -97,11 +97,8 @@ def test_get_last_error_overtemp_error(servo, mcu_error_queue_a, environment):
 
 
 @pytest.mark.fsoe_phase2
-@pytest.mark.skip("https://novantamotion.atlassian.net/browse/SACOAPP-314")
-def test_get_last_error_feedback_combination(
-    mcu_error_queue_a, mcu_error_queue_b, mc_with_fsoe_factory, environment
-):
-    """Test getting the last error when there is a feedback combination error."""
+def test_get_last_error_invalid_map(mcu_error_queue_a, mc_with_fsoe_factory, environment):
+    """Test getting the last error when there is an invalid map error."""
     environment.power_cycle(wait_for_drives=True)
 
     mc, handler = mc_with_fsoe_factory(use_sra=True, fail_on_fsoe_errors=False)
@@ -129,13 +126,11 @@ def test_get_last_error_feedback_combination(
     time.sleep(TIMEOUT_FOR_DATA_SRA)
     try:
         assert mcu_error_queue_a.get_number_total_errors() == 1
-        assert mcu_error_queue_b.get_number_total_errors() == 1
-        assert mcu_error_queue_a.get_last_error().error_id == 0x90090701
-        assert mcu_error_queue_b.get_last_error().error_id == 0x90090701
+        assert mcu_error_queue_a.get_last_error().error_id == 0x80040002
 
         errors_a, errors_losts = mcu_error_queue_a.get_pending_errors()
         assert len(errors_a) == 1
-        assert errors_a[0].error_id == 0x90090701
+        assert errors_a[0].error_id == 0x80040002
 
         assert not errors_losts
     finally:

--- a/tests/fsoe/test_safety_errors.py
+++ b/tests/fsoe/test_safety_errors.py
@@ -97,6 +97,7 @@ def test_get_last_error_overtemp_error(servo, mcu_error_queue_a, environment):
 
 
 @pytest.mark.fsoe_phase2
+@pytest.mark.skip("https://novantamotion.atlassian.net/browse/SACOAPP-314")
 def test_get_last_error_feedback_combination(
     mcu_error_queue_a, mcu_error_queue_b, mc_with_fsoe_factory, environment
 ):

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -56,14 +56,14 @@ ECAT_DEN_S_PHASE2_SETUP = RackServiceConfigSpecifier.from_firmware(
     interface=Interface.ECAT,
     config_file=None,
     firmware=Path(
-        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.2/den-s-net-e_2.9.0.lfu"
+        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.5/den-s-net-e_2.9.0.lfu"
     ),
     dictionary=Path(
-        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.2/den-s-net-e_2.9.0.002_v3.xdf"
+        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.5/den-s-net-e_2.9.0.005_v3.xdf"
     ),
     extra_data={
         "esi_file": Path(
-            "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.2/den-s-net-e_esi_2.9.0.002.xml"
+            "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.5/den-s-net-e_esi_2.9.0.005.xml"
         )
     },
 )

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -56,14 +56,14 @@ ECAT_DEN_S_PHASE2_SETUP = RackServiceConfigSpecifier.from_firmware(
     interface=Interface.ECAT,
     config_file=None,
     firmware=Path(
-        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.5/den-s-net-e_2.9.0.lfu"
+        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.6/den-s-net-e_2.9.0.lfu"
     ),
     dictionary=Path(
-        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.5/den-s-net-e_2.9.0.005_v3.xdf"
+        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.6/den-s-net-e_2.9.0.006_v3.xdf"
     ),
     extra_data={
         "esi_file": Path(
-            "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.5/den-s-net-e_esi_2.9.0.005.xml"
+            "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.6/den-s-net-e_esi_2.9.0.006.xml"
         )
     },
 )

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -118,9 +118,9 @@ class FSoEErrorDisplay:
 
     error: FSoEError
     """Main error that was reported."""
-    mcua_last_error: Optional[Error]
+    mcua_last_error: Optional["Error"]
     """Last error in MCUA error queue."""
-    mcub_last_error: Optional[Error]
+    mcub_last_error: Optional["Error"]
     """Last error in MCUB error queue."""
     states: list[FSoEState]
     """State transitions that occurred until the error."""

--- a/tests/test_fsoe_master.py
+++ b/tests/test_fsoe_master.py
@@ -235,10 +235,10 @@ def mc_with_fsoe_factory(request, mc, fsoe_states):
             mc.fsoe.subscribe_to_errors(request.getfixturevalue(fsoe_error_monitor.__name__))
         created_handlers.append(handler)
         # If phase II, initialize the handler with the default mapping
+        # and set feedback scenario to 0
         if handler.maps.editable:
             __set_default_phase2_mapping(handler)
-
-        handler.safety_parameters.get("FSOE_FEEDBACK_SCENARIO").set(0)
+            handler.safety_parameters.get("FSOE_FEEDBACK_SCENARIO").set(0)
 
         if handler.sout_function() is not None:
             handler.sout_disable()


### PR DESCRIPTION
### Description

Add last error information to FSoE exception if servo cannot reach data state. 

### Type of change

Please add a description and delete options that are not relevant.

- [X] Improve INGM network PDO teardown. If there was an exception when activating the PDOs, the PDOs were not active but INGM tried to stop them, so an exception was triggered (this is already properly handled in INGK)
- [X] Add last error information to FSoE exception if servo cannot reach data state. 
- [X] Print exceptions in `safety_torque_off.py` and `safety_mapping_example.py` for better debugging
- [X] Updated DEN-S-NET-E phase II specifier to `2.9.0.6`.
- [X] Fixed bug in `set_without_updating` for direct validation parameters -> fsoe aplication parameter was not being set when configuring the PDOs, which caused a mismatch between the information that the master set on the slave and the information that the master actually send to the slave.
- [X] Updated `safety_mapping_example.py` map -> the previous map was invalid with feedback scenario 0
- [X] Skipped `test_get_last_error_feedback_combination`, the map is indeed invalid and should trigger an invalid map error (`0x80040002`) -> waiting for FW fix


### Tests
- [ ] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [X] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [ ] Set fix version field in the Jira issue.
