### PR TITLE
CIT-546 remove motion_controller_teadown

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4169,13 +4169,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.1.5+pr61b8"
+version = "0.1.5+pr62b1"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.1.5+pr61b8-py3-none-any.whl", hash = "sha256:7af4a8a9f992820a26b957ae0023b64d75b4afefe3d50ca06803acbc927c188a"},
+    {file = "summit_testing_framework-0.1.5+pr62b1-py3-none-any.whl", hash = "sha256:984ff271ceb9022d77e1606d19ed5c9d7a49d3f6af763a034b66616e12f03ddf"},
 ]
 
 [package.dependencies]
@@ -4754,4 +4754,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "fdadefced5278e5d3121004634d07d904d701abd6288906d4cfe3bf8deecce0e"
+content-hash = "d3c77ead122273e466b4612109b6812b8313375963339b2030e3f5bb556e3897"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
 ingenialink = {extras = ["virtual_drive"], version = "7.5.2+pr681b4"}
-summit-testing-framework = {version = "==0.1.5+pr61b8"}
+summit-testing-framework = {version = "==0.1.5+pr62b1"}
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -1,6 +1,7 @@
 import contextlib
 import time
 from threading import Thread
+from typing import TYPE_CHECKING
 
 import pytest
 from ingenialink import exceptions
@@ -20,6 +21,9 @@ from ingeniamotion.wizard_tests.feedbacks_tests.digital_incremental2_test import
 from ingeniamotion.wizard_tests.feedbacks_tests.secondary_ssi_test import SecondarySSITest
 from ingeniamotion.wizard_tests.phase_calibration import Phasing
 from ingeniamotion.wizard_tests.phasing_check import PhasingCheck
+
+if TYPE_CHECKING:
+    from ingeniamotion.motion_controller import MotionController
 
 CURRENT_QUADRATURE_SET_POINT_REGISTER = "CL_CUR_Q_SET_POINT"
 RATED_CURRENT_REGISTER = "MOT_RATED_CURRENT"
@@ -137,8 +141,7 @@ def test_secondary_ssi_test(mc, alias, feedback_list):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-def test_commutation(alias, motion_controller_teardown):
-    mc = motion_controller_teardown
+def test_commutation(alias: str, mc: "MotionController") -> None:
     results = mc.tests.commutation(servo=alias)
     assert results["result_severity"] == SeverityLevel.SUCCESS
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,4 +1,5 @@
 import os
+from typing import TYPE_CHECKING
 
 import pytest
 from ingenialink import CanBaudrate
@@ -13,6 +14,9 @@ from ingeniamotion.enums import (
     STOAbnormalLatchedStatus,
 )
 from ingeniamotion.exceptions import IMError
+
+if TYPE_CHECKING:
+    from ingeniamotion.motion_controller import MotionController
 
 BRAKE_OVERRIDE_REGISTER = "MOT_BRAKE_OVERRIDE"
 POSITION_SET_POINT_REGISTER = "CL_POS_SET_POINT_VALUE"
@@ -214,9 +218,8 @@ def test_get_power_stage_frequency_enum(mc, alias):
 
 @pytest.mark.virtual
 @pytest.mark.parametrize("input_value", [0, 1, 2, 3])
-def test_set_power_stage_frequency(motion_controller_teardown, alias, input_value):
+def test_set_power_stage_frequency(mc: "MotionController", alias: str, input_value: int) -> None:
     input_value = 0
-    mc = motion_controller_teardown
     mc.configuration.set_power_stage_frequency(input_value, servo=alias)
     output_value = mc.communication.get_register(
         POWER_STAGE_FREQUENCY_SELECTION_REGISTER, servo=alias
@@ -314,23 +317,22 @@ def test_set_generator_mode(mc, alias):
 
 
 @pytest.mark.virtual
-def test_set_motor_pair_poles(motion_controller_teardown, alias):
+def test_set_motor_pair_poles(mc: "MotionController", alias: str) -> None:
     input_value = 0
-    mc = motion_controller_teardown
     mc.configuration.set_motor_pair_poles(input_value, servo=alias)
     output_value = mc.communication.get_register(MOTOR_POLE_PAIRS_REGISTER, servo=alias)
     assert pytest.approx(input_value) == output_value
 
 
 @pytest.mark.virtual
-def test_get_motor_pair_poles(mc, alias):
+def test_get_motor_pair_poles(mc: "MotionController", alias: str) -> None:
     test_value = mc.configuration.get_motor_pair_poles(servo=alias)
     reg_value = mc.communication.get_register(MOTOR_POLE_PAIRS_REGISTER, servo=alias)
     assert test_value == reg_value
 
 
 @pytest.mark.virtual
-def test_get_sto_status(mc, alias):
+def test_get_sto_status(mc: "MotionController", alias: str) -> None:
     test_value = mc.configuration.get_sto_status(servo=alias)
     reg_value = mc.communication.get_register(STO_STATUS_REGISTER, servo=alias)
     assert test_value == reg_value
@@ -567,8 +569,7 @@ def test_change_node_id_exception(mc, alias):
 
 
 @pytest.mark.virtual
-def test_set_velocity_pid(motion_controller_teardown, alias):
-    mc = motion_controller_teardown
+def test_set_velocity_pid(mc: "MotionController", alias: str) -> None:
     kp_test = 1
     ki_test = 2
     kd_test = 3
@@ -582,8 +583,7 @@ def test_set_velocity_pid(motion_controller_teardown, alias):
 
 
 @pytest.mark.virtual
-def test_set_position_pid(motion_controller_teardown, alias):
-    mc = motion_controller_teardown
+def test_set_position_pid(mc: "MotionController", alias: str) -> None:
     kp_test = 1
     ki_test = 2
     kd_test = 3

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
@@ -9,6 +9,12 @@ from ingeniamotion.enums import OperationMode
 from ingeniamotion.exceptions import IMTimeoutError
 from ingeniamotion.motion import Motion
 from tests.conftest import mean_actual_velocity_position
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from ingeniamotion.motion_controller import MotionController
+
 
 POS_PID_KP_VALUE = 0.1
 POSITION_PERCENTAGE_ERROR_ALLOWED = 5
@@ -108,9 +114,13 @@ def test_motor_enable(mc, alias):
     ],
 )
 def test_motor_enable_with_fault(
-    motion_controller_teardown, alias, uid, value, exception_type, message
-):
-    mc = motion_controller_teardown
+    mc: "MotionController",
+    alias: str,
+    uid: str,
+    value: int,
+    exception_type: Exception,
+    message: str,
+) -> None:
     mc.communication.set_register(uid, value, alias)
     with pytest.raises(exception_type) as excinfo:
         mc.motion.motor_enable(servo=alias)
