### PR TITLE
INGK-1123 Catch virtual drive monitoring V1 exception

### DIFF
--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, ClassVar, Optional, Union
 
 import numpy as np
 from ingenialink.dictionary import SubnodeType
-from ingenialink.exceptions import ILError, ILIOError
+from ingenialink.exceptions import ILError
 from ingenialink.poller import Poller
 from numpy.typing import NDArray
 
@@ -304,7 +304,7 @@ class Capture:
                 self.MONITORING_VERSION_REGISTER, servo=servo, axis=0
             )
             return MonitoringVersion.MONITORING_V3
-        except (IMRegisterNotExistError, ILIOError):
+        except (IMRegisterNotExistError, ILError):
             # The Monitoring V3 is NOT available
             pass
         try:
@@ -312,7 +312,7 @@ class Capture:
                 self.MONITORING_CURRENT_NUMBER_BYTES_REGISTER, servo=servo, axis=0
             )
             return MonitoringVersion.MONITORING_V2
-        except (IMRegisterNotExistError, ILIOError):
+        except (IMRegisterNotExistError, ILError):
             # The Monitoring V2 is NOT available
             pass
         try:

--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, ClassVar, Optional, Union
 
 import numpy as np
 from ingenialink.dictionary import SubnodeType
-from ingenialink.exceptions import ILIOError
+from ingenialink.exceptions import ILError, ILIOError
 from ingenialink.poller import Poller
 from numpy.typing import NDArray
 
@@ -318,7 +318,7 @@ class Capture:
         try:
             self.mc.communication.get_register(self.MONITORING_STATUS_REGISTER, servo=servo, axis=0)
             return MonitoringVersion.MONITORING_V1
-        except (IMRegisterNotExistError, ILIOError):
+        except (IMRegisterNotExistError, ILError):
             # Monitoring/disturbance are not available
             raise NotImplementedError(
                 "The monitoring and disturbance features are not available for this drive"

--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -34,7 +34,7 @@ from ingeniamotion.exceptions import IMFirmwareLoadError, IMRegisterWrongAccessE
 if TYPE_CHECKING:
     from ingenialink.ethercat.servo import EthercatServo
     from ingenialink.ethernet.servo import EthernetServo
-    from ingenialink.virtual.servo import VirtualServo
+    from ingenialink.virtual.ethernet.servo import VirtualEthernetServo
 
     from ingeniamotion.motion_controller import MotionController
 
@@ -204,7 +204,7 @@ class Communication:
         connection_timeout: int = 1,
         servo_status_listener: bool = False,
         net_status_listener: bool = False,
-    ) -> tuple[VirtualNetwork, "VirtualServo"]:
+    ) -> tuple[VirtualNetwork, "VirtualEthernetServo"]:
         """Connect to the virtual drive using an ethernet communication.
 
         Args:

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -8,7 +8,7 @@ from ingenialink.dictionary import SubnodeType
 from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethercat.network import EthercatNetwork
-from ingenialink.ethernet.network import EthernetNetwork
+from ingenialink.ethernet.network import EthernetNetworkBase
 from ingenialink.register import Register
 
 from ingeniamotion.enums import CommunicationType
@@ -212,7 +212,7 @@ class Information:
         """
         drive = self.mc._get_drive(servo)
         net = self.mc._get_network(servo)
-        if isinstance(net, EthernetNetwork):
+        if isinstance(net, EthernetNetworkBase):
             return str(drive.target)
         else:
             raise IMError("You need an Ethernet communication to use this function")
@@ -264,7 +264,7 @@ class Information:
         drive_network = self.mc._get_network(servo)
         if isinstance(drive_network, CanopenNetwork):
             communication_type = CommunicationType.Canopen
-        elif isinstance(drive_network, EthernetNetwork):
+        elif isinstance(drive_network, EthernetNetworkBase):
             communication_type = CommunicationType.Ethernet
         elif isinstance(drive_network, (EoENetwork, EthercatNetwork)):
             communication_type = CommunicationType.Ethercat
@@ -285,7 +285,7 @@ class Information:
         name = self.get_name(servo)
         full_name = f"{prod_name} - {name}"
         net = self.mc._get_network(servo)
-        if isinstance(net, EthernetNetwork):
+        if isinstance(net, EthernetNetworkBase):
             ip = self.get_ip(servo)
             full_name = f"{full_name} ({ip})"
         return full_name

--- a/poetry.lock
+++ b/poetry.lock
@@ -1338,18 +1338,18 @@ reference = "novanta"
 
 [[package]]
 name = "ingenialink"
