### PR TITLE
MOT3-5405 Make the get_error_queue function public

### DIFF
--- a/ingeniamotion/errors.py
+++ b/ingeniamotion/errors.py
@@ -17,6 +17,12 @@ from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 class Error:
     """Class to represent an error from the servo."""
 
+    ERROR_CODE_BITS = 0xFFFF
+    ERROR_SUBNODE_BITS = 0xF00000
+    ERROR_SUBNODE_SHIFT = 20
+    ERROR_WARNING_BIT = 0x10000000
+    ERROR_WARNING_SHIFT = 28
+
     def __init__(self, error_id: int, dictionary_error: Optional[DictionaryError] = None):
         """Constructor.
 
@@ -31,6 +37,16 @@ class Error:
     def error_id(self) -> int:
         """Get the error ID."""
         return self.__error_id
+
+    @property
+    def error_code(self) -> int:
+        """Get the error code."""
+        return self.__error_id & self.ERROR_CODE_BITS
+
+    @property
+    def axis(self) -> int:
+        """Get the error ID."""
+        return self.__error_id & self.ERROR_SUBNODE_BITS >> self.ERROR_SUBNODE_SHIFT
 
     @property
     def is_warning(self) -> bool:
@@ -330,7 +346,7 @@ class Errors:
         Returns:
             ServoErrorQueue instance for the specified servo/axis.
         """
-        error_version = self.__get_error_location(servo)
+        error_version = self.get_error_location(servo)
         axis, error_location = self.__get_error_subnode(error_version, axis)
 
         # Select the appropriate descriptor based on error location
@@ -348,20 +364,16 @@ class Errors:
         return ServoErrorQueue(descriptor, drive, axis=axis)
 
     def __parse_error_to_tuple(
-        self, error: int, location: ErrorLocation, subnode: Optional[int] = None
+        self, error: Error, subnode: Optional[int] = None
     ) -> tuple[int, Optional[int], Optional[bool]]:
-        error_code = error & self.ERROR_CODE_BITS
+        error_code = error.error_code
         if error_code == 0:
             return error_code, None, None
         if subnode is None:
-            if location == self.ErrorLocation.MOCO:
-                subnode = DEFAULT_AXIS
-            else:
-                subnode = (error & self.ERROR_SUBNODE_BITS) >> self.ERROR_SUBNODE_SHIFT
-        is_warning = (error & self.ERROR_WARNING_BIT) >> self.ERROR_WARNING_SHIFT
-        return error_code, subnode, bool(is_warning)
+            subnode = error.axis
+        return error_code, subnode, error.is_warning
 
-    def __get_error_location(self, servo: str = DEFAULT_SERVO) -> ErrorLocation:
+    def get_error_location(self, servo: str = DEFAULT_SERVO) -> ErrorLocation:
         """Determine the error location based on available registers.
 
         Args:
@@ -427,14 +439,13 @@ class Errors:
             TypeError: If some read value has a wrong type.
 
         """
-        error_version = self.__get_error_location(servo)
         queue = self.get_error_queue(servo, axis)
         error_obj = queue.get_last_error()
 
         if error_obj is None:
             return 0, None, None
 
