### PR TITLE
MOT3-5353 Configure absolute encoder frame type in brake test

### DIFF
--- a/ingeniamotion/wizard_tests/brake.py
+++ b/ingeniamotion/wizard_tests/brake.py
@@ -19,6 +19,7 @@ class Brake(BaseTest[None]):  # type: ignore [type-var]
     BRAKE_OVERRIDE_REGISTER = "MOT_BRAKE_OVERRIDE"
 
     PRIMARY_ABSOLUTE_SLAVE_1_PROTOCOL = "FBK_BISS1_SSI1_PROTOCOL"
+    PRIMARY_ABSOLUTE_SLAVE_1_FRAME_TYPE = "FBK_BISS1_SSI1_FRAME_TYPE"
 
     BACKUP_REGISTERS: ClassVar[list[str]] = [
         "MOT_BRAKE_OVERRIDE",
@@ -32,6 +33,7 @@ class Brake(BaseTest[None]):  # type: ignore [type-var]
         "CL_AUX_FBK_SENSOR",
         "MOT_COMMU_MOD",
         PRIMARY_ABSOLUTE_SLAVE_1_PROTOCOL,
+        PRIMARY_ABSOLUTE_SLAVE_1_FRAME_TYPE,
     ]
 
     def __init__(
@@ -70,11 +72,17 @@ class Brake(BaseTest[None]):  # type: ignore [type-var]
         self.mc.configuration.set_position_feedback(
             SensorType.INTGEN, servo=self.servo, axis=self.axis
         )
+        # Set the auxiliar feedback to ABS1 because the internal generator is not allowed
+        # as auxiliar feedback for all drives
         self.mc.configuration.set_auxiliar_feedback(
             SensorType.ABS1, servo=self.servo, axis=self.axis
         )
+        # Set the absolute encoder protocol to SSI and the frame type to RAW to avoid errors.
         self.mc.communication.set_register(
             self.PRIMARY_ABSOLUTE_SLAVE_1_PROTOCOL, 1, servo=self.servo, axis=self.axis
+        )
+        self.mc.communication.set_register(
+            self.PRIMARY_ABSOLUTE_SLAVE_1_FRAME_TYPE, 0, servo=self.servo, axis=self.axis
         )
 
     @override

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -206,7 +206,7 @@ def test_sto_test_error(mocker, mc, alias, sto_value, message):
 @pytest.mark.soem
 @pytest.mark.canopen
 def test_brake_test(mc, alias):
-    # Set frame type to BiSS-C BP3 to ensure thet the test change it to avoid an error.
+    # Set frame type to BiSS-C BP3 to ensure that the test changes it to avoid an error.
     mc.communication.set_register("FBK_BISS1_SSI1_FRAME_TYPE", 3, servo=alias)
     pair_poles = mc.configuration.get_motor_pair_poles(servo=alias)
     brake_test = mc.tests.brake_test(servo=alias)

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -206,6 +206,8 @@ def test_sto_test_error(mocker, mc, alias, sto_value, message):
 @pytest.mark.soem
 @pytest.mark.canopen
 def test_brake_test(mc, alias):
+    # Set frame type to BiSS-C BP3 to ensure thet the test change it to avoid an error.
+    mc.communication.set_register("FBK_BISS1_SSI1_FRAME_TYPE", 3, servo=alias)
     pair_poles = mc.configuration.get_motor_pair_poles(servo=alias)
     brake_test = mc.tests.brake_test(servo=alias)
     assert mc.configuration.get_motor_pair_poles(servo=alias) == 1


### PR DESCRIPTION
This pull request updates the brake test logic to ensure proper configuration of the absolute encoder protocol and frame type, which helps avoid errors during testing. The changes introduce a new register constant, update the backup register list, and explicitly set both the protocol and frame type during setup and testing.

**Brake test configuration improvements:**

* Added a new constant `PRIMARY_ABSOLUTE_SLAVE_1_FRAME_TYPE` (`FBK_BISS1_SSI1_FRAME_TYPE`) to the `Brake` test class and included it in the `BACKUP_REGISTERS` list to ensure it is managed as part of the test's backup and restore process. [[1]](diffhunk://#diff-c6f257264de350ea9c48952e1222534ba57ead356515517ab4846b58a76749ccR22) [[2]](diffhunk://#diff-c6f257264de350ea9c48952e1222534ba57ead356515517ab4846b58a76749ccR36)
* Updated the `setup` method in `Brake` to explicitly set the absolute encoder protocol to SSI and the frame type to RAW, preventing configuration errors on different drives.

**Test reliability improvements:**

* Modified the `test_brake_test` function to set the frame type to BiSS-C BP3 before running the test, ensuring the test logic properly changes it as required and avoids test failures due to incorrect initial configuration.