### PR TITLE
Cit 554 create valid versions for product and not valid for product markers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,6 +68,7 @@ def runTest(run_identifier, markers, setup_name, extra_args = "", useWireshark =
                             "--job_name=\"${env.JOB_NAME}-#${env.BUILD_NUMBER}-${run_identifier}\"",
                             "--tb=long",
                             "-o log_cli=True",
+                            "--enable_firmware_version_check",
                             effectiveExtraArgs
                         ].findAll { it }.join(" ")
                         

--- a/poetry.lock
+++ b/poetry.lock
@@ -4169,13 +4169,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.2.0+pr69b4"
+version = "0.2.0+pr69b5"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.2.0+pr69b4-py3-none-any.whl", hash = "sha256:11096d004091ff629c138bfff0a57b2c9624be3ac7ada0c81af331909660e316"},
+    {file = "summit_testing_framework-0.2.0+pr69b5-py3-none-any.whl", hash = "sha256:019a313575e5a597ea3d6af574dc2a28174e820c96bd7fac1f8f9d12c4391088"},
 ]
 
 [package.dependencies]
@@ -4754,4 +4754,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "e2af79bde8f1cbad4554b1d75d45c582236993bfcdecd4b60833aac488af21b1"
+content-hash = "eab3a6f54547fe51492766690578f9ef8ab0c7c2777ba338e06ca342c8b26c90"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4169,13 +4169,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.2.0+pr70b5"
+version = "0.2.0+pr69b4"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.2.0+pr70b5-py3-none-any.whl", hash = "sha256:4d97b38bda40efa7352df689b2c7faef95c7eeb168c376041c8bacc1c2a9204c"},
+    {file = "summit_testing_framework-0.2.0+pr69b4-py3-none-any.whl", hash = "sha256:11096d004091ff629c138bfff0a57b2c9624be3ac7ada0c81af331909660e316"},
 ]
 
 [package.dependencies]
@@ -4754,4 +4754,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "27dfc7fe529c51bc001f2c471043e0a1c2fa72b19ee7d1e9af7a522f62defb39"
+content-hash = "e2af79bde8f1cbad4554b1d75d45c582236993bfcdecd4b60833aac488af21b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
 ingenialink = {extras = ["virtual_drive"], version = "7.5.2+pr685b1"}
-summit-testing-framework = {version = "==0.2.0+pr70b5"}
+summit-testing-framework = {version = "==0.2.0+pr69b4"}
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
 ingenialink = {extras = ["virtual_drive"], version = "7.5.2+pr685b1"}
-summit-testing-framework = {version = "==0.2.0+pr69b4"}
+summit-testing-framework = {version = "==0.2.0+pr69b5"}
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,8 @@ markers =
     virtual: Tests without connection
     fsoe: Safety over EtherCAT
     fsoe_phase2: Safety over EtherCAT phase 2 tests
+    valid_versions_for_product: Specify valid firmware version range for a specific product (part_number, min=version, max=version)
+    not_valid_for_product: Specify part number for which the test should never run
 log_cli = False
 log_cli_level = INFO
 env=

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,20 +77,11 @@ def pytest_collection_modifyitems(
 
 @pytest.fixture
 def disable_monitoring_disturbance(
-    skip_if_monitoring_not_available: None,  # noqa: ARG001
     mc: "MotionController",
     alias: str,
 ) -> Generator[None, None, None]:
     yield
     mc.capture.clean_monitoring_disturbance(servo=alias)
-
-
-@pytest.fixture
-def skip_if_monitoring_not_available(mc: "MotionController", alias: str) -> None:
-    try:
-        mc.capture._check_version(alias)
-    except NotImplementedError:
-        pytest.skip("Monitoring is not available")
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Callable, Optional, Union
 
 import numpy as np
 import pytest
+from ingenialink.dictionary import Interface
 from summit_testing_framework import dynamic_loader
 from summit_testing_framework.pytest_helpers.marker_helper import (
     apply_firmware_version_markers_to_items,
@@ -13,6 +14,32 @@ from summit_testing_framework.pytest_helpers.marker_helper import (
 
 if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
+
+
+def not_valid_for_eve_products(func: Callable) -> Callable:
+    """Decorator that applies not_valid_for_product markers for all EVE products.
+
+    Returns:
+        The decorated function with the markers applied.
+    """
+    func = pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])(
+        func
+    )
+    func = pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])(
+        func
+    )
+    func = pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])(
+        func
+    )
+    func = pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])(
+        func
+    )
+    func = pytest.mark.not_valid_for_product(part_number="CAP-NET-C", interfaces=[Interface.CAN])(
+        func
+    )
+    return func
+
+
 pytest_plugins = [
     "summit_testing_framework.pytest_addoptions",
     "summit_testing_framework.setup_fixtures",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,9 +34,6 @@ def not_valid_for_eve_products(func: Callable) -> Callable:
     func = pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])(
         func
     )