-        return self.__parse_error_to_tuple(error_obj.error_id, error_version, axis)
+        return self.__parse_error_to_tuple(error_obj, axis)
 
     def get_last_buffer_error(
         self, servo: str = DEFAULT_SERVO, axis: Optional[int] = None
@@ -488,14 +499,13 @@ class Errors:
         if index >= self.MAXIMUM_ERROR_INDEX:
             raise ValueError("index must be less than 32")
 
-        error_version = self.__get_error_location(servo)
         queue = self.get_error_queue(servo, axis)
         error_obj = queue.get_error_by_index(index)
 
         if error_obj is None:
             return 0, None, None
 
-        return self.__parse_error_to_tuple(error_obj.error_id, error_version, axis)
+        return self.__parse_error_to_tuple(error_obj, axis)
 
     def get_number_total_errors(
         self, servo: str = DEFAULT_SERVO, axis: Optional[int] = None

--- a/ingeniamotion/errors.py
+++ b/ingeniamotion/errors.py
@@ -17,12 +17,6 @@ from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
 class Error:
     """Class to represent an error from the servo."""
 
-    ERROR_CODE_BITS = 0xFFFF
-    ERROR_SUBNODE_BITS = 0xF00000
-    ERROR_SUBNODE_SHIFT = 20
-    ERROR_WARNING_BIT = 0x10000000
-    ERROR_WARNING_SHIFT = 28
-
     def __init__(self, error_id: int, dictionary_error: Optional[DictionaryError] = None):
         """Constructor.
 
@@ -30,28 +24,13 @@ class Error:
             error_id: Error ID.
             dictionary_error: DictionaryError instance from the dictionary, if available.
         """
-        self.__error_id = error_id
+        self._error_id = error_id
         self.__dictionary_error = dictionary_error
 
     @property
     def error_id(self) -> int:
         """Get the error ID."""
-        return self.__error_id
-
-    @property
-    def error_code(self) -> int:
-        """Get the error code."""
-        return self.__error_id & self.ERROR_CODE_BITS
-
-    @property
-    def axis(self) -> int:
-        """Get the error ID."""
-        return self.__error_id & self.ERROR_SUBNODE_BITS >> self.ERROR_SUBNODE_SHIFT
-
-    @property
-    def is_warning(self) -> bool:
-        """Check if the error is a warning."""
-        return (self.__error_id & Errors.ERROR_WARNING_BIT) != 0
+        return self._error_id
 
     @property
     def error_description(self) -> str:
@@ -94,6 +73,31 @@ class Error:
         )
 
 
+class OperationError(Error):
+    """Class to represent an operation error from the servo."""
+
+    __ERROR_CODE_BITS = 0xFFFF
+    __ERROR_SUBNODE_BITS = 0xF00000
+    __ERROR_SUBNODE_SHIFT = 20
+    __ERROR_WARNING_BIT = 0x10000000
+    __ERROR_WARNING_SHIFT = 28
+
+    @property
+    def error_code(self) -> int:
+        """Get the error code."""
+        return self._error_id & self.__ERROR_CODE_BITS
+
+    @property
+    def axis(self) -> int:
+        """Get the error axis. If 0, it is a COCO error."""
+        return (self._error_id & self.__ERROR_SUBNODE_BITS) >> self.__ERROR_SUBNODE_SHIFT
+
+    @property
+    def is_warning(self) -> bool:
+        """Check if the error is a warning."""
+        return bool((self._error_id & self.__ERROR_WARNING_BIT) >> self.__ERROR_WARNING_SHIFT)
+
+
 @dataclass()
 class ErrorQueueDescriptor:
     """Descriptor for an error queue in a servo."""
@@ -103,6 +107,7 @@ class ErrorQueueDescriptor:
     error_request_index_reg_uid: str
     error_request_code_reg_uid: str
     max_index_request: int
+    error_type: type[Error]
 
 
 class ServoErrorQueue:
@@ -150,7 +155,7 @@ class ServoErrorQueue:
         Returns:
             Optional[Error]: The last error, or None if there is no error.
         """
-        error = Error.from_id(
+        error = self.descriptor.error_type.from_id(
             self.__read_int_reg(self.descriptor.last_error_reg_uid), self.__dictionary
         )
         return error
@@ -187,7 +192,7 @@ class ServoErrorQueue:
             )
         else:
             self.__servo.write(self.descriptor.error_request_index_reg_uid, index)
-        error = Error.from_id(
+        error = self.descriptor.error_type.from_id(
             self.__read_int_reg(self.descriptor.error_request_code_reg_uid), self.__dictionary
         )
         return error
@@ -258,6 +263,7 @@ MOCO_ERROR_QUEUE = ErrorQueueDescriptor(
     error_request_index_reg_uid="DRV_DIAG_ERROR_LIST_IDX",
     error_request_code_reg_uid="DRV_DIAG_ERROR_LIST_CODE",
     max_index_request=31,
+    error_type=OperationError,
 )
 
 COCO_ERROR_QUEUE = ErrorQueueDescriptor(
@@ -266,6 +272,7 @@ COCO_ERROR_QUEUE = ErrorQueueDescriptor(
     error_request_index_reg_uid="DRV_DIAG_ERROR_LIST_IDX_COM",
     error_request_code_reg_uid="DRV_DIAG_ERROR_LIST_CODE_COM",
     max_index_request=31,
+    error_type=OperationError,
 )
 
 SYSTEM_ERROR_QUEUE = ErrorQueueDescriptor(
@@ -274,6 +281,7 @@ SYSTEM_ERROR_QUEUE = ErrorQueueDescriptor(
     error_request_index_reg_uid="DRV_DIAG_SYS_ERROR_LIST_IDX_COM",
     error_request_code_reg_uid="DRV_DIAG_SYS_ERROR_LIST_CODE_COM",
     max_index_request=31,
+    error_type=OperationError,
 )
 
 
@@ -325,11 +333,7 @@ class Errors:
     STATUS_WORD_FAULT_BIT = 0x08
     STATUS_WORD_WARNING_BIT = 0x80
 
-    ERROR_CODE_BITS = 0xFFFF
-    ERROR_SUBNODE_BITS = 0xF00000
-    ERROR_SUBNODE_SHIFT = 20
-    ERROR_WARNING_BIT = 0x10000000
-    ERROR_WARNING_SHIFT = 28
+    __ERROR_CODE_BITS = 0xFFFF
 
     def __init__(self, motion_controller: "MotionController") -> None:
         self.mc = motion_controller
@@ -346,7 +350,7 @@ class Errors:
         Returns:
             ServoErrorQueue instance for the specified servo/axis.
         """
-        error_version = self.get_error_location(servo)
+        error_version = self._get_error_location(servo)
         axis, error_location = self.__get_error_subnode(error_version, axis)
 
         # Select the appropriate descriptor based on error location
@@ -366,6 +370,8 @@ class Errors:
     def __parse_error_to_tuple(
         self, error: Error, subnode: Optional[int] = None
     ) -> tuple[int, Optional[int], Optional[bool]]:
+        if not isinstance(error, OperationError):
+            return error.error_id, None, None
         error_code = error.error_code
         if error_code == 0:
             return error_code, None, None
@@ -373,7 +379,7 @@ class Errors:
             subnode = error.axis
         return error_code, subnode, error.is_warning
 
-    def get_error_location(self, servo: str = DEFAULT_SERVO) -> ErrorLocation:
+    def _get_error_location(self, servo: str = DEFAULT_SERVO) -> ErrorLocation:
         """Determine the error location based on available registers.
 
         Args:
@@ -598,5 +604,5 @@ class Errors:
 
         """
         drive = self.mc._get_drive(servo)
-        dictionary_errors = drive.errors[error_code & self.ERROR_CODE_BITS]
+        dictionary_errors = drive.errors[error_code & self.__ERROR_CODE_BITS]
         return tuple(dictionary_errors)  # type: ignore[return-value]

--- a/ingeniamotion/errors.py
+++ b/ingeniamotion/errors.py
@@ -318,7 +318,7 @@ class Errors:
     def __init__(self, motion_controller: "MotionController") -> None:
         self.mc = motion_controller
 
-    def __get_error_queue(
+    def get_error_queue(
         self, servo: str = DEFAULT_SERVO, axis: Optional[int] = None
     ) -> ServoErrorQueue:
         """Get the appropriate ServoErrorQueue for the given servo and axis.
@@ -428,7 +428,7 @@ class Errors:
 
         """
         error_version = self.__get_error_location(servo)
-        queue = self.__get_error_queue(servo, axis)
+        queue = self.get_error_queue(servo, axis)
         error_obj = queue.get_last_error()
 
         if error_obj is None:
@@ -489,7 +489,7 @@ class Errors:
             raise ValueError("index must be less than 32")
 
         error_version = self.__get_error_location(servo)
-        queue = self.__get_error_queue(servo, axis)
+        queue = self.get_error_queue(servo, axis)
         error_obj = queue.get_error_by_index(index)
 
         if error_obj is None:
@@ -513,7 +513,7 @@ class Errors:
             TypeError: If some read value has a wrong type.
 
         """
-        queue = self.__get_error_queue(servo, axis)
+        queue = self.get_error_queue(servo, axis)
         return queue.get_number_total_errors()
 
     def get_all_errors(

--- a/ingeniamotion/fsoe_master/errors.py
+++ b/ingeniamotion/fsoe_master/errors.py
@@ -1,4 +1,4 @@
-from ingeniamotion.errors import ErrorQueueDescriptor
+from ingeniamotion.errors import Error, ErrorQueueDescriptor
 
 MCUA_ERROR_QUEUE = ErrorQueueDescriptor(
     last_error_reg_uid="FSOE_LAST_ERROR_MCUA",
@@ -6,6 +6,7 @@ MCUA_ERROR_QUEUE = ErrorQueueDescriptor(
     error_request_index_reg_uid="FSOE_ERROR_REQUEST_INDEX_MCUA",
     error_request_code_reg_uid="FSOE_ERROR_REQUEST_CODE_MCUA",
     max_index_request=31,
+    error_type=Error,
 )
 
 MCUB_ERROR_QUEUE = ErrorQueueDescriptor(
@@ -14,4 +15,5 @@ MCUB_ERROR_QUEUE = ErrorQueueDescriptor(
     error_request_index_reg_uid="FSOE_ERROR_REQUEST_INDEX_MCUB",
     error_request_code_reg_uid="FSOE_ERROR_REQUEST_CODE_MCUB",
     max_index_request=31,
+    error_type=Error,
 )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 from ingenialink.exceptions import ILError
 
-from ingeniamotion.errors import MOCO_ERROR_QUEUE, Error, ServoErrorQueue
+from ingeniamotion.errors import MOCO_ERROR_QUEUE, OperationError, ServoErrorQueue
 
 if TYPE_CHECKING:
     from ingenialink.servo import Servo
@@ -60,21 +60,21 @@ def force_warning(mc: "MotionController", alias: str) -> Iterator[None]:
 @pytest.mark.parametrize(
     "error_id, expected_error_code, expected_axis, expected_is_warning",
     [
-        (0x1003241, 0x3241, 1, False),   # axis=1, no warning
-        (0x2003241, 0x3241, 2, False),   # axis=2, no warning
-        (0x11003241, 0x3241, 1, True),   # axis=1, warning bit set
-        (0x12003241, 0x3241, 2, True),   # axis=2, warning bit set
-        (0x0000ABCD, 0xABCD, 0, False),  # axis=0, no warning
+        (0x103241, 0x3241, 1, False),  # axis=1, no warning
+        (0x203241, 0x3241, 2, False),  # axis=2, no warning
+        (0x10103241, 0x3241, 1, True),  # axis=1, warning bit set
+        (0x10203241, 0x3241, 2, True),  # axis=2, warning bit set
+        (0x000ABCD, 0xABCD, 0, False),  # axis=0, no warning
     ],
 )
-def test_error_class_properties(
+def test_operation_error_class_properties(
     error_id: int,
     expected_error_code: int,
     expected_axis: int,
     expected_is_warning: bool,
 ) -> None:
-    """Test Error class error_code, axis, and is_warning properties."""
-    error = Error(error_id)
+    """Test OperationError class error_code, axis, and is_warning properties."""
+    error = OperationError.from_id(error_id)
     assert error.error_code == expected_error_code
     assert error.axis == expected_axis
     assert error.is_warning is expected_is_warning
@@ -316,5 +316,3 @@ class TestErrors:
         mc.motion.fault_reset(servo=alias)
         last_error = error_queue.get_last_error()
         assert last_error is None
-
-

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 from ingenialink.exceptions import ILError
 
-from ingeniamotion.errors import MOCO_ERROR_QUEUE, ServoErrorQueue
+from ingeniamotion.errors import MOCO_ERROR_QUEUE, Error, ServoErrorQueue
 
 if TYPE_CHECKING:
     from ingenialink.servo import Servo
@@ -55,6 +55,29 @@ def force_warning(mc: "MotionController", alias: str) -> Iterator[None]:
     yield
     mc.communication.set_register(USER_UNDER_VOLTAGE_ERROR_OPTION_CODE_REGISTER, 0, servo=alias)
     mc.communication.set_register(USER_UNDER_VOLTAGE_LEVEL_REGISTER, 10, servo=alias)
+
+
+@pytest.mark.parametrize(
+    "error_id, expected_error_code, expected_axis, expected_is_warning",
+    [
+        (0x1003241, 0x3241, 1, False),   # axis=1, no warning
+        (0x2003241, 0x3241, 2, False),   # axis=2, no warning
+        (0x11003241, 0x3241, 1, True),   # axis=1, warning bit set
+        (0x12003241, 0x3241, 2, True),   # axis=2, warning bit set
+        (0x0000ABCD, 0xABCD, 0, False),  # axis=0, no warning
+    ],
+)
+def test_error_class_properties(
+    error_id: int,
+    expected_error_code: int,
+    expected_axis: int,
+    expected_is_warning: bool,
+) -> None:
+    """Test Error class error_code, axis, and is_warning properties."""
+    error = Error(error_id)
+    assert error.error_code == expected_error_code
+    assert error.axis == expected_axis
+    assert error.is_warning is expected_is_warning
 
 
 class TestErrors:
@@ -293,3 +316,5 @@ class TestErrors:
         mc.motion.fault_reset(servo=alias)
         last_error = error_queue.get_last_error()
         assert last_error is None
+
+


### PR DESCRIPTION
### Error Parsing and Representation Improvements

* Added new properties to the `Error` class for extracting error code, axis, and warning status, using bitmasking and shifting for more precise parsing. [[1]](diffhunk://#diff-4484bb4a547a40e5da47273213182ded36d133760f1f9de06195a2f2e6cbdf4bR20-R25) [[2]](diffhunk://#diff-4484bb4a547a40e5da47273213182ded36d133760f1f9de06195a2f2e6cbdf4bR41-R50)
* Refactored the error parsing logic to operate directly on `Error` objects instead of raw integers, improving clarity and encapsulation. [[1]](diffhunk://#diff-4484bb4a547a40e5da47273213182ded36d133760f1f9de06195a2f2e6cbdf4bL351-R376) [[2]](diffhunk://#diff-4484bb4a547a40e5da47273213182ded36d133760f1f9de06195a2f2e6cbdf4bL430-R448) [[3]](diffhunk://#diff-4484bb4a547a40e5da47273213182ded36d133760f1f9de06195a2f2e6cbdf4bL491-R508)

### API and Naming Consistency

* Renamed internal methods (e.g., `__get_error_queue` to `get_error_queue`, `__get_error_location` to `get_error_location`) to make them public and updated all usages. [[1]](diffhunk://#diff-4484bb4a547a40e5da47273213182ded36d133760f1f9de06195a2f2e6cbdf4bL321-R337) [[2]](diffhunk://#diff-4484bb4a547a40e5da47273213182ded36d133760f1f9de06195a2f2e6cbdf4bL333-R349) [[3]](diffhunk://#diff-4484bb4a547a40e5da47273213182ded36d133760f1f9de06195a2f2e6cbdf4bL351-R376) [[4]](diffhunk://#diff-4484bb4a547a40e5da47273213182ded36d133760f1f9de06195a2f2e6cbdf4bL430-R448) [[5]](diffhunk://#diff-4484bb4a547a40e5da47273213182ded36d133760f1f9de06195a2f2e6cbdf4bL491-R508) [[6]](diffhunk://#diff-4484bb4a547a40e5da47273213182ded36d133760f1f9de06195a2f2e6cbdf4bL516-R526)