### PR TITLE
Cit 556 create specifier container class

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -563,7 +563,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                runTest("fsoe_phase1", "fsoe", "tests.setups.rack_specifiers.ECAT_SAFETY_SETUP@DEN-S-NET-PHASE1", "", true)
+                                runTest("fsoe_phase1", "fsoe", "tests.setups.rack_specifiers.ECAT_DEN_S_NET_E_SETUP@PHASE1", "", true)
                             }
                         }
                         stage("Safety Denali Phase II") {
@@ -573,7 +573,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                runTest("fsoe_phase2", "fsoe or fsoe_phase2", "tests.setups.rack_specifiers.ECAT_SAFETY_SETUP@DEN-S-NET-PHASE2", "", true)
+                                runTest("fsoe_phase2", "fsoe or fsoe_phase2", "tests.setups.rack_specifiers.ECAT_DEN_S_NET_E_SETUP@PHASE2", "", true)
                             }
                         }
                         stage("Ethercat Multislave") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -469,7 +469,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                runTest("canopen_everest", "canopen", "tests.setups.rack_specifiers.CAN_EVE_SETUP", "", false)
+                                runTest("canopen_everest", "canopen", "tests.setups.rack_specifiers.CAN_SETUP@EVE-XCR-C", "", false)
                             }
                         }
                         stage("Ethernet Everest") {
@@ -479,7 +479,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                runTest("ethernet_everest", "ethernet", "tests.setups.rack_specifiers.ETH_EVE_SETUP", "", true)
+                                runTest("ethernet_everest", "ethernet", "tests.setups.rack_specifiers.ETH_SETUP@EVE-XCR-C", "", true)
                             }
                         }
                         stage("CanOpen Capitan") {
@@ -489,7 +489,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                runTest("canopen_capitan", "canopen", "tests.setups.rack_specifiers.CAN_CAP_SETUP", "", false)
+                                runTest("canopen_capitan", "canopen", "tests.setups.rack_specifiers.CAN_SETUP@CAP-XCR-C", "", false)
                             }
                         }
                         stage("Ethernet Capitan") {
@@ -498,7 +498,7 @@ pipeline {
                                 expression { false }
                             }
                             steps {
-                                runTest("ethernet_capitan", "ethernet", "tests.setups.rack_specifiers.ETH_CAP_SETUP", "", true)
+                                runTest("ethernet_capitan", "ethernet", "tests.setups.rack_specifiers.ETH_SETUP@CAP-XCR-C", "", true)
                             }
                         }
                     }
@@ -543,7 +543,7 @@ pipeline {
                                 expression { false }
                             }
                             steps {
-                                runTest("ethercat_everest", "soem", "tests.setups.rack_specifiers.ECAT_EVE_SETUP", "", true)
+                                runTest("ethercat_everest", "soem", "tests.setups.rack_specifiers.ECAT_SETUP@EVE-XCR-E", "", true)
                             }
                         }
                         stage("Ethercat Capitan") {
@@ -553,7 +553,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                runTest("ethercat_capitan", "soem", "tests.setups.rack_specifiers.ECAT_CAP_SETUP", "", true)
+                                runTest("ethercat_capitan", "soem", "tests.setups.rack_specifiers.ECAT_SETUP@CAP-XCR-E", "", true)
                             }
                         }
                         stage("Safety Denali Phase I") {
@@ -563,7 +563,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                runTest("fsoe_phase1", "fsoe", "tests.setups.rack_specifiers.ECAT_DEN_S_PHASE1_SETUP", "", true)
+                                runTest("fsoe_phase1", "fsoe", "tests.setups.rack_specifiers.ECAT_SAFETY_SETUP@DEN-S-NET-PHASE1", "", true)
                             }
                         }
                         stage("Safety Denali Phase II") {
@@ -573,7 +573,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                runTest("fsoe_phase2", "fsoe or fsoe_phase2", "tests.setups.rack_specifiers.ECAT_DEN_S_PHASE2_SETUP", "", true)
+                                runTest("fsoe_phase2", "fsoe or fsoe_phase2", "tests.setups.rack_specifiers.ECAT_SAFETY_SETUP@DEN-S-NET-PHASE2", "", true)
                             }
                         }
                         stage("Ethercat Multislave") {

--- a/poetry.lock
+++ b/poetry.lock
@@ -4169,13 +4169,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.2.0+pr69b5"
+version = "0.2.0+pr71b3"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.2.0+pr69b5-py3-none-any.whl", hash = "sha256:019a313575e5a597ea3d6af574dc2a28174e820c96bd7fac1f8f9d12c4391088"},
+    {file = "summit_testing_framework-0.2.0+pr71b3-py3-none-any.whl", hash = "sha256:e92f66c129bde3a31541a23477dd8b90bd0848ee025fd6fb2db23ac59d49e1eb"},
 ]
 
 [package.dependencies]
