### PR TITLE
Ingm 721 Fix and update safety functions name

### DIFF
--- a/ingeniamotion/fsoe_master/safety_functions.py
+++ b/ingeniamotion/fsoe_master/safety_functions.py
@@ -323,7 +323,7 @@ class STOFunction(SafetyFunction):
 class SS1Function(SafetyFunction):
     """Safe Stop 1 Safety Function."""
 
-    name = "Safe Stop {i}"
+    name = "Safe Stop 1 instance {i}"
 
     COMMAND_UID = "FSOE_SS1_{i}"
 
@@ -424,7 +424,7 @@ class SafeInputsFunction(SafetyFunction):
 class SOSFunction(SafetyFunction):
     """Safe Operation Stop Safety Function."""
 
-    name = "Safe Operation Stop {i}"
+    name = "Safe Operation Stop instance {i}"
 
     command: FSoEDictionaryItemInputOutput = safety_field(
         uid="FSOE_SOS_{i}", display_name="Command"
@@ -453,7 +453,7 @@ class SOSFunction(SafetyFunction):
 class SS2Function(SafetyFunction):
     """Safe Stop 2 Safety Function."""
 
-    name = "Safe Stop 2 {i}"
+    name = "Safe Stop 2 instance {i}"
 
     command: FSoEDictionaryItemInputOutput = safety_field(
         uid="FSOE_SS2_{i}", display_name="Command"
@@ -580,7 +580,7 @@ class SafeHomingFunction(SafetyFunction):
 class SLSFunction(SafetyFunction):
     """Safe Limited Speed Safety Function."""
 
-    name = "Safe Limited Speed {i}"
+    name = "Safe Limited Speed instance {i}"
 
     command: FSoEDictionaryItemInputOutput = safety_field(
         uid="FSOE_SLS_CMD_{i}", display_name="Command"
@@ -604,7 +604,7 @@ class SLSFunction(SafetyFunction):
 class SSRFunction(SafetyFunction):
     """Safe Speed Range Safety Function."""
 
-    name = "Safe Speed Range {i}"
+    name = "Safe Speed Range instance {i}"
 
     command: FSoEDictionaryItemInputOutput = safety_field(
         uid="FSOE_SSR_COMMAND_{i}", display_name="Command"
@@ -631,7 +631,7 @@ class SSRFunction(SafetyFunction):
 class SLPFunction(SafetyFunction):
     """Safe Limited Position Safety Function."""
 
-    name = "Safe Limited Position {i}"
+    name = "Safe Limited Position instance {i}"
 
     command: FSoEDictionaryItemInputOutput = safety_field(
         uid="FSOE_SLP_COMMAND_{i}", display_name="Command"
@@ -676,7 +676,7 @@ class SDIFunction(SafetyFunction):
 class SLIFunction(SafetyFunction):
     """Safe Limited Increment Safety Function."""
 
-    name = "Safe Limited Increment {i}"
+    name = "Safe Limited Increment instance {i}"
 
     command: FSoEDictionaryItemInputOutput = safety_field(
         uid="FSOE_SLI_COMMAND_{i}", display_name="Command"

--- a/tests/fsoe/test_safety_functions.py
+++ b/tests/fsoe/test_safety_functions.py
@@ -67,7 +67,7 @@ def test_detect_safety_functions_ph1() -> None:
     ss1 = sf[1]
     assert isinstance(ss1, SS1Function)
     assert ss1.n_instance == 1
-    assert ss1.name == "Safe Stop 1"
+    assert ss1.name == "Safe Stop 1 instance 1"
     assert isinstance(ss1.command, FSoEDictionaryItemInputOutput)
     assert len(ss1.parameters) == 1
     for metadata, parameter in ss1.parameters.items():


### PR DESCRIPTION
### Description

Current SafetyFunction naming for SafetyFunctions that can have multiple instances is a bit confusing. ex: “Safe Stop 2 1“, “Safe Stop 2 2“, “Safe Stop 2 3“…

Replace by less confusing naming that differentiates better the instance number. ex: “Safe Stop 2 instance 1“, “Safe Stop 2 instance 2“, “Safe Stop 2 instance 3“…

Fixes # INGM-721

### Type of change

- [x] Update Safety Functions naming


### Tests
- [x] Fix tests.
- [ ] Run tests.


### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Use [type hints](https://docs.python.org/3/library/typing.html) for every function and argument.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [ ] Use the ruff package to format the code: `ruff format ingeniamotion tests`.
- [ ] Use the ruff package to lint the code: `ruff check ingeniamotion tests`.

### Others

- [x] Set fix version field in the Jira issue.