-    func = pytest.mark.not_valid_for_product(part_number="CAP-NET-C", interfaces=[Interface.CAN])(
-        func
-    )
     return func
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING, Callable, Optional, Union
 import numpy as np
 import pytest
 from summit_testing_framework import dynamic_loader
+from summit_testing_framework.pytest_helpers.marker_helper import (
+    apply_firmware_version_markers_to_items,
+)
 
 if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
@@ -53,6 +56,23 @@ def pytest_sessionstart(session):
 def pytest_configure(config):  # noqa: ARG001
     # https://novantamotion.atlassian.net/browse/INGM-627
     logging.getLogger("ingenialink.ethercat.servo").addFilter(SuppressSpecificLogs())
+
+
+def pytest_collection_modifyitems(
+    session: pytest.Session,  # noqa: ARG001
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Modifies collected tests to skip those that do not meet firmware version restrictions.
+
+    Only runs if --enable_firmware_version_check is passed.
+
+    Args:
+        session: pytest session.
+        config: pytest configuration.
+        items: collected test items.
+    """
+    apply_firmware_version_markers_to_items(config=config, items=items)
 
 
 @pytest.fixture

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -2,7 +2,6 @@ import time
 
 import numpy as np
 import pytest
-from ingenialink.dictionary import Interface
 
 from ingeniamotion.enums import (
     MonitoringProcessStage,
@@ -12,6 +11,7 @@ from ingeniamotion.enums import (
     OperationMode,
 )
 from ingeniamotion.exceptions import IMMonitoringError, IMStatusWordError
+from tests.conftest import not_valid_for_eve_products
 
 
 def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
@@ -53,10 +53,7 @@ def test_create_poller(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_create_monitoring_no_trigger(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     mc.motion.set_operation_mode(OperationMode.VELOCITY, alias)
@@ -89,10 +86,7 @@ def test_create_monitoring_no_trigger(mc, alias):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 @pytest.mark.parametrize(
     "trigger_mode, trigger_config, values_list",
@@ -160,10 +154,7 @@ def test_create_monitoring_edge_trigger(
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("trigger_delay_rate", [-1 / 4, 1 / 4])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_create_monitoring_trigger_delay(
     mc,
     alias,
@@ -222,10 +213,7 @@ def test_create_monitoring_trigger_delay(
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 def test_create_disturbance(mc, alias):
     target_register = "CL_POS_SET_POINT_VALUE"
@@ -274,10 +262,7 @@ def test_mcb_synchronization_fail(mc, alias):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_disturbance_max_sample_size(mc, alias):
     target_register = mc.capture.DISTURBANCE_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -288,10 +273,7 @@ def test_disturbance_max_sample_size(mc, alias):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -305,10 +287,7 @@ def test_monitoring_max_sample_size(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_get_frequency(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     max_frequency = mc.configuration.get_position_and_velocity_loop_rate(alias)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -53,9 +53,10 @@ def test_create_poller(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@pytest.mark.not_valid_for_product(
-    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
-)
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_create_monitoring_no_trigger(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     mc.motion.set_operation_mode(OperationMode.VELOCITY, alias)
@@ -88,9 +89,10 @@ def test_create_monitoring_no_trigger(mc, alias):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(
-    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
-)
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 @pytest.mark.parametrize(
     "trigger_mode, trigger_config, values_list",
@@ -158,9 +160,10 @@ def test_create_monitoring_edge_trigger(
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("trigger_delay_rate", [-1 / 4, 1 / 4])
-@pytest.mark.not_valid_for_product(
-    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
-)
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_create_monitoring_trigger_delay(
     mc,
     alias,
@@ -219,9 +222,10 @@ def test_create_monitoring_trigger_delay(
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(
-    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
-)
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 def test_create_disturbance(mc, alias):
     target_register = "CL_POS_SET_POINT_VALUE"
@@ -270,9 +274,10 @@ def test_mcb_synchronization_fail(mc, alias):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(
-    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
-)
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_disturbance_max_sample_size(mc, alias):
     target_register = mc.capture.DISTURBANCE_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -283,9 +288,10 @@ def test_disturbance_max_sample_size(mc, alias):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(
-    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
-)
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -299,9 +305,10 @@ def test_monitoring_max_sample_size(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@pytest.mark.not_valid_for_product(
-    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
-)
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_get_frequency(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     max_frequency = mc.configuration.get_position_and_velocity_loop_rate(alias)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -2,6 +2,7 @@ import time
 
 import numpy as np
 import pytest
+from ingenialink.dictionary import Interface
 
 from ingeniamotion.enums import (
     MonitoringProcessStage,
@@ -52,7 +53,9 @@ def test_create_poller(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@pytest.mark.usefixtures("skip_if_monitoring_not_available")
+@pytest.mark.not_valid_for_product(
+    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
+)
 def test_create_monitoring_no_trigger(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     mc.motion.set_operation_mode(OperationMode.VELOCITY, alias)
@@ -85,7 +88,9 @@ def test_create_monitoring_no_trigger(mc, alias):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.usefixtures("skip_if_monitoring_not_available")
+@pytest.mark.not_valid_for_product(
+    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
+)
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 @pytest.mark.parametrize(
     "trigger_mode, trigger_config, values_list",
@@ -153,7 +158,9 @@ def test_create_monitoring_edge_trigger(
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("trigger_delay_rate", [-1 / 4, 1 / 4])
-@pytest.mark.usefixtures("skip_if_monitoring_not_available")
+@pytest.mark.not_valid_for_product(
+    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
+)
 def test_create_monitoring_trigger_delay(
     mc,
     alias,
@@ -212,7 +219,9 @@ def test_create_monitoring_trigger_delay(
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.usefixtures("skip_if_monitoring_not_available")
+@pytest.mark.not_valid_for_product(
+    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
+)
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 def test_create_disturbance(mc, alias):
     target_register = "CL_POS_SET_POINT_VALUE"
@@ -261,7 +270,9 @@ def test_mcb_synchronization_fail(mc, alias):
 
 
 @pytest.mark.virtual
-@pytest.mark.usefixtures("skip_if_monitoring_not_available")
+@pytest.mark.not_valid_for_product(
+    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
+)
 def test_disturbance_max_sample_size(mc, alias):
     target_register = mc.capture.DISTURBANCE_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -272,7 +283,9 @@ def test_disturbance_max_sample_size(mc, alias):
 
 
 @pytest.mark.virtual
-@pytest.mark.usefixtures("skip_if_monitoring_not_available")
+@pytest.mark.not_valid_for_product(
+    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
+)
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -286,7 +299,9 @@ def test_monitoring_max_sample_size(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@pytest.mark.usefixtures("skip_if_monitoring_not_available")
+@pytest.mark.not_valid_for_product(
+    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
+)
 def test_get_frequency(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     max_frequency = mc.configuration.get_position_and_velocity_loop_rate(alias)

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -1,8 +1,8 @@
 import pytest
-from ingenialink.dictionary import Interface
 
 from ingeniamotion.disturbance import Disturbance
 from ingeniamotion.exceptions import IMDisturbanceError
+from tests.conftest import not_valid_for_eve_products
 
 
 @pytest.fixture
@@ -16,10 +16,7 @@ def disturbance(mc, alias):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_disturbance_max_sample_size(mc, alias, disturbance):
     max_sample_size = disturbance.max_sample_number
     value = mc.communication.get_register(
@@ -32,10 +29,7 @@ def test_disturbance_max_sample_size(mc, alias, disturbance):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_set_frequency_divider(mc, alias, disturbance, prescaler):
     disturbance.set_frequency_divider(prescaler)
     value = mc.communication.get_register(
@@ -47,10 +41,7 @@ def test_set_frequency_divider(mc, alias, disturbance, prescaler):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_set_frequency_divider_exception(disturbance):
     prescaler = -1
     with pytest.raises(ValueError):
@@ -60,10 +51,7 @@ def test_set_frequency_divider_exception(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 @pytest.mark.parametrize(
     "axis, name, expected_value",
     [
@@ -84,10 +72,7 @@ def test_disturbance_map_registers(mc, alias, disturbance, axis, name, expected_
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 @pytest.mark.parametrize("number_registers", list(range(1, 17)))
 def test_disturbance_number_map_registers(mc, alias, disturbance, number_registers):
     reg_dict = {"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}
@@ -100,10 +85,7 @@ def test_disturbance_number_map_registers(mc, alias, disturbance, number_registe
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_disturbance_map_registers_sample_number(disturbance):
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]
     value = disturbance.map_registers(registers)
@@ -111,10 +93,7 @@ def test_disturbance_map_registers_sample_number(disturbance):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_disturbance_map_registers_exception(disturbance):
     registers = [{"axis": 0, "name": "DRV_AXIS_NUMBER"}]
     with pytest.raises(IMDisturbanceError):
@@ -122,10 +101,7 @@ def test_disturbance_map_registers_exception(disturbance):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_disturbance_map_registers_empty(disturbance):
     registers = []
     with pytest.raises(IMDisturbanceError):
@@ -135,10 +111,7 @@ def test_disturbance_map_registers_empty(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 @pytest.mark.usefixtures("disturbance_map_registers")
 def test_write_disturbance_data_buffer_exception(disturbance):
     with pytest.raises(IMDisturbanceError):
@@ -146,10 +119,7 @@ def test_write_disturbance_data_buffer_exception(disturbance):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_write_disturbance_data_not_configured(disturbance):
     with pytest.raises(IMDisturbanceError):
         disturbance.write_disturbance_data([0] * 100)
@@ -158,10 +128,7 @@ def test_write_disturbance_data_not_configured(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 def test_write_disturbance_data_enabled(mc, alias, disturbance):
     mc.capture.enable_disturbance(alias)
@@ -170,10 +137,7 @@ def test_write_disturbance_data_enabled(mc, alias, disturbance):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_disturbance_map_registers_invalid_subnode(mocker, mc, disturbance):
     registers = [{"axis": "1", "name": "DRV_AXIS_NUMBER"}]
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
@@ -182,10 +146,7 @@ def test_disturbance_map_registers_invalid_subnode(mocker, mc, disturbance):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_disturbance_map_registers_invalid_register(mocker, mc, disturbance):
     registers = [{"axis": 1, "name": 1}]
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
@@ -194,10 +155,7 @@ def test_disturbance_map_registers_invalid_register(mocker, mc, disturbance):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_write_disturbance_data_wrong_data_type(mocker, mc, disturbance):
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -5,12 +5,12 @@ from ingeniamotion.exceptions import IMDisturbanceError
 
 
 @pytest.fixture
-def disturbance_map_registers(disturbance, skip_if_monitoring_not_available):  # noqa: ARG001
+def disturbance_map_registers(disturbance):
     disturbance.map_registers([{"axis": 1, "name": "CL_TOR_SET_POINT_VALUE"}])
 
 
 @pytest.fixture
-def disturbance(mc, alias, skip_if_monitoring_not_available):  # noqa: ARG001
+def disturbance(mc, alias):
     return Disturbance(mc, alias)
 
 

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -1,4 +1,5 @@
 import pytest
+from ingenialink.dictionary import Interface
 
 from ingeniamotion.disturbance import Disturbance
 from ingeniamotion.exceptions import IMDisturbanceError
@@ -15,6 +16,10 @@ def disturbance(mc, alias):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_disturbance_max_sample_size(mc, alias, disturbance):
     max_sample_size = disturbance.max_sample_number
     value = mc.communication.get_register(
@@ -27,6 +32,10 @@ def test_disturbance_max_sample_size(mc, alias, disturbance):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_set_frequency_divider(mc, alias, disturbance, prescaler):
     disturbance.set_frequency_divider(prescaler)
     value = mc.communication.get_register(
@@ -38,6 +47,10 @@ def test_set_frequency_divider(mc, alias, disturbance, prescaler):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_set_frequency_divider_exception(disturbance):
     prescaler = -1
     with pytest.raises(ValueError):
@@ -47,6 +60,10 @@ def test_set_frequency_divider_exception(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 @pytest.mark.parametrize(
     "axis, name, expected_value",
     [
@@ -67,6 +84,10 @@ def test_disturbance_map_registers(mc, alias, disturbance, axis, name, expected_
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 @pytest.mark.parametrize("number_registers", list(range(1, 17)))
 def test_disturbance_number_map_registers(mc, alias, disturbance, number_registers):
     reg_dict = {"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}
@@ -79,6 +100,10 @@ def test_disturbance_number_map_registers(mc, alias, disturbance, number_registe
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_disturbance_map_registers_sample_number(disturbance):
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]
     value = disturbance.map_registers(registers)
@@ -86,6 +111,10 @@ def test_disturbance_map_registers_sample_number(disturbance):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_disturbance_map_registers_exception(disturbance):
     registers = [{"axis": 0, "name": "DRV_AXIS_NUMBER"}]
     with pytest.raises(IMDisturbanceError):
@@ -93,6 +122,10 @@ def test_disturbance_map_registers_exception(disturbance):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_disturbance_map_registers_empty(disturbance):
     registers = []
     with pytest.raises(IMDisturbanceError):
@@ -102,6 +135,10 @@ def test_disturbance_map_registers_empty(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 @pytest.mark.usefixtures("disturbance_map_registers")
 def test_write_disturbance_data_buffer_exception(disturbance):
     with pytest.raises(IMDisturbanceError):
@@ -109,6 +146,10 @@ def test_write_disturbance_data_buffer_exception(disturbance):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_write_disturbance_data_not_configured(disturbance):
     with pytest.raises(IMDisturbanceError):
         disturbance.write_disturbance_data([0] * 100)
@@ -117,6 +158,10 @@ def test_write_disturbance_data_not_configured(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 def test_write_disturbance_data_enabled(mc, alias, disturbance):
     mc.capture.enable_disturbance(alias)
@@ -125,6 +170,10 @@ def test_write_disturbance_data_enabled(mc, alias, disturbance):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_disturbance_map_registers_invalid_subnode(mocker, mc, disturbance):
     registers = [{"axis": "1", "name": "DRV_AXIS_NUMBER"}]
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
@@ -133,6 +182,10 @@ def test_disturbance_map_registers_invalid_subnode(mocker, mc, disturbance):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_disturbance_map_registers_invalid_register(mocker, mc, disturbance):
     registers = [{"axis": 1, "name": 1}]
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
@@ -141,6 +194,10 @@ def test_disturbance_map_registers_invalid_register(mocker, mc, disturbance):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_write_disturbance_data_wrong_data_type(mocker, mc, disturbance):
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -49,6 +49,10 @@ def mon_map_registers(monitoring):
         4,  # Invalid value
     ],
 )
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_get_trigger_type(mc, alias, monitoring, trigger_type):
     mc.communication.set_register(
         MONITOR_START_CONDITION_TYPE_REGISTER, trigger_type, servo=alias, axis=0
@@ -72,6 +76,10 @@ def test_get_trigger_type(mc, alias, monitoring, trigger_type):
         (True, 0.1, 0.8, 0, False),
     ],
 )
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_raise_forced_trigger(
     mc,
     alias,
@@ -97,6 +105,10 @@ def test_raise_forced_trigger(
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_raise_forced_trigger_fail(mc, alias, monitoring):
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_AUTO)
     monitoring.configure_sample_time(0.8, 0)
@@ -118,6 +130,10 @@ def test_raise_forced_trigger_fail(mc, alias, monitoring):
         (0.1, 0.8, False),
     ],
 )
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_read_monitoring_data_forced_trigger(mc, alias, monitoring, timeout, sample_t, result):
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_FORCED)
     monitoring.configure_sample_time(sample_t, 0)
@@ -133,6 +149,10 @@ def test_read_monitoring_data_forced_trigger(mc, alias, monitoring, timeout, sam
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_set_monitoring_frequency(mc, alias, monitoring, prescaler):
     monitoring.set_frequency(prescaler)
     value = mc.communication.get_register(
@@ -144,6 +164,10 @@ def test_set_monitoring_frequency(mc, alias, monitoring, prescaler):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_set_monitoring_frequency_exception(monitoring):
     prescaler = 0.5
     with pytest.raises(ValueError):
@@ -151,6 +175,10 @@ def test_set_monitoring_frequency_exception(monitoring):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_monitoring_map_registers_size_exception(monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     monitoring.samples_number = monitoring.max_sample_number
@@ -159,6 +187,10 @@ def test_monitoring_map_registers_size_exception(monitoring):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_monitoring_map_registers_fail(monitoring):
     registers = []
     with pytest.raises(IMMonitoringError):
@@ -166,6 +198,10 @@ def test_monitoring_map_registers_fail(monitoring):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_monitoring_map_registers_wrong_cyclic(monitoring):
     registers = [{"axis": 1, "name": "DRV_STATE_CONTROL"}]
     with pytest.raises(IMMonitoringError):
@@ -189,6 +225,10 @@ def test_monitoring_map_registers_wrong_cyclic(monitoring):
         ),
     ],
 )
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_monitoring_set_trigger(
     mc,
     alias,
@@ -227,6 +267,10 @@ def test_monitoring_set_trigger(
         ),
     ],
 )
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_monitoring_set_trigger_exceptions(
     monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
 ):
@@ -237,6 +281,10 @@ def test_monitoring_set_trigger_exceptions(
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_configure_number_samples(mc, alias, monitoring):
     total_num_samples = 500
     trigger_delay_samples = 100
@@ -255,6 +303,10 @@ def test_configure_number_samples(mc, alias, monitoring):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("total_num_samples, trigger_delay_samples", [(500, 510), (510, -500)])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_configure_number_samples_exceptions(monitoring, total_num_samples, trigger_delay_samples):
     with pytest.raises(ValueError):
         monitoring.configure_number_samples(total_num_samples, trigger_delay_samples)
@@ -263,6 +315,10 @@ def test_configure_number_samples_exceptions(monitoring, total_num_samples, trig
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_configure_sample_time(mc, alias, monitoring):
     total_time = 5
     sampling_freq = 1e4
@@ -285,6 +341,10 @@ def test_configure_sample_time(mc, alias, monitoring):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("total_time, sign", [(5, 1), (5, -1)])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_configure_sample_time_exception(monitoring, total_time, sign):
     trigger_delay = sign * ((total_time // 2) + 1)
     with pytest.raises(ValueError):
@@ -310,6 +370,10 @@ def test_enable_monitoring_no_mapped_registers(mc, alias):
 @pytest.mark.canopen
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_read_monitoring_data_disabled(monitoring):
     monitoring.configure_sample_time(0.8, 0)
     with pytest.raises(IMMonitoringError) as exc:
@@ -323,6 +387,10 @@ def test_read_monitoring_data_disabled(monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_read_monitoring_data_timeout(mc, alias, monitoring):
     timeout = 2
     sample_t = 0.8
@@ -339,6 +407,10 @@ def test_read_monitoring_data_timeout(mc, alias, monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_read_monitoring_data_no_rearm(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 2
@@ -364,6 +436,10 @@ def test_read_monitoring_data_no_rearm(mc, alias, monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_rearm_monitoring(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 2
@@ -403,6 +479,10 @@ def run_read_monitoring_data_and_stop(monitoring, timeout):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_stop_reading_data(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 10
@@ -430,6 +510,10 @@ def test_monitoring_max_sample_size(mc, alias):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_monitoring_map_registers_invalid_subnode(mocker, mc, monitoring):
     registers = [{"axis": "1", "name": "DRV_AXIS_NUMBER"}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -438,6 +522,10 @@ def test_monitoring_map_registers_invalid_subnode(mocker, mc, monitoring):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_monitoring_map_registers_invalid_register(mocker, mc, monitoring):
     registers = [{"axis": 1, "name": 1}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -446,6 +534,10 @@ def test_monitoring_map_registers_invalid_register(mocker, mc, monitoring):
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_monitoring_map_registers_invalid_number_mapped_registers(mocker, mc, monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -462,6 +554,10 @@ def test_monitoring_map_registers_invalid_number_mapped_registers(mocker, mc, mo
     ],
 )
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_configure_sample_time_exceptions(
     mocker, mc, monitoring, trigger_delay, expected_exception
 ):
@@ -472,6 +568,10 @@ def test_configure_sample_time_exceptions(
 
 
 @pytest.mark.virtual
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_get_trigger_type_exception(mocker, mc, monitoring):
     mocker.patch.object(mc.communication, "get_register", return_value="invalid_value")
     with pytest.raises(TypeError):

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -3,10 +3,10 @@ from functools import partial
 from threading import Thread
 
 import pytest
-from ingenialink.dictionary import Interface
 
 from ingeniamotion.enums import MonitoringSoCConfig, MonitoringSoCType
 from ingeniamotion.exceptions import IMMonitoringError
+from tests.conftest import not_valid_for_eve_products
 
 MONITOR_START_CONDITION_TYPE_REGISTER = "MON_CFG_SOC_TYPE"
 
@@ -49,10 +49,7 @@ def mon_map_registers(monitoring):
         4,  # Invalid value
     ],
 )
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_get_trigger_type(mc, alias, monitoring, trigger_type):
     mc.communication.set_register(
         MONITOR_START_CONDITION_TYPE_REGISTER, trigger_type, servo=alias, axis=0
@@ -76,10 +73,7 @@ def test_get_trigger_type(mc, alias, monitoring, trigger_type):
         (True, 0.1, 0.8, 0, False),
     ],
 )
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_raise_forced_trigger(
     mc,
     alias,
@@ -105,10 +99,7 @@ def test_raise_forced_trigger(
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_raise_forced_trigger_fail(mc, alias, monitoring):
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_AUTO)
     monitoring.configure_sample_time(0.8, 0)
@@ -130,10 +121,7 @@ def test_raise_forced_trigger_fail(mc, alias, monitoring):
         (0.1, 0.8, False),
     ],
 )
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_read_monitoring_data_forced_trigger(mc, alias, monitoring, timeout, sample_t, result):
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_FORCED)
     monitoring.configure_sample_time(sample_t, 0)
@@ -149,10 +137,7 @@ def test_read_monitoring_data_forced_trigger(mc, alias, monitoring, timeout, sam
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_set_monitoring_frequency(mc, alias, monitoring, prescaler):
     monitoring.set_frequency(prescaler)
     value = mc.communication.get_register(
@@ -164,10 +149,7 @@ def test_set_monitoring_frequency(mc, alias, monitoring, prescaler):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_set_monitoring_frequency_exception(monitoring):
     prescaler = 0.5
     with pytest.raises(ValueError):
@@ -175,10 +157,7 @@ def test_set_monitoring_frequency_exception(monitoring):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_monitoring_map_registers_size_exception(monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     monitoring.samples_number = monitoring.max_sample_number
@@ -187,10 +166,7 @@ def test_monitoring_map_registers_size_exception(monitoring):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_monitoring_map_registers_fail(monitoring):
     registers = []
     with pytest.raises(IMMonitoringError):
@@ -198,10 +174,7 @@ def test_monitoring_map_registers_fail(monitoring):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_monitoring_map_registers_wrong_cyclic(monitoring):
     registers = [{"axis": 1, "name": "DRV_STATE_CONTROL"}]
     with pytest.raises(IMMonitoringError):
@@ -225,10 +198,7 @@ def test_monitoring_map_registers_wrong_cyclic(monitoring):
         ),
     ],
 )
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_monitoring_set_trigger(
     mc,
     alias,
@@ -267,10 +237,7 @@ def test_monitoring_set_trigger(
         ),
     ],
 )
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_monitoring_set_trigger_exceptions(
     monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
 ):
@@ -281,10 +248,7 @@ def test_monitoring_set_trigger_exceptions(
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_configure_number_samples(mc, alias, monitoring):
     total_num_samples = 500
     trigger_delay_samples = 100
@@ -303,10 +267,7 @@ def test_configure_number_samples(mc, alias, monitoring):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("total_num_samples, trigger_delay_samples", [(500, 510), (510, -500)])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_configure_number_samples_exceptions(monitoring, total_num_samples, trigger_delay_samples):
     with pytest.raises(ValueError):
         monitoring.configure_number_samples(total_num_samples, trigger_delay_samples)
@@ -315,10 +276,7 @@ def test_configure_number_samples_exceptions(monitoring, total_num_samples, trig
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_configure_sample_time(mc, alias, monitoring):
     total_time = 5
     sampling_freq = 1e4
@@ -341,10 +299,7 @@ def test_configure_sample_time(mc, alias, monitoring):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("total_time, sign", [(5, 1), (5, -1)])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_configure_sample_time_exception(monitoring, total_time, sign):
     trigger_delay = sign * ((total_time // 2) + 1)
     with pytest.raises(ValueError):
@@ -354,10 +309,7 @@ def test_configure_sample_time_exception(monitoring, total_time, sign):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_enable_monitoring_no_mapped_registers(mc, alias):
     mc.capture.clean_monitoring(alias)
     with pytest.raises(IMMonitoringError) as exc:
@@ -370,10 +322,7 @@ def test_enable_monitoring_no_mapped_registers(mc, alias):
 @pytest.mark.canopen
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_read_monitoring_data_disabled(monitoring):
     monitoring.configure_sample_time(0.8, 0)
     with pytest.raises(IMMonitoringError) as exc:
@@ -387,10 +336,7 @@ def test_read_monitoring_data_disabled(monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_read_monitoring_data_timeout(mc, alias, monitoring):
     timeout = 2
     sample_t = 0.8
@@ -407,10 +353,7 @@ def test_read_monitoring_data_timeout(mc, alias, monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_read_monitoring_data_no_rearm(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 2
@@ -436,10 +379,7 @@ def test_read_monitoring_data_no_rearm(mc, alias, monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_rearm_monitoring(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 2
@@ -479,10 +419,7 @@ def run_read_monitoring_data_and_stop(monitoring, timeout):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_stop_reading_data(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 10
@@ -496,10 +433,7 @@ def test_stop_reading_data(mc, alias, monitoring):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -510,10 +444,7 @@ def test_monitoring_max_sample_size(mc, alias):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_monitoring_map_registers_invalid_subnode(mocker, mc, monitoring):
     registers = [{"axis": "1", "name": "DRV_AXIS_NUMBER"}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -522,10 +453,7 @@ def test_monitoring_map_registers_invalid_subnode(mocker, mc, monitoring):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_monitoring_map_registers_invalid_register(mocker, mc, monitoring):
     registers = [{"axis": 1, "name": 1}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -534,10 +462,7 @@ def test_monitoring_map_registers_invalid_register(mocker, mc, monitoring):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_monitoring_map_registers_invalid_number_mapped_registers(mocker, mc, monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -554,10 +479,7 @@ def test_monitoring_map_registers_invalid_number_mapped_registers(mocker, mc, mo
     ],
 )
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_configure_sample_time_exceptions(
     mocker, mc, monitoring, trigger_delay, expected_exception
 ):
@@ -568,10 +490,7 @@ def test_configure_sample_time_exceptions(
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
-@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
+@not_valid_for_eve_products
 def test_get_trigger_type_exception(mocker, mc, monitoring):
     mocker.patch.object(mc.communication, "get_register", return_value="invalid_value")
     with pytest.raises(TypeError):

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -3,6 +3,7 @@ from functools import partial
 from threading import Thread
 
 import pytest
+from ingenialink.dictionary import Interface
 
 from ingeniamotion.enums import MonitoringSoCConfig, MonitoringSoCType
 from ingeniamotion.exceptions import IMMonitoringError
@@ -24,17 +25,17 @@ class ThreadWithReturnValue(Thread):
 
 
 @pytest.fixture
-def monitoring(skip_if_monitoring_not_available, mc, alias):  # noqa: ARG001
+def monitoring(mc, alias):
     return mc.capture.create_empty_monitoring(alias)
 
 
 @pytest.fixture
-def mon_set_freq(skip_if_monitoring_not_available, monitoring):  # noqa: ARG001
+def mon_set_freq(monitoring):
     monitoring.set_frequency(10)
 
 
 @pytest.fixture
-def mon_map_registers(skip_if_monitoring_not_available, monitoring):  # noqa: ARG001
+def mon_map_registers(monitoring):
     monitoring.map_registers([{"axis": 1, "name": "CL_POS_FBK_VALUE"}])
 
 
@@ -293,7 +294,9 @@ def test_configure_sample_time_exception(monitoring, total_time, sign):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.usefixtures("skip_if_monitoring_not_available")
+@pytest.mark.not_valid_for_product(
+    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
+)
 def test_enable_monitoring_no_mapped_registers(mc, alias):
     mc.capture.clean_monitoring(alias)
     with pytest.raises(IMMonitoringError) as exc:
@@ -412,7 +415,9 @@ def test_stop_reading_data(mc, alias, monitoring):
 
 
 @pytest.mark.virtual
-@pytest.mark.usefixtures("skip_if_monitoring_not_available")
+@pytest.mark.not_valid_for_product(
+    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
+)
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -294,9 +294,10 @@ def test_configure_sample_time_exception(monitoring, total_time, sign):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.not_valid_for_product(
-    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
-)
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_enable_monitoring_no_mapped_registers(mc, alias):
     mc.capture.clean_monitoring(alias)
     with pytest.raises(IMMonitoringError) as exc:
@@ -415,9 +416,10 @@ def test_stop_reading_data(mc, alias, monitoring):
 
 
 @pytest.mark.virtual
-@pytest.mark.not_valid_for_product(
-    part_number="EVE-XCR-E", interfaces=[Interface.ECAT, Interface.CAN]
-)
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])
+@pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0


### PR DESCRIPTION
### Description

Update tests to use new feature to skip tests with part number / interface / firmware version.

Using new markers allow to deselect tests instead of collecting them and skipping.
[Develop](http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingeniamotion/job/develop/1270/pipeline-overview/?selected-node=316): 
<img width="1843" height="545" alt="image" src="https://github.com/user-attachments/assets/09706ade-01aa-40f4-b4fb-01abcb764b73" />
[This branch](http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingeniamotion/job/PR-494/13/pipeline-overview/?selected-node=312):
<img width="1736" height="370" alt="image" src="https://github.com/user-attachments/assets/c292834e-f1b9-41b9-aae4-09d98cf4fb31" />

The same number of tests is executed (113), but in develop 72 are skipped whereas in this PR (removes monitoring and disturbance skipping) just 6 tests are skipped.


### Type of change

Please add a description and delete options that are not relevant.

- [X] Run tests with `enable_firmware_version_check` argument
- [X] Added valid_versions_for_product and not_valid_for_product 
- [X] Created `pytest_collection_modifyitems` to allow firmware version filter in tests.
- [X] Updated summit testing framework wheel
- [X] Added `not_valid_for_eve_products` decorator to mark all monitoring and disturbance tests that should not run on EVE products with CAN/ECAT interface -> replaces `skip_if_monitoring_not_available` fixture


### Tests
- [ ] Add new unit tests if it applies.

Please describe the manual tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).