@@ -140,9 +150,15 @@ def test_motor_enable_with_fault(
     ],
 )
 def test_motor_enable_with_delayed_fault(
-    mocker, motion_controller_teardown, alias, uid, value, exception_type, message, timeout
+    mocker: "MockerFixture",
+    mc: "MotionController",
+    alias: str,
+    uid: str,
+    value: int,
+    exception_type: Exception,
+    message: str,
+    timeout: int,
 ):
-    mc = motion_controller_teardown
     # Mock function response with delay
     num_errors_before_test = mc.errors.get_number_total_errors(servo=alias, axis=1)
     patch_get_number_total_errors = mocker.patch(
@@ -172,11 +188,10 @@ def test_motor_disable(mc, alias, enable_motor):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-def test_motor_disable_with_fault(motion_controller_teardown, alias):
+def test_motor_disable_with_fault(mc: "MotionController", alias: str) -> None:
     uid = "DRV_PROT_USER_UNDER_VOLT"
     value = 100
     exception_type = exceptions.ILError
-    mc = motion_controller_teardown
     mc.communication.set_register(uid, value, alias)
     with pytest.raises(exception_type):
         mc.motion.motor_enable(servo=alias)
@@ -187,8 +202,7 @@ def test_motor_disable_with_fault(motion_controller_teardown, alias):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-def test_fault_reset(motion_controller_teardown, alias):
-    mc = motion_controller_teardown
+def test_fault_reset(mc: "MotionController", alias: str) -> None:
     uid = "DRV_PROT_USER_UNDER_VOLT"
     value = 100
     mc.communication.set_register(uid, value, alias)
@@ -379,8 +393,9 @@ def test_wait_for_function_timeout(mc, alias, function):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("op_mode", [OperationMode.VOLTAGE, OperationMode.CURRENT])
-def test_set_internal_generator_configuration(motion_controller_teardown, alias, op_mode):
-    mc = motion_controller_teardown
+def test_set_internal_generator_configuration(
+    mc: "MotionController", alias: str, op_mode: "OperationMode"
+) -> None:
     mc.motion.set_internal_generator_configuration(op_mode, servo=alias)
     assert op_mode == mc.motion.get_operation_mode(servo=alias)
     assert mc.configuration.get_motor_pair_poles(servo=alias) == 1
@@ -391,8 +406,9 @@ def test_set_internal_generator_configuration(motion_controller_teardown, alias,
 @pytest.mark.canopen
 @pytest.mark.parametrize("op_mode", [OperationMode.VOLTAGE, OperationMode.CURRENT])
 @pytest.mark.parametrize("direction", [-1, 1])
-def test_internal_generator_saw_tooth_move(motion_controller_teardown, alias, op_mode, direction):
-    mc = motion_controller_teardown
+def test_internal_generator_saw_tooth_move(
+    mc: "MotionController", alias: str, op_mode: "OperationMode", direction: int
+) -> None:
     pair_poles = mc.configuration.get_motor_pair_poles(servo=alias)
     pos_resolution = mc.configuration.get_position_feedback_resolution(servo=alias)
     mc.motion.set_internal_generator_configuration(op_mode, servo=alias)
@@ -419,8 +435,9 @@ def test_internal_generator_saw_tooth_move(motion_controller_teardown, alias, op
 @pytest.mark.canopen
 @pytest.mark.parametrize("op_mode", [OperationMode.VOLTAGE, OperationMode.CURRENT])
 @pytest.mark.parametrize("direction", [-1, 1])
-def test_internal_generator_constant_move(motion_controller_teardown, alias, op_mode, direction):
-    mc = motion_controller_teardown
+def test_internal_generator_constant_move(
+    mc: "MotionController", alias: str, op_mode: "OperationMode", direction: int
+) -> None:
     pair_poles = mc.configuration.get_motor_pair_poles(servo=alias)
     pos_resolution = mc.configuration.get_position_feedback_resolution(servo=alias)
     cycle_pos = pos_resolution / pair_poles


### PR DESCRIPTION
### Description

Replace motion controller teardown fixture by standard motion controller fixture in tests.  

### Type of change

Please add a description and delete options that are not relevant.

- [X] Replaced `motion_controller_teardown` by `mc`
- [X] Updated `summit-testing-framework` wheel


### Tests
- [X] Run Jenkins tests and verify that everything passes.

Please describe the manual tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).