### PR TITLE
INGM-712 Fix get_error_by_index

### DIFF
--- a/ingeniamotion/fsoe_master/errors.py
+++ b/ingeniamotion/fsoe_master/errors.py
@@ -152,7 +152,7 @@ class ServoErrorQueue:
         """
         self.__servo.write(self.descriptor.error_request_index_reg_uid, index)
         return Error.from_id(
-            self.__read_int_reg(self.descriptor.error_request_code_reg_uid),
+            self.__read_int_reg(self.descriptor.error_request_code_reg_uid), self.__dictionary
         )
 
     def __get_pending_error_indexes(


### PR DESCRIPTION
### Description

The error description was not retrieved when calling the get_error_by_index because the dictionary was not being passed to the Error class.

### Type of change

- Pass the dictionary reference to the Error class.


### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.


### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [x] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
