### PR TITLE
Add property to check if error is warning

### DIFF
--- a/ingeniamotion/errors.py
+++ b/ingeniamotion/errors.py
@@ -33,6 +33,11 @@ class Error:
         return self.__error_id
 
     @property
+    def is_warning(self) -> bool:
+        """Check if the error is a warning."""
+        return (self.__error_id & Errors.ERROR_WARNING_BIT) != 0
+
+    @property
     def error_description(self) -> str:
         """Get the error description."""
         if self.__dictionary_error is not None and self.__dictionary_error.description is not None:


### PR DESCRIPTION
This pull request adds a new property to the error handling in `ingeniamotion/errors.py` to help distinguish warnings from errors.

Enhancements to error handling:

* Added an `is_warning` property to the error class, allowing you to check if a given error is actually a warning by evaluating the `ERROR_WARNING_BIT` flag.### Pull request name 
