### PR TITLE
MOT3-5405 Introduce SystemQueueError class and enhance error handling

### DIFF
--- a/ingeniamotion/errors.py
+++ b/ingeniamotion/errors.py
@@ -92,14 +92,17 @@ class OperationError(Error):
 
     @classmethod
     def from_id(cls, error_id: int, dictionary: Optional[Dictionary] = None) -> Optional["Error"]:
-        """Get an Error instance from an error ID.
+        """Get an OperationError instance from an error ID.
+
+        The dictionary lookup uses the masked error code (lower 16 bits) instead of
+        the full error_id, which may contain additional flag bits (e.g. warning bit).
 
         Args:
             error_id: Error ID.
             dictionary: Dictionary to get the error description from.
 
         Returns:
-            Error: Error instance, or None if error_id is 0.
+            OperationError: Error instance, or None if error_id is 0.
         """
         if error_id == 0:
             return None

--- a/ingeniamotion/errors.py
+++ b/ingeniamotion/errors.py
@@ -77,8 +77,6 @@ class OperationError(Error):
     """Class to represent an operation error from the servo."""
 
     __ERROR_CODE_BITS = 0xFFFF
-    __ERROR_SUBNODE_BITS = 0xF00000
-    __ERROR_SUBNODE_SHIFT = 20
     __ERROR_WARNING_BIT = 0x10000000
     __ERROR_WARNING_SHIFT = 28
 
@@ -88,14 +86,43 @@ class OperationError(Error):
         return self._error_id & self.__ERROR_CODE_BITS
 
     @property
-    def axis(self) -> int:
-        """Get the error axis. If 0, it is a COCO error."""
-        return (self._error_id & self.__ERROR_SUBNODE_BITS) >> self.__ERROR_SUBNODE_SHIFT
-
-    @property
     def is_warning(self) -> bool:
         """Check if the error is a warning."""
         return bool((self._error_id & self.__ERROR_WARNING_BIT) >> self.__ERROR_WARNING_SHIFT)
+
+    @classmethod
+    def from_id(cls, error_id: int, dictionary: Optional[Dictionary] = None) -> Optional["Error"]:
+        """Get an Error instance from an error ID.
+
+        Args:
+            error_id: Error ID.
+            dictionary: Dictionary to get the error description from.
+
+        Returns:
+            Error: Error instance, or None if error_id is 0.
+        """
+        if error_id == 0:
+            return None
+
+        dictionary_error = None
+
+        if dictionary:
+            error_code = error_id & cls.__ERROR_CODE_BITS
+            dictionary_error = dictionary.errors.get(error_code, None)
+
+        return cls(error_id, dictionary_error)
+
+
+class SystemQueueError(OperationError):
+    """Class to represent a system error from the servo."""
+
+    __ERROR_SUBNODE_BITS = 0xF00000
+    __ERROR_SUBNODE_SHIFT = 20
+
+    @property
+    def axis(self) -> int:
+        """Get the error axis. If 0, it is a COCO error."""
+        return (self._error_id & self.__ERROR_SUBNODE_BITS) >> self.__ERROR_SUBNODE_SHIFT
 
 
 @dataclass()
@@ -281,7 +308,7 @@ SYSTEM_ERROR_QUEUE = ErrorQueueDescriptor(
     error_request_index_reg_uid="DRV_DIAG_SYS_ERROR_LIST_IDX_COM",
     error_request_code_reg_uid="DRV_DIAG_SYS_ERROR_LIST_CODE_COM",
     max_index_request=31,
-    error_type=OperationError,
+    error_type=SystemQueueError,
 )
 
 
@@ -372,12 +399,9 @@ class Errors:
     ) -> tuple[int, Optional[int], Optional[bool]]:
         if not isinstance(error, OperationError):
             return error.error_id, None, None
-        error_code = error.error_code
-        if error_code == 0:
-            return error_code, None, None
-        if subnode is None:
-            subnode = error.axis
-        return error_code, subnode, error.is_warning
+        if isinstance(error, SystemQueueError):
+            return error.error_code, error.axis, error.is_warning
+        return error.error_code, subnode, error.is_warning
 
     def _get_error_location(self, servo: str = DEFAULT_SERVO) -> ErrorLocation:
         """Determine the error location based on available registers.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
 
 
-def not_valid_for_eve_products(func: Callable) -> Callable:
-    """Decorator that applies not_valid_for_product markers for all EVE products.
+def not_valid_for_eve_CAN_ECAT_products(func: Callable) -> Callable:
+    """Decorator that applies not_valid_for_product markers for CAN and ECAT EVE products.
 
     Returns:
         The decorated function with the markers applied.
@@ -32,6 +32,33 @@ def not_valid_for_eve_products(func: Callable) -> Callable:
         func
     )
     func = pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])(
+        func
+    )
+    return func
+
+
+def not_valid_for_all_eve_products(func: Callable) -> Callable:
+    """Decorator that applies not_valid_for_product markers for all EVE products.
+
+    Returns:
+        The decorated function with the markers applied.
+    """
+    func = pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])(
+        func
+    )
+    func = pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])(
+        func
+    )
+    func = pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.ETH])(
+        func
+    )
+    func = pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])(
+        func
+    )
+    func = pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])(
+        func
+    )
+    func = pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.ETH])(
         func
     )
     return func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
 
 