-version = "7.5.2+g9d07ab1bc"
+version = "7.5.2+g939f8461f"
 description = "IngeniaLink Communications Library"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "tests"]
 files = [
-    {file = "ingenialink-7.5.2+g9d07ab1bc-cp310-cp310-win_amd64.whl", hash = "sha256:b4096ecd566a482925dfec28b5e49e61077f195430dea2100eedcc9c15517060"},
-    {file = "ingenialink-7.5.2+g9d07ab1bc-cp311-cp311-win_amd64.whl", hash = "sha256:a58c5d5fa476c87a1aa5b720016bcc4df74ae0163232df1df73b5e9777872fbc"},
-    {file = "ingenialink-7.5.2+g9d07ab1bc-cp312-cp312-win_amd64.whl", hash = "sha256:81ee4bdc25519eaf0e459b3be30cc178bf04329f8c0d3f0c7e8141544a985d46"},
-    {file = "ingenialink-7.5.2+g9d07ab1bc-cp39-cp39-win_amd64.whl", hash = "sha256:9196da302506c556aecc3391f6a29808a53936f3a78b578b9492d95d6cb49b3f"},
-    {file = "ingenialink-7.5.2+g9d07ab1bc-py3-none-any.whl", hash = "sha256:f165a9fdd0c6773b165730010c261226ce6ca5dea4c4fa7108c1256d9e5d934c"},
-    {file = "ingenialink-7.5.2+g9d07ab1bc.tar.gz", hash = "sha256:f7eea1f4c9dce3943de4c391e7cb128f32f4623a9a458a8108818515bf7f7f93"},
+    {file = "ingenialink-7.5.2+g939f8461f-cp310-cp310-win_amd64.whl", hash = "sha256:abfa6cfc15d5b46eb8d64cbd678367df049014be3f0dc12691aa888286a8f10d"},
+    {file = "ingenialink-7.5.2+g939f8461f-cp311-cp311-win_amd64.whl", hash = "sha256:d78aedd157c6dd07e4d2e606a23ec2fad91f735a5c86ffd97ac6351bc9ea9db7"},
+    {file = "ingenialink-7.5.2+g939f8461f-cp312-cp312-win_amd64.whl", hash = "sha256:b4f118d5b2bb765c86f7ce0f643d8dbec6dbae585b3517477b7b5ca8578b835b"},
+    {file = "ingenialink-7.5.2+g939f8461f-cp39-cp39-win_amd64.whl", hash = "sha256:270963c9e70a2643c4023034fd5b442a32bae8fd72f98aef4fc77605baaf5e2f"},
+    {file = "ingenialink-7.5.2+g939f8461f-py3-none-any.whl", hash = "sha256:bc4e8e104d1c172b059498b0503b6a2994de671d7821090fe5b9cbea944a0f23"},
+    {file = "ingenialink-7.5.2+g939f8461f.tar.gz", hash = "sha256:ca7d832ec92dd9516b61fbd1d4b50c219ce50ba31bf51ad9d8f6a11560da0b95"},
 ]
 
 [package.dependencies]
@@ -1361,10 +1361,10 @@ numpy = ">=1.26.0"
 ping3 = "4.0.3"
 pysoem = ">=1.1.13,<1.2.0"
 python-can = "4.4.2"
-virtual_drive = {version = "0.0.0+gbd3e3d8f8", optional = true, markers = "extra == \"virtual-drive\""}
+virtual_drive = {version = "0.0.0+gee364581e", optional = true, markers = "extra == \"virtual-drive\""}
 
 [package.extras]
-virtual-drive = ["virtual_drive (==0.0.0+gbd3e3d8f8)"]
+virtual-drive = ["virtual_drive (==0.0.0+gee364581e)"]
 
 [package.source]
 type = "legacy"
@@ -4432,13 +4432,13 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtual-drive"
-version = "0.0+gbd3e3d8f8"
+version = "0.0+gee364581e"
 description = "Emulates a Summit drive for development and testing purposes."
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "virtual_drive-0.0+gbd3e3d8f8-py3-none-any.whl", hash = "sha256:efc0da7412b49bde573413380194494512c181c982f65cfd2572d76f1e143d49"},
+    {file = "virtual_drive-0.0+gee364581e-py3-none-any.whl", hash = "sha256:759b2ddbf5622fa3da52391efaff5527d792ad5cec0a2b7ca864c952ecfdca8a"},
 ]
 
 [package.dependencies]
@@ -4784,4 +4784,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "129978e10dbea4c885bf87ae39c6d4b78f6a9bc28f341df0a4b04ee641341209"
+content-hash = "1928cbaa6d7347a5593dc8aefd97fe6beae36d048700737d423bbc493dc26622"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ pytest-mock = "==3.6.1"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-ingenialink = {extras = ["virtual_drive"], version = "7.5.2+g9d07ab1bc"}
+ingenialink = {extras = ["virtual_drive"], version = "7.5.2+g939f8461f"}
 summit-testing-framework = {version = "==0.2.0+pr76b31"}
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
This pull request makes a minor update to exception handling in the `ingeniamotion/capture.py` file. The change ensures that the code catches a more general `ILError` exception instead of just `ILIOError` when checking the monitoring version, and imports `ILError` accordingly. This improves robustness in error handling.

- Exception handling improvement:
  * Updated `_check_version` to catch `ILError` instead of only `ILIOError`, and imported `ILError` from `ingenialink.exceptions` to support this change. [[1]](diffhunk://#diff-fbf2a038c5d21ee547ace76454dc2fcbb5df34417c2c5b7f0ba59add232ce913L5-R5) [[2]](diffhunk://#diff-fbf2a038c5d21ee547ace76454dc2fcbb5df34417c2c5b7f0ba59add232ce913L321-R321)