@@ -4754,4 +4754,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "eab3a6f54547fe51492766690578f9ef8ab0c7c2777ba338e06ca342c8b26c90"
+content-hash = "a36e96971230bea2eca115df555f732369234dcc1fa01b1af877c2b3977a6e6e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
 ingenialink = {extras = ["virtual_drive"], version = "7.5.2+pr685b1"}
-summit-testing-framework = {version = "==0.2.0+pr69b5"}
+summit-testing-framework = {version = "==0.2.0+pr71b3"}
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from ingenialink.dictionary import Interface
+from summit_testing_framework.setups.specifier_container import SpecifierContainer
 from summit_testing_framework.setups.specifiers import (
     DictionaryType,
     MultiRackServiceConfigSpecifier,
@@ -8,74 +9,82 @@ from summit_testing_framework.setups.specifiers import (
     RackServiceConfigSpecifier,
 )
 
-ETH_EVE_SETUP = RackServiceConfigSpecifier.from_firmware(
-    part_number=PartNumber.EVE_XCR_C,
-    interface=Interface.ETH,
-    config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_can/1.2.0/config.xml"),
-    version="2.4.0",
-    dictionary_type=DictionaryType.XDF_V2,
-)
-
-ETH_CAP_SETUP = RackServiceConfigSpecifier.from_firmware(
-    part_number=PartNumber.CAP_XCR_C,
-    interface=Interface.ETH,
-    config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_can/1.1.0/config.xml"),
-    version="2.4.0",
-    dictionary_type=DictionaryType.XDF_V2,
-)
-
-ECAT_EVE_SETUP = RackServiceConfigSpecifier.from_firmware(
-    part_number=PartNumber.EVE_XCR_E,
-    interface=Interface.ECAT,
-    config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_ecat/1.2.0/config.xml"),
-    version="2.6.0",
-    dictionary_type=DictionaryType.XDF_V2,
-)
-
-ECAT_CAP_SETUP = RackServiceConfigSpecifier.from_firmware(
-    part_number=PartNumber.CAP_XCR_E,
-    interface=Interface.ECAT,
-    config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_ecat/1.1.0/config.xml"),
-    version="2.6.0",
-    dictionary_type=DictionaryType.XDF_V2,
-)
-
-ECAT_DEN_S_PHASE1_SETUP = RackServiceConfigSpecifier.from_firmware(
-    part_number=PartNumber.DEN_S_NET_E,
-    interface=Interface.ECAT,
-    config_file=None,
-    version="2.7.4",
-    dictionary_type=DictionaryType.XDF_V2,
-)
-
-ECAT_DEN_S_PHASE2_SETUP = RackServiceConfigSpecifier.from_firmware(
-    part_number=PartNumber.DEN_S_NET_E,
-    interface=Interface.ECAT,
-    config_file=None,
-    firmware=Path(
-        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.lfu"
+ETH_SETUP = SpecifierContainer({
+    PartNumber.EVE_XCR_C: RackServiceConfigSpecifier.from_firmware(
+        part_number=PartNumber.EVE_XCR_C,
+        interface=Interface.ETH,
+        config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_can/1.2.0/config.xml"),
+        version="2.4.0",
+        dictionary_type=DictionaryType.XDF_V2,
     ),
-    dictionary=Path(
-        "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.016.xdf3"
+    PartNumber.CAP_XCR_C: RackServiceConfigSpecifier.from_firmware(
+        part_number=PartNumber.CAP_XCR_C,
+        interface=Interface.ETH,
+        config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_can/1.1.0/config.xml"),
+        version="2.4.0",
+        dictionary_type=DictionaryType.XDF_V2,
     ),
-)
+})
 
-CAN_EVE_SETUP = RackServiceConfigSpecifier.from_firmware(
-    part_number=PartNumber.EVE_XCR_C,
-    interface=Interface.CAN,
-    config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_can/1.2.0/config.xml"),
-    version="2.4.0",
-    dictionary_type=DictionaryType.XDF_V2,
-)
+ECAT_SETUP = SpecifierContainer({
+    PartNumber.EVE_XCR_E: RackServiceConfigSpecifier.from_firmware(
+        part_number=PartNumber.EVE_XCR_E,
+        interface=Interface.ECAT,
+        config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_ecat/1.2.0/config.xml"),
+        version="2.6.0",
+        dictionary_type=DictionaryType.XDF_V2,
+    ),
+    PartNumber.CAP_XCR_E: RackServiceConfigSpecifier.from_firmware(
+        part_number=PartNumber.CAP_XCR_E,
+        interface=Interface.ECAT,
+        config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_ecat/1.1.0/config.xml"),
+        version="2.6.0",
+        dictionary_type=DictionaryType.XDF_V2,
+    ),
+})
 
-CAN_CAP_SETUP = RackServiceConfigSpecifier.from_firmware(
-    part_number=PartNumber.CAP_XCR_C,
-    interface=Interface.CAN,
-    config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_can/1.1.0/config.xml"),
-    version="2.4.0",
-    dictionary_type=DictionaryType.XDF_V2,
-)
+ECAT_SAFETY_SETUP = SpecifierContainer({
+    "DEN-S-NET-PHASE1": RackServiceConfigSpecifier.from_firmware(
+        part_number=PartNumber.DEN_S_NET_E,
+        interface=Interface.ECAT,
+        config_file=None,
+        version="2.7.4",
+        dictionary_type=DictionaryType.XDF_V2,
+    ),
+    "DEN-S-NET-PHASE2": RackServiceConfigSpecifier.from_firmware(
+        part_number=PartNumber.DEN_S_NET_E,
+        interface=Interface.ECAT,
+        config_file=None,
+        firmware=Path(
+            "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.lfu"
+        ),
+        dictionary=Path(
+            "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.016.xdf3"
+        ),
+    ),
+})
+
+CAN_SETUP = SpecifierContainer({
+    PartNumber.EVE_XCR_C: RackServiceConfigSpecifier.from_firmware(
+        part_number=PartNumber.EVE_XCR_C,
+        interface=Interface.CAN,
+        config_file=Path("//azr-srv-ingfs1/dist/setups/setup_eve_can/1.2.0/config.xml"),
+        version="2.4.0",
+        dictionary_type=DictionaryType.XDF_V2,
+    ),
+    PartNumber.CAP_XCR_C: RackServiceConfigSpecifier.from_firmware(
+        part_number=PartNumber.CAP_XCR_C,
+        interface=Interface.CAN,
+        config_file=Path("//azr-srv-ingfs1/dist/setups/setup_cap_can/1.1.0/config.xml"),
+        version="2.4.0",
+        dictionary_type=DictionaryType.XDF_V2,
+    ),
+})
+
 
 ECAT_MULTISLAVE_SETUP = MultiRackServiceConfigSpecifier(
-    specifiers=[ECAT_EVE_SETUP, ECAT_CAP_SETUP],
+    specifiers=[
+        ECAT_SETUP.get_specifier_by_identifier(PartNumber.EVE_XCR_E),
+        ECAT_SETUP.get_specifier_by_identifier(PartNumber.CAP_XCR_E),
+    ],
 )

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -7,6 +7,7 @@ from summit_testing_framework.setups.specifiers import (
     MultiRackServiceConfigSpecifier,
     PartNumber,
     RackServiceConfigSpecifier,
+    VersionConfig,
 )
 
 ETH_SETUP = SpecifierContainer({
@@ -43,26 +44,28 @@ ECAT_SETUP = SpecifierContainer({
     ),
 })
 
-ECAT_SAFETY_SETUP = SpecifierContainer({
-    "DEN-S-NET-PHASE1": RackServiceConfigSpecifier.from_firmware(
-        part_number=PartNumber.DEN_S_NET_E,
-        interface=Interface.ECAT,
-        config_file=None,
-        version="2.7.4",
-        dictionary_type=DictionaryType.XDF_V2,
-    ),
-    "DEN-S-NET-PHASE2": RackServiceConfigSpecifier.from_firmware(
-        part_number=PartNumber.DEN_S_NET_E,
-        interface=Interface.ECAT,
-        config_file=None,
-        firmware=Path(
-            "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.lfu"
+ECAT_DEN_S_NET_E_SETUP = RackServiceConfigSpecifier.from_version_configs(
+    part_number=PartNumber.DEN_S_NET_E,
+    interface=Interface.ECAT,
+    version_configs={
+        "PHASE1": VersionConfig.from_version(
+            version="2.7.4",
+            config_file=None,
+            dictionary_type=DictionaryType.XDF_V2,
         ),
-        dictionary=Path(
-            "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.016.xdf3"
+        "PHASE2": VersionConfig.from_files(
+            version="2.9.0.16",
+            config_file=None,
+            firmware=Path(
+                "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.lfu"
+            ),
+            dictionary=Path(
+                "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.016.xdf3"
+            ),
         ),
-    ),
-})
+    },
+)
+
 
 CAN_SETUP = SpecifierContainer({
     PartNumber.EVE_XCR_C: RackServiceConfigSpecifier.from_firmware(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,4 +1,5 @@
 import pytest
+from summit_testing_framework.product_constants import PartNumber
 from summit_testing_framework.setups import (
     MultiRackServiceConfigSpecifier,
     RackServiceConfigSpecifier,
@@ -6,7 +7,7 @@ from summit_testing_framework.setups import (
 
 from ingeniamotion.enums import GPI, GPO, DigitalVoltageLevel, GPIOPolarity
 from ingeniamotion.exceptions import IMError
-from tests.setups.rack_specifiers import CAN_CAP_SETUP, ECAT_CAP_SETUP, ETH_CAP_SETUP
+from tests.setups.rack_specifiers import CAN_SETUP, ECAT_SETUP, ETH_SETUP
 
 
 @pytest.mark.virtual
@@ -51,7 +52,11 @@ def test_get_gpi_voltage_level(mc, alias, environment, setup_specifier):
     ):
         pytest.skip("Skipping test for local configurations")
 
-    if setup_specifier in [ETH_CAP_SETUP, ECAT_CAP_SETUP, CAN_CAP_SETUP]:
+    if setup_specifier in [
+        ETH_SETUP.get_specifier_by_identifier(PartNumber.CAP_XCR_C),
+        ECAT_SETUP.get_specifier_by_identifier(PartNumber.CAP_XCR_E),
+        CAN_SETUP.get_specifier_by_identifier(PartNumber.CAP_XCR_C),
+    ]:
         pytest.skip("Capitan rack setups do not have gpio control")
 
     environment.set_gpi(number=1, value=False)


### PR DESCRIPTION
### Description

This pull request refactors how rack setup specifiers are managed and referenced throughout the codebase, improving maintainability and consistency. The main change is the introduction of grouped `SpecifierContainer` objects in `rack_specifiers.py`, replacing individual specifiers for each rack type and part number. All usages in the pipeline and tests have been updated to use these new containers.  

### Type of change

Please add a description and delete options that are not relevant.

- [X] Replaced individual rack setup specifiers (`ETH_EVE_SETUP`, `ETH_CAP_SETUP`, etc.) with grouped `SpecifierContainer` objects (`ETH_SETUP`, `ECAT_SETUP`, `CAN_SETUP`) in `tests/setups/rack_specifiers.py`, allowing lookup by part number and simplifying future additions. Also, consolidated Denali safety phase setups into a single specifier with version-based configs.
- [X] Updated the multisalve setup to use the new container-based specifiers, improving consistency.
- [X] Modified all `runTest` calls in `Jenkinsfile` to reference the new container-based specifiers using the `@` syntax, ensuring the correct setup is used for each test stage. 
- [X] Updated test imports and logic in `tests/test_io.py` to use the new containers and fetch specifiers by identifier, ensuring tests skip correctly for Capitan rack setups. 
- [x] Updated `summit-testing-framework` dependency in `pyproject.toml` to version `0.2.0+pr71b3` to support the new specifier containers.### Pull request name 


### Tests
- [ ] Add new unit tests if it applies.

Please describe the manual tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).