-def not_valid_for_eve_CAN_ECAT_products(func: Callable) -> Callable:
+def not_valid_for_eve_can_ecat_products(func: Callable) -> Callable:
     """Decorator that applies not_valid_for_product markers for CAN and ECAT EVE products.
 
     Returns:

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -11,7 +11,7 @@ from ingeniamotion.enums import (
     OperationMode,
 )
 from ingeniamotion.exceptions import IMMonitoringError, IMStatusWordError
-from tests.conftest import not_valid_for_eve_CAN_ECAT_products
+from tests.conftest import not_valid_for_eve_can_ecat_products
 
 
 def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
@@ -53,7 +53,7 @@ def test_create_poller(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_create_monitoring_no_trigger(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     mc.motion.set_operation_mode(OperationMode.VELOCITY, alias)
@@ -86,7 +86,7 @@ def test_create_monitoring_no_trigger(mc, alias):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 @pytest.mark.parametrize(
     "trigger_mode, trigger_config, values_list",
@@ -154,7 +154,7 @@ def test_create_monitoring_edge_trigger(
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("trigger_delay_rate", [-1 / 4, 1 / 4])
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_create_monitoring_trigger_delay(
     mc,
     alias,
@@ -213,7 +213,7 @@ def test_create_monitoring_trigger_delay(
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 def test_create_disturbance(mc, alias):
     target_register = "CL_POS_SET_POINT_VALUE"
@@ -262,7 +262,7 @@ def test_mcb_synchronization_fail(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_disturbance_max_sample_size(mc, alias):
     target_register = mc.capture.DISTURBANCE_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -273,7 +273,7 @@ def test_disturbance_max_sample_size(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -287,7 +287,7 @@ def test_monitoring_max_sample_size(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_get_frequency(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     max_frequency = mc.configuration.get_position_and_velocity_loop_rate(alias)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -11,7 +11,7 @@ from ingeniamotion.enums import (
     OperationMode,
 )
 from ingeniamotion.exceptions import IMMonitoringError, IMStatusWordError
-from tests.conftest import not_valid_for_eve_products
+from tests.conftest import not_valid_for_eve_CAN_ECAT_products
 
 
 def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
@@ -53,7 +53,7 @@ def test_create_poller(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_create_monitoring_no_trigger(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     mc.motion.set_operation_mode(OperationMode.VELOCITY, alias)
@@ -86,7 +86,7 @@ def test_create_monitoring_no_trigger(mc, alias):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 @pytest.mark.parametrize(
     "trigger_mode, trigger_config, values_list",
@@ -154,7 +154,7 @@ def test_create_monitoring_edge_trigger(
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("trigger_delay_rate", [-1 / 4, 1 / 4])
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_create_monitoring_trigger_delay(
     mc,
     alias,
@@ -213,7 +213,7 @@ def test_create_monitoring_trigger_delay(
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 def test_create_disturbance(mc, alias):
     target_register = "CL_POS_SET_POINT_VALUE"
@@ -262,7 +262,7 @@ def test_mcb_synchronization_fail(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_disturbance_max_sample_size(mc, alias):
     target_register = mc.capture.DISTURBANCE_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -273,7 +273,7 @@ def test_disturbance_max_sample_size(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -287,7 +287,7 @@ def test_monitoring_max_sample_size(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_get_frequency(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     max_frequency = mc.configuration.get_position_and_velocity_loop_rate(alias)

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -2,7 +2,7 @@ import pytest
 
 from ingeniamotion.disturbance import Disturbance
 from ingeniamotion.exceptions import IMDisturbanceError
-from tests.conftest import not_valid_for_eve_CAN_ECAT_products
+from tests.conftest import not_valid_for_eve_can_ecat_products
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def disturbance(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_disturbance_max_sample_size(mc, alias, disturbance):
     max_sample_size = disturbance.max_sample_number
     value = mc.communication.get_register(
@@ -29,7 +29,7 @@ def test_disturbance_max_sample_size(mc, alias, disturbance):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_set_frequency_divider(mc, alias, disturbance, prescaler):
     disturbance.set_frequency_divider(prescaler)
     value = mc.communication.get_register(
@@ -41,7 +41,7 @@ def test_set_frequency_divider(mc, alias, disturbance, prescaler):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_set_frequency_divider_exception(disturbance):
     prescaler = -1
     with pytest.raises(ValueError):
@@ -51,7 +51,7 @@ def test_set_frequency_divider_exception(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 @pytest.mark.parametrize(
     "axis, name, expected_value",
     [
@@ -72,7 +72,7 @@ def test_disturbance_map_registers(mc, alias, disturbance, axis, name, expected_
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 @pytest.mark.parametrize("number_registers", list(range(1, 17)))
 def test_disturbance_number_map_registers(mc, alias, disturbance, number_registers):
     reg_dict = {"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}
@@ -85,7 +85,7 @@ def test_disturbance_number_map_registers(mc, alias, disturbance, number_registe
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_disturbance_map_registers_sample_number(disturbance):
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]
     value = disturbance.map_registers(registers)
@@ -93,7 +93,7 @@ def test_disturbance_map_registers_sample_number(disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_disturbance_map_registers_exception(disturbance):
     registers = [{"axis": 0, "name": "DRV_AXIS_NUMBER"}]
     with pytest.raises(IMDisturbanceError):
@@ -101,7 +101,7 @@ def test_disturbance_map_registers_exception(disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_disturbance_map_registers_empty(disturbance):
     registers = []
     with pytest.raises(IMDisturbanceError):
@@ -111,7 +111,7 @@ def test_disturbance_map_registers_empty(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 @pytest.mark.usefixtures("disturbance_map_registers")
 def test_write_disturbance_data_buffer_exception(disturbance):
     with pytest.raises(IMDisturbanceError):
@@ -119,7 +119,7 @@ def test_write_disturbance_data_buffer_exception(disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_write_disturbance_data_not_configured(disturbance):
     with pytest.raises(IMDisturbanceError):
         disturbance.write_disturbance_data([0] * 100)
@@ -128,7 +128,7 @@ def test_write_disturbance_data_not_configured(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 def test_write_disturbance_data_enabled(mc, alias, disturbance):
     mc.capture.enable_disturbance(alias)
@@ -137,7 +137,7 @@ def test_write_disturbance_data_enabled(mc, alias, disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_disturbance_map_registers_invalid_subnode(mocker, mc, disturbance):
     registers = [{"axis": "1", "name": "DRV_AXIS_NUMBER"}]
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
@@ -146,7 +146,7 @@ def test_disturbance_map_registers_invalid_subnode(mocker, mc, disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_disturbance_map_registers_invalid_register(mocker, mc, disturbance):
     registers = [{"axis": 1, "name": 1}]
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
@@ -155,7 +155,7 @@ def test_disturbance_map_registers_invalid_register(mocker, mc, disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_write_disturbance_data_wrong_data_type(mocker, mc, disturbance):
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -2,7 +2,7 @@ import pytest
 
 from ingeniamotion.disturbance import Disturbance
 from ingeniamotion.exceptions import IMDisturbanceError
-from tests.conftest import not_valid_for_eve_products
+from tests.conftest import not_valid_for_eve_CAN_ECAT_products
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def disturbance(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_disturbance_max_sample_size(mc, alias, disturbance):
     max_sample_size = disturbance.max_sample_number
     value = mc.communication.get_register(
@@ -29,7 +29,7 @@ def test_disturbance_max_sample_size(mc, alias, disturbance):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_set_frequency_divider(mc, alias, disturbance, prescaler):
     disturbance.set_frequency_divider(prescaler)
     value = mc.communication.get_register(
@@ -41,7 +41,7 @@ def test_set_frequency_divider(mc, alias, disturbance, prescaler):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_set_frequency_divider_exception(disturbance):
     prescaler = -1
     with pytest.raises(ValueError):
@@ -51,7 +51,7 @@ def test_set_frequency_divider_exception(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 @pytest.mark.parametrize(
     "axis, name, expected_value",
     [
@@ -72,7 +72,7 @@ def test_disturbance_map_registers(mc, alias, disturbance, axis, name, expected_
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 @pytest.mark.parametrize("number_registers", list(range(1, 17)))
 def test_disturbance_number_map_registers(mc, alias, disturbance, number_registers):
     reg_dict = {"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}
@@ -85,7 +85,7 @@ def test_disturbance_number_map_registers(mc, alias, disturbance, number_registe
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_disturbance_map_registers_sample_number(disturbance):
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]
     value = disturbance.map_registers(registers)
@@ -93,7 +93,7 @@ def test_disturbance_map_registers_sample_number(disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_disturbance_map_registers_exception(disturbance):
     registers = [{"axis": 0, "name": "DRV_AXIS_NUMBER"}]
     with pytest.raises(IMDisturbanceError):
@@ -101,7 +101,7 @@ def test_disturbance_map_registers_exception(disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_disturbance_map_registers_empty(disturbance):
     registers = []
     with pytest.raises(IMDisturbanceError):
@@ -111,7 +111,7 @@ def test_disturbance_map_registers_empty(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 @pytest.mark.usefixtures("disturbance_map_registers")
 def test_write_disturbance_data_buffer_exception(disturbance):
     with pytest.raises(IMDisturbanceError):
@@ -119,7 +119,7 @@ def test_write_disturbance_data_buffer_exception(disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_write_disturbance_data_not_configured(disturbance):
     with pytest.raises(IMDisturbanceError):
         disturbance.write_disturbance_data([0] * 100)
@@ -128,7 +128,7 @@ def test_write_disturbance_data_not_configured(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 def test_write_disturbance_data_enabled(mc, alias, disturbance):
     mc.capture.enable_disturbance(alias)
@@ -137,7 +137,7 @@ def test_write_disturbance_data_enabled(mc, alias, disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_disturbance_map_registers_invalid_subnode(mocker, mc, disturbance):
     registers = [{"axis": "1", "name": "DRV_AXIS_NUMBER"}]
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
@@ -146,7 +146,7 @@ def test_disturbance_map_registers_invalid_subnode(mocker, mc, disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_disturbance_map_registers_invalid_register(mocker, mc, disturbance):
     registers = [{"axis": 1, "name": 1}]
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
@@ -155,7 +155,7 @@ def test_disturbance_map_registers_invalid_register(mocker, mc, disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_write_disturbance_data_wrong_data_type(mocker, mc, disturbance):
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 USER_UNDER_VOLTAGE_ERROR_OPTION_CODE_REGISTER = "ERROR_PROT_UNDER_VOLT_OPTION"
 USER_UNDER_VOLTAGE_LEVEL_REGISTER = "DRV_PROT_USER_UNDER_VOLT"
-UNDER_TEMO_ERROR_CODE = 0x4304
+UNDER_TEMP_ERROR_CODE = 0x4304
 UNDER_TEMP_ERROR_OPTION_REGISTER = "ERROR_PROT_UNDER_TEMP_OPTION"
 UNDER_TEMP_REGISTER = "DRV_PROT_USER_UNDER_TEMP"
 OPTION_DO_NOTHING = 1
@@ -58,12 +58,12 @@ def generate_drive_errors(mc: "MotionController", alias: str) -> Iterator[list[i
 
 
 @pytest.fixture
-def generate_drive_warning(mc: "MotionController", alias: str) -> None:
+def generate_drive_warning(mc: "MotionController", alias: str) -> Iterator[int]:
     """Generate an under-temperature warning."""
     mc.communication.set_register(UNDER_TEMP_ERROR_OPTION_REGISTER, OPTION_DO_NOTHING, servo=alias)
     mc.communication.set_register(UNDER_TEMP_REGISTER, 100, servo=alias)
     mc.motion.motor_enable(servo=alias)
-    yield UNDER_TEMO_ERROR_CODE
+    yield UNDER_TEMP_ERROR_CODE
     mc.motion.motor_disable(servo=alias)
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -94,7 +94,7 @@ def test_operation_error_class_properties(
     expected_is_warning: bool,
 ) -> None:
     """Test OperationError class error_code, axis, and is_warning properties."""
-    error = OperationError.from_id(error_id)
+    error = SystemQueueError.from_id(error_id)
     assert error.error_code == expected_error_code
     assert error.axis == expected_axis
     assert error.is_warning is expected_is_warning

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -5,7 +5,13 @@ from typing import TYPE_CHECKING
 import pytest
 from ingenialink.exceptions import ILError
 
-from ingeniamotion.errors import MOCO_ERROR_QUEUE, OperationError, ServoErrorQueue
+from ingeniamotion.errors import (
+    MOCO_ERROR_QUEUE,
+    SYSTEM_ERROR_QUEUE,
+    OperationError,
+    ServoErrorQueue,
+    SystemQueueError,
+)
 
 if TYPE_CHECKING:
     from ingenialink.servo import Servo
@@ -15,6 +21,10 @@ if TYPE_CHECKING:
 
 USER_UNDER_VOLTAGE_ERROR_OPTION_CODE_REGISTER = "ERROR_PROT_UNDER_VOLT_OPTION"
 USER_UNDER_VOLTAGE_LEVEL_REGISTER = "DRV_PROT_USER_UNDER_VOLT"
+UNDER_TEMO_ERROR_CODE = 0x4304
+UNDER_TEMP_ERROR_OPTION_REGISTER = "ERROR_PROT_UNDER_TEMP_OPTION"
+UNDER_TEMP_REGISTER = "DRV_PROT_USER_UNDER_TEMP"
+OPTION_DO_NOTHING = 1
 
 
 @pytest.fixture
@@ -45,6 +55,15 @@ def generate_drive_errors(mc: "MotionController", alias: str) -> Iterator[list[i
             mc.communication.set_register(item["register"], old_value, servo=alias)
     yield error_code_list[::-1]
     mc.motion.fault_reset(servo=alias)
+
+
+@pytest.fixture
+def generate_drive_warning(mc: "MotionController", alias: str) -> None:
+    mc.communication.set_register(UNDER_TEMP_ERROR_OPTION_REGISTER, OPTION_DO_NOTHING, servo=alias)
+    mc.communication.set_register(UNDER_TEMP_REGISTER, 100, servo=alias)
+    mc.motion.motor_enable(servo=alias)
+    yield UNDER_TEMO_ERROR_CODE
+    mc.motion.motor_disable(servo=alias)
 
 
 @pytest.fixture
@@ -296,7 +315,7 @@ class TestErrors:
     @pytest.mark.ethernet
     @pytest.mark.soem
     @pytest.mark.canopen
-    def test_error_queue_get_last_error(
+    def test_error_queue_get_last_error_moco(
         self,
         mc: "MotionController",
         servo: "Servo",
@@ -309,10 +328,72 @@ class TestErrors:
         last_error = error_queue.get_last_error()
 
         assert last_error is not None
-        assert last_error.error_id == generate_drive_errors[0]
+        assert isinstance(last_error, OperationError)
+        assert last_error.error_code == generate_drive_errors[0]
+        assert last_error.is_warning is False
         assert last_error.error_description is not None
 
         # After fault reset, should return None
         mc.motion.fault_reset(servo=alias)
         last_error = error_queue.get_last_error()
         assert last_error is None
+
+    @pytest.mark.ethernet
+    @pytest.mark.soem
+    @pytest.mark.canopen
+    def test_error_queue_get_error_by_index_moco_warning(
+        self, servo: "Servo", generate_drive_warning: int
+    ) -> None:
+        """Test ServoErrorQueue.get_last_error() method."""
+        error_queue = ServoErrorQueue(MOCO_ERROR_QUEUE, servo)
+        last_buffer_error = error_queue.get_error_by_index(0)
+
+        assert last_buffer_error is not None
+        assert isinstance(last_buffer_error, OperationError)
+        assert last_buffer_error.error_code == generate_drive_warning
+        assert last_buffer_error.is_warning is True
+        assert last_buffer_error.error_description == "Under-temperature detected (user limit)"
+
+    @pytest.mark.ethernet
+    @pytest.mark.soem
+    @pytest.mark.canopen
+    def test_error_queue_get_last_error_system(
+        self,
+        mc: "MotionController",
+        servo: "Servo",
+        alias: str,
+        generate_drive_errors: list[int],
+    ) -> None:
+        """Test ServoErrorQueue.get_last_error() method."""
+        # generate_drive_errors fixture already power cycled and cleared errors
+        error_queue = ServoErrorQueue(SYSTEM_ERROR_QUEUE, servo, axis=0)
+        last_error = error_queue.get_last_error()
+
+        assert last_error is not None
+        assert isinstance(last_error, SystemQueueError)
+        assert last_error.error_code == generate_drive_errors[0]
+        assert last_error.axis == 1
+        assert last_error.is_warning is False
+        assert last_error.error_description is not None
+
+        # After fault reset, should return None
+        mc.motion.fault_reset(servo=alias)
+        last_error = error_queue.get_last_error()
+        assert last_error is None
+
+    @pytest.mark.ethernet
+    @pytest.mark.soem
+    @pytest.mark.canopen
+    def test_error_queue_get_error_by_index_system_warning(
+        self, servo: "Servo", generate_drive_warning: int
+    ) -> None:
+        """Test ServoErrorQueue.get_last_error() method."""
+        error_queue = ServoErrorQueue(SYSTEM_ERROR_QUEUE, servo, axis=0)
+        last_buffer_error = error_queue.get_error_by_index(0)
+
+        assert last_buffer_error is not None
+        assert isinstance(last_buffer_error, SystemQueueError)
+        assert last_buffer_error.error_code == generate_drive_warning
+        assert last_buffer_error.axis == 1
+        assert last_buffer_error.is_warning is True
+        assert last_buffer_error.error_description == "Under-temperature detected (user limit)"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -12,6 +12,7 @@ from ingeniamotion.errors import (
     ServoErrorQueue,
     SystemQueueError,
 )
+from tests.conftest import not_valid_for_eve_products
 
 if TYPE_CHECKING:
     from ingenialink.servo import Servo

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -390,6 +390,7 @@ class TestErrors:
     @pytest.mark.ethernet
     @pytest.mark.soem
     @pytest.mark.canopen
+    @not_valid_for_eve_products
     def test_error_queue_get_error_by_index_system_warning(
         self, servo: "Servo", generate_drive_warning: int
     ) -> None:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -12,7 +12,7 @@ from ingeniamotion.errors import (
     ServoErrorQueue,
     SystemQueueError,
 )
-from tests.conftest import not_valid_for_eve_products
+from tests.conftest import not_valid_for_all_eve_products
 
 if TYPE_CHECKING:
     from ingenialink.servo import Servo
@@ -391,7 +391,7 @@ class TestErrors:
     @pytest.mark.ethernet
     @pytest.mark.soem
     @pytest.mark.canopen
-    @not_valid_for_eve_products
+    @not_valid_for_all_eve_products
     def test_error_queue_get_error_by_index_system_warning(
         self, servo: "Servo", generate_drive_warning: int
     ) -> None:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -59,7 +59,12 @@ def generate_drive_errors(mc: "MotionController", alias: str) -> Iterator[list[i
 
 @pytest.fixture
 def generate_drive_warning(mc: "MotionController", alias: str) -> Iterator[int]:
-    """Generate an under-temperature warning."""
+    """Generate an under-temperature warning.
+
+    Yields:
+        The error code of the generated warning.
+
+    """
     mc.communication.set_register(UNDER_TEMP_ERROR_OPTION_REGISTER, OPTION_DO_NOTHING, servo=alias)
     mc.communication.set_register(UNDER_TEMP_REGISTER, 100, servo=alias)
     mc.motion.motor_enable(servo=alias)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -59,6 +59,7 @@ def generate_drive_errors(mc: "MotionController", alias: str) -> Iterator[list[i
 
 @pytest.fixture
 def generate_drive_warning(mc: "MotionController", alias: str) -> None:
+    """Generate an under-temperature warning."""
     mc.communication.set_register(UNDER_TEMP_ERROR_OPTION_REGISTER, OPTION_DO_NOTHING, servo=alias)
     mc.communication.set_register(UNDER_TEMP_REGISTER, 100, servo=alias)
     mc.motion.motor_enable(servo=alias)
@@ -322,7 +323,7 @@ class TestErrors:
         alias: str,
         generate_drive_errors: list[int],
     ) -> None:
-        """Test ServoErrorQueue.get_last_error() method."""
+        """Test ServoErrorQueue.get_last_error() method with MOCO queue."""
         # generate_drive_errors fixture already power cycled and cleared errors
         error_queue = ServoErrorQueue(MOCO_ERROR_QUEUE, servo)
         last_error = error_queue.get_last_error()
@@ -344,7 +345,7 @@ class TestErrors:
     def test_error_queue_get_error_by_index_moco_warning(
         self, servo: "Servo", generate_drive_warning: int
     ) -> None:
-        """Test ServoErrorQueue.get_last_error() method."""
+        """Test ServoErrorQueue.get_error_by_index() method with MOCO queue and a warning."""
         error_queue = ServoErrorQueue(MOCO_ERROR_QUEUE, servo)
         last_buffer_error = error_queue.get_error_by_index(0)
 
@@ -364,7 +365,7 @@ class TestErrors:
         alias: str,
         generate_drive_errors: list[int],
     ) -> None:
-        """Test ServoErrorQueue.get_last_error() method."""
+        """Test ServoErrorQueue.get_last_error() method with System queue."""
         # generate_drive_errors fixture already power cycled and cleared errors
         error_queue = ServoErrorQueue(SYSTEM_ERROR_QUEUE, servo, axis=0)
         last_error = error_queue.get_last_error()
@@ -387,7 +388,7 @@ class TestErrors:
     def test_error_queue_get_error_by_index_system_warning(
         self, servo: "Servo", generate_drive_warning: int
     ) -> None:
-        """Test ServoErrorQueue.get_last_error() method."""
+        """Test ServoErrorQueue.get_error_by_index() method with System queue and a warning."""
         error_queue = ServoErrorQueue(SYSTEM_ERROR_QUEUE, servo, axis=0)
         last_buffer_error = error_queue.get_error_by_index(0)
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -6,7 +6,7 @@ import pytest
 
 from ingeniamotion.enums import MonitoringSoCConfig, MonitoringSoCType
 from ingeniamotion.exceptions import IMMonitoringError
-from tests.conftest import not_valid_for_eve_CAN_ECAT_products
+from tests.conftest import not_valid_for_eve_can_ecat_products
 
 MONITOR_START_CONDITION_TYPE_REGISTER = "MON_CFG_SOC_TYPE"
 
@@ -49,7 +49,7 @@ def mon_map_registers(monitoring):
         4,  # Invalid value
     ],
 )
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_get_trigger_type(mc, alias, monitoring, trigger_type):
     mc.communication.set_register(
         MONITOR_START_CONDITION_TYPE_REGISTER, trigger_type, servo=alias, axis=0
@@ -73,7 +73,7 @@ def test_get_trigger_type(mc, alias, monitoring, trigger_type):
         (True, 0.1, 0.8, 0, False),
     ],
 )
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_raise_forced_trigger(
     mc,
     alias,
@@ -99,7 +99,7 @@ def test_raise_forced_trigger(
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_raise_forced_trigger_fail(mc, alias, monitoring):
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_AUTO)
     monitoring.configure_sample_time(0.8, 0)
@@ -121,7 +121,7 @@ def test_raise_forced_trigger_fail(mc, alias, monitoring):
         (0.1, 0.8, False),
     ],
 )
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_read_monitoring_data_forced_trigger(mc, alias, monitoring, timeout, sample_t, result):
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_FORCED)
     monitoring.configure_sample_time(sample_t, 0)
@@ -137,7 +137,7 @@ def test_read_monitoring_data_forced_trigger(mc, alias, monitoring, timeout, sam
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_set_monitoring_frequency(mc, alias, monitoring, prescaler):
     monitoring.set_frequency(prescaler)
     value = mc.communication.get_register(
@@ -149,7 +149,7 @@ def test_set_monitoring_frequency(mc, alias, monitoring, prescaler):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_set_monitoring_frequency_exception(monitoring):
     prescaler = 0.5
     with pytest.raises(ValueError):
@@ -157,7 +157,7 @@ def test_set_monitoring_frequency_exception(monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_monitoring_map_registers_size_exception(monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     monitoring.samples_number = monitoring.max_sample_number
@@ -166,7 +166,7 @@ def test_monitoring_map_registers_size_exception(monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_monitoring_map_registers_fail(monitoring):
     registers = []
     with pytest.raises(IMMonitoringError):
@@ -174,7 +174,7 @@ def test_monitoring_map_registers_fail(monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_monitoring_map_registers_wrong_cyclic(monitoring):
     registers = [{"axis": 1, "name": "DRV_STATE_CONTROL"}]
     with pytest.raises(IMMonitoringError):
@@ -198,7 +198,7 @@ def test_monitoring_map_registers_wrong_cyclic(monitoring):
         ),
     ],
 )
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_monitoring_set_trigger(
     mc,
     alias,
@@ -237,7 +237,7 @@ def test_monitoring_set_trigger(
         ),
     ],
 )
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_monitoring_set_trigger_exceptions(
     monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
 ):
@@ -248,7 +248,7 @@ def test_monitoring_set_trigger_exceptions(
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_configure_number_samples(mc, alias, monitoring):
     total_num_samples = 500
     trigger_delay_samples = 100
@@ -267,7 +267,7 @@ def test_configure_number_samples(mc, alias, monitoring):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("total_num_samples, trigger_delay_samples", [(500, 510), (510, -500)])
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_configure_number_samples_exceptions(monitoring, total_num_samples, trigger_delay_samples):
     with pytest.raises(ValueError):
         monitoring.configure_number_samples(total_num_samples, trigger_delay_samples)
@@ -276,7 +276,7 @@ def test_configure_number_samples_exceptions(monitoring, total_num_samples, trig
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_configure_sample_time(mc, alias, monitoring):
     total_time = 5
     sampling_freq = 1e4
@@ -299,7 +299,7 @@ def test_configure_sample_time(mc, alias, monitoring):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("total_time, sign", [(5, 1), (5, -1)])
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_configure_sample_time_exception(monitoring, total_time, sign):
     trigger_delay = sign * ((total_time // 2) + 1)
     with pytest.raises(ValueError):
@@ -309,7 +309,7 @@ def test_configure_sample_time_exception(monitoring, total_time, sign):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_enable_monitoring_no_mapped_registers(mc, alias):
     mc.capture.clean_monitoring(alias)
     with pytest.raises(IMMonitoringError) as exc:
@@ -322,7 +322,7 @@ def test_enable_monitoring_no_mapped_registers(mc, alias):
 @pytest.mark.canopen
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_read_monitoring_data_disabled(monitoring):
     monitoring.configure_sample_time(0.8, 0)
     with pytest.raises(IMMonitoringError) as exc:
@@ -336,7 +336,7 @@ def test_read_monitoring_data_disabled(monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_read_monitoring_data_timeout(mc, alias, monitoring):
     timeout = 2
     sample_t = 0.8
@@ -353,7 +353,7 @@ def test_read_monitoring_data_timeout(mc, alias, monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_read_monitoring_data_no_rearm(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 2
@@ -379,7 +379,7 @@ def test_read_monitoring_data_no_rearm(mc, alias, monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_rearm_monitoring(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 2
@@ -419,7 +419,7 @@ def run_read_monitoring_data_and_stop(monitoring, timeout):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_stop_reading_data(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 10
@@ -433,7 +433,7 @@ def test_stop_reading_data(mc, alias, monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -444,7 +444,7 @@ def test_monitoring_max_sample_size(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_monitoring_map_registers_invalid_subnode(mocker, mc, monitoring):
     registers = [{"axis": "1", "name": "DRV_AXIS_NUMBER"}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -453,7 +453,7 @@ def test_monitoring_map_registers_invalid_subnode(mocker, mc, monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_monitoring_map_registers_invalid_register(mocker, mc, monitoring):
     registers = [{"axis": 1, "name": 1}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -462,7 +462,7 @@ def test_monitoring_map_registers_invalid_register(mocker, mc, monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_monitoring_map_registers_invalid_number_mapped_registers(mocker, mc, monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -479,7 +479,7 @@ def test_monitoring_map_registers_invalid_number_mapped_registers(mocker, mc, mo
     ],
 )
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_configure_sample_time_exceptions(
     mocker, mc, monitoring, trigger_delay, expected_exception
 ):
@@ -490,7 +490,7 @@ def test_configure_sample_time_exceptions(
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_CAN_ECAT_products
+@not_valid_for_eve_can_ecat_products
 def test_get_trigger_type_exception(mocker, mc, monitoring):
     mocker.patch.object(mc.communication, "get_register", return_value="invalid_value")
     with pytest.raises(TypeError):

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -6,7 +6,7 @@ import pytest
 
 from ingeniamotion.enums import MonitoringSoCConfig, MonitoringSoCType
 from ingeniamotion.exceptions import IMMonitoringError
-from tests.conftest import not_valid_for_eve_products
+from tests.conftest import not_valid_for_eve_CAN_ECAT_products
 
 MONITOR_START_CONDITION_TYPE_REGISTER = "MON_CFG_SOC_TYPE"
 
@@ -49,7 +49,7 @@ def mon_map_registers(monitoring):
         4,  # Invalid value
     ],
 )
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_get_trigger_type(mc, alias, monitoring, trigger_type):
     mc.communication.set_register(
         MONITOR_START_CONDITION_TYPE_REGISTER, trigger_type, servo=alias, axis=0
@@ -73,7 +73,7 @@ def test_get_trigger_type(mc, alias, monitoring, trigger_type):
         (True, 0.1, 0.8, 0, False),
     ],
 )
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_raise_forced_trigger(
     mc,
     alias,
@@ -99,7 +99,7 @@ def test_raise_forced_trigger(
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_raise_forced_trigger_fail(mc, alias, monitoring):
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_AUTO)
     monitoring.configure_sample_time(0.8, 0)
@@ -121,7 +121,7 @@ def test_raise_forced_trigger_fail(mc, alias, monitoring):
         (0.1, 0.8, False),
     ],
 )
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_read_monitoring_data_forced_trigger(mc, alias, monitoring, timeout, sample_t, result):
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_FORCED)
     monitoring.configure_sample_time(sample_t, 0)
@@ -137,7 +137,7 @@ def test_read_monitoring_data_forced_trigger(mc, alias, monitoring, timeout, sam
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_set_monitoring_frequency(mc, alias, monitoring, prescaler):
     monitoring.set_frequency(prescaler)
     value = mc.communication.get_register(
@@ -149,7 +149,7 @@ def test_set_monitoring_frequency(mc, alias, monitoring, prescaler):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_set_monitoring_frequency_exception(monitoring):
     prescaler = 0.5
     with pytest.raises(ValueError):
@@ -157,7 +157,7 @@ def test_set_monitoring_frequency_exception(monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_monitoring_map_registers_size_exception(monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     monitoring.samples_number = monitoring.max_sample_number
@@ -166,7 +166,7 @@ def test_monitoring_map_registers_size_exception(monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_monitoring_map_registers_fail(monitoring):
     registers = []
     with pytest.raises(IMMonitoringError):
@@ -174,7 +174,7 @@ def test_monitoring_map_registers_fail(monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_monitoring_map_registers_wrong_cyclic(monitoring):
     registers = [{"axis": 1, "name": "DRV_STATE_CONTROL"}]
     with pytest.raises(IMMonitoringError):
@@ -198,7 +198,7 @@ def test_monitoring_map_registers_wrong_cyclic(monitoring):
         ),
     ],
 )
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_monitoring_set_trigger(
     mc,
     alias,
@@ -237,7 +237,7 @@ def test_monitoring_set_trigger(
         ),
     ],
 )
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_monitoring_set_trigger_exceptions(
     monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
 ):
@@ -248,7 +248,7 @@ def test_monitoring_set_trigger_exceptions(
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_configure_number_samples(mc, alias, monitoring):
     total_num_samples = 500
     trigger_delay_samples = 100
@@ -267,7 +267,7 @@ def test_configure_number_samples(mc, alias, monitoring):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("total_num_samples, trigger_delay_samples", [(500, 510), (510, -500)])
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_configure_number_samples_exceptions(monitoring, total_num_samples, trigger_delay_samples):
     with pytest.raises(ValueError):
         monitoring.configure_number_samples(total_num_samples, trigger_delay_samples)
@@ -276,7 +276,7 @@ def test_configure_number_samples_exceptions(monitoring, total_num_samples, trig
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_configure_sample_time(mc, alias, monitoring):
     total_time = 5
     sampling_freq = 1e4
@@ -299,7 +299,7 @@ def test_configure_sample_time(mc, alias, monitoring):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("total_time, sign", [(5, 1), (5, -1)])
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_configure_sample_time_exception(monitoring, total_time, sign):
     trigger_delay = sign * ((total_time // 2) + 1)
     with pytest.raises(ValueError):
@@ -309,7 +309,7 @@ def test_configure_sample_time_exception(monitoring, total_time, sign):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_enable_monitoring_no_mapped_registers(mc, alias):
     mc.capture.clean_monitoring(alias)
     with pytest.raises(IMMonitoringError) as exc:
@@ -322,7 +322,7 @@ def test_enable_monitoring_no_mapped_registers(mc, alias):
 @pytest.mark.canopen
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_read_monitoring_data_disabled(monitoring):
     monitoring.configure_sample_time(0.8, 0)
     with pytest.raises(IMMonitoringError) as exc:
@@ -336,7 +336,7 @@ def test_read_monitoring_data_disabled(monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_read_monitoring_data_timeout(mc, alias, monitoring):
     timeout = 2
     sample_t = 0.8
@@ -353,7 +353,7 @@ def test_read_monitoring_data_timeout(mc, alias, monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_read_monitoring_data_no_rearm(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 2
@@ -379,7 +379,7 @@ def test_read_monitoring_data_no_rearm(mc, alias, monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_rearm_monitoring(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 2
@@ -419,7 +419,7 @@ def run_read_monitoring_data_and_stop(monitoring, timeout):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_stop_reading_data(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 10
@@ -433,7 +433,7 @@ def test_stop_reading_data(mc, alias, monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -444,7 +444,7 @@ def test_monitoring_max_sample_size(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_monitoring_map_registers_invalid_subnode(mocker, mc, monitoring):
     registers = [{"axis": "1", "name": "DRV_AXIS_NUMBER"}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -453,7 +453,7 @@ def test_monitoring_map_registers_invalid_subnode(mocker, mc, monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_monitoring_map_registers_invalid_register(mocker, mc, monitoring):
     registers = [{"axis": 1, "name": 1}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -462,7 +462,7 @@ def test_monitoring_map_registers_invalid_register(mocker, mc, monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_monitoring_map_registers_invalid_number_mapped_registers(mocker, mc, monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -479,7 +479,7 @@ def test_monitoring_map_registers_invalid_number_mapped_registers(mocker, mc, mo
     ],
 )
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_configure_sample_time_exceptions(
     mocker, mc, monitoring, trigger_delay, expected_exception
 ):
@@ -490,7 +490,7 @@ def test_configure_sample_time_exceptions(
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_products
+@not_valid_for_eve_CAN_ECAT_products
 def test_get_trigger_type_exception(mocker, mc, monitoring):
     mocker.patch.object(mc.communication, "get_register", return_value="invalid_value")
     with pytest.raises(TypeError):


### PR DESCRIPTION
This PR fix some bugs added by the last PR:

- Separate old OperationError in two: OperationError (without axis) and SystemQueueError (with axis)
- COCO and MOCO error queue generates OperationError, System queue generates SystemQueueError
- Fix error description in OperationError

### Tests
- [x] Add new unit tests if it applies.

### Documentation

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
