### PR TITLE
SVD-35 Implement SDO protocol adapter for CANopen

### DIFF
--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -26,6 +26,7 @@ from ingenialink.exceptions import ILError
 from ingenialink.network import SlaveInfo
 from ingenialink.register import Register
 from ingenialink.servo import DictionaryFactory, Servo
+from ingenialink.virtual.canopen.network import VirtualCanopenNetwork
 from ingenialink.virtual.ethercat.network import VirtualEthercatNetwork
 from ingenialink.virtual.ethernet.network import VirtualEthernetNetwork
 from ping3 import ping
@@ -36,6 +37,7 @@ from ingeniamotion.exceptions import IMFirmwareLoadError, IMRegisterWrongAccessE
 if TYPE_CHECKING:
     from ingenialink.ethercat.servo import EthercatServo
     from ingenialink.ethernet.servo import EthernetServo
+    from ingenialink.virtual.canopen.servo import VirtualCanopenServo
     from ingenialink.virtual.ethercat.servo import VirtualEthercatServo
     from ingenialink.virtual.ethernet.servo import VirtualEthernetServo
 
@@ -106,6 +108,7 @@ class Communication:
         self.logger = logger
         self.__virtual_drive_ethernet: Optional[VirtualDrive] = None
         self.__virtual_drive_ethercat: Optional[VirtualDrive] = None
+        self.__virtual_drive_canopen: Optional[VirtualDrive] = None
         self.register_update_observers: dict[Servo, list[IMRegisterUpdateObserver]] = {}
         self.emergency_messages_observers: dict[Servo, list[IMEmergencyMessageObserver]] = {}
 
@@ -124,6 +127,9 @@ class Communication:
         if isinstance(network, VirtualEthercatNetwork) and self.__virtual_drive_ethercat:
             self.__virtual_drive_ethercat.stop()
             self.__virtual_drive_ethercat = None
+        if isinstance(network, VirtualCanopenNetwork) and self.__virtual_drive_canopen:
+            self.__virtual_drive_canopen.stop()
+            self.__virtual_drive_canopen = None
 
         # Delegate actual removal/cleanup to MotionController
         self.mc.remove_motion_node(alias)
@@ -455,6 +461,61 @@ class Communication:
             1,
             self.__virtual_drive_ethercat.dictionary_path,
             self.__virtual_drive_ethercat.port,
+            connection_timeout,
+            servo_status_listener=servo_status_listener,
+            net_status_listener=net_status_listener,
+            disconnect_callback=self._disconnect_callback,
+        )
+
+        self.mc.create_motion_node(alias, servo, net)
+        return net, servo
+
+    def connect_servo_virtual_canopen(
+        self,
+        dict_path: Optional[str] = None,
+        alias: str = DEFAULT_SERVO,
+        port: Optional[int] = None,
+        connection_timeout: int = 1,
+        servo_status_listener: bool = False,
+        net_status_listener: bool = False,
+    ) -> tuple[VirtualCanopenNetwork, "VirtualCanopenServo"]:
+        """Connect to the virtual drive using a simulated CANopen communication.
+
+        Args:
+            dict_path : dictionary path. The dictionary must be compatible
+            with CANopen communication.
+            alias : servo alias to reference it. ``default`` by default.
+            port : Port number. If not specified, it will be automatically assigned.
+            connection_timeout: Timeout in seconds for connection.
+                ``1`` seconds by default.
+            servo_status_listener : Toggle the listener of the servo for
+                its status, errors, faults, etc.
+            net_status_listener : Toggle the listener of the network
+                status, connection and disconnection.
+
+        Returns:
+            The virtual network and the connected servo.
+
+        Raises:
+            FileNotFoundError: If the dict file doesn't exist.
+
+        """
+        if dict_path is not None and not path.isfile(dict_path):
+            raise FileNotFoundError(f"{dict_path} file does not exist!")
+
+        if self.__virtual_drive_canopen is None:
+            self.__virtual_drive_canopen = VirtualDrive(
+                port, dictionary_path=dict_path, protocol=Interface.CAN
+            )
+            self.__virtual_drive_canopen.start()
+
+        net = VirtualCanopenNetwork()
+        self.mc.register_network(alias, net)
+
+        servo = net.connect_to_slave(
+            1,
+            self.__virtual_drive_canopen.dictionary_path,
+            self.__virtual_drive_canopen.port,
             connection_timeout,
             servo_status_listener=servo_status_listener,
             net_status_listener=net_status_listener,

--- a/ingeniamotion/information.py
+++ b/ingeniamotion/information.py
@@ -3,11 +3,11 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import ingenialogger
 from ingenialink import CanBaudrate
-from ingenialink.canopen.network import CanopenNetwork
+from ingenialink.canopen.network import CanopenNetwork, CanopenNetworkBase
 from ingenialink.dictionary import SubnodeType
 from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.eoe.network import EoENetwork
-from ingenialink.ethercat.network import EthercatNetwork
+from ingenialink.ethercat.network import EthercatNetworkBase
 from ingenialink.ethernet.network import EthernetNetworkBase
 from ingenialink.register import Register
 
@@ -176,7 +176,7 @@ class Information:
         """
         drive = self.mc._get_drive(servo)
         net = self.mc._get_network(servo)
-        if isinstance(net, CanopenNetwork):
+        if isinstance(net, CanopenNetworkBase):
             return int(drive.target)
         else:
             raise IMError("You need a CANopen communication to use this function")
@@ -234,7 +234,7 @@ class Information:
         net = self.mc._get_network(servo)
         if isinstance(net, EoENetwork) and isinstance(drive.target, str):
             return net._configured_slaves[drive.target]
-        elif isinstance(net, EthercatNetwork) and isinstance(drive.target, int):
+        elif isinstance(net, EthercatNetworkBase) and isinstance(drive.target, int):
             return drive.target
         raise IMError(f"The servo {servo} is not an EtherCAT slave.")
 
@@ -262,11 +262,11 @@ class Information:
 
         """
         drive_network = self.mc._get_network(servo)
-        if isinstance(drive_network, CanopenNetwork):
+        if isinstance(drive_network, CanopenNetworkBase):
             communication_type = CommunicationType.Canopen
         elif isinstance(drive_network, EthernetNetworkBase):
             communication_type = CommunicationType.Ethernet
-        elif isinstance(drive_network, (EoENetwork, EthercatNetwork)):
+        elif isinstance(drive_network, (EoENetwork, EthercatNetworkBase)):
             communication_type = CommunicationType.Ethercat
         else:
             raise NotImplementedError("Unknown communication type.")

--- a/poetry.lock
+++ b/poetry.lock
@@ -4199,13 +4199,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.2.0+pr80b6"
+version = "0.2.0+pr83b1"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.2.0+pr80b6-py3-none-any.whl", hash = "sha256:20a627b51b50066404ec8069ae699e34834695dd348c240bd62ddde7d5c7d800"},
+    {file = "summit_testing_framework-0.2.0+pr83b1-py3-none-any.whl", hash = "sha256:564927e06d49a88e5ceceef787dc618e73475d19bfd89b2ae404b8a1e3618ff5"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "efe6a5837467270f6a2810b93de45bd224a4e0f0445577ed4a74dfb279e72307"
+content-hash = "9bbe629e5c25c4c4dee42dfdde40e13259ae9b50255bbd47e9c93b451aea6f1d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1338,18 +1338,18 @@ reference = "novanta"
 
 [[package]]
 name = "ingenialink"
-version = "7.5.2+pr734b1"
+version = "7.5.2+pr742b8"
 description = "IngeniaLink Communications Library"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "tests"]
 files = [
-    {file = "ingenialink-7.5.2+pr734b1-cp310-cp310-win_amd64.whl", hash = "sha256:b84857b179a7d32b55e4e64ae70426dd4b4eff81394576de9b31fb9c704fcfa7"},
-    {file = "ingenialink-7.5.2+pr734b1-cp311-cp311-win_amd64.whl", hash = "sha256:8525fcb716396f77a5d627ebf3e79cb358354b93f61e0e85fddc215a4e98138e"},
-    {file = "ingenialink-7.5.2+pr734b1-cp312-cp312-win_amd64.whl", hash = "sha256:607d46b2c661ab17dfd134d228aab59122097c0ee87a67c42a83ebee1aceec55"},
-    {file = "ingenialink-7.5.2+pr734b1-cp39-cp39-win_amd64.whl", hash = "sha256:2aa6a3e2e7693068e62609ca32d2cc91d2d1051b6922529850ae91f10692f6d4"},
-    {file = "ingenialink-7.5.2+pr734b1-py3-none-any.whl", hash = "sha256:c7687c8f234565eab9c0dd70374e87523a2df730e6398647fcd6f1b7d534f5f9"},
-    {file = "ingenialink-7.5.2+pr734b1.tar.gz", hash = "sha256:42faa24567bc0eebc18b3bdf5e815f54572b533847939ae7a4c2974646226361"},
+    {file = "ingenialink-7.5.2+pr742b8-cp310-cp310-win_amd64.whl", hash = "sha256:b5e57a57eb15ad84664ed38ce126c9c303a505479c6d3ee365cc756c32bdec26"},
+    {file = "ingenialink-7.5.2+pr742b8-cp311-cp311-win_amd64.whl", hash = "sha256:25c0aa8ae25a48b91ef51c324009f98942e1d710590a2f3e131542f140f9483b"},
+    {file = "ingenialink-7.5.2+pr742b8-cp312-cp312-win_amd64.whl", hash = "sha256:e593a249c67b2a5c4ae9ab03583a8484f321c7e9d7313244df295a042f835c98"},
+    {file = "ingenialink-7.5.2+pr742b8-cp39-cp39-win_amd64.whl", hash = "sha256:dda8ce0bcda073408a3f9f2f0af44c1bcda4f7012665c42e7f007d4a80a630fe"},
+    {file = "ingenialink-7.5.2+pr742b8-py3-none-any.whl", hash = "sha256:a3b00152b965c4c94754d093da12c94b6a1ae7f09b1441497103ed5297751a9b"},
+    {file = "ingenialink-7.5.2+pr742b8.tar.gz", hash = "sha256:2b658c47c0bacd7a9cd242087f230e5cc59e92f0a609a28650ebef7e7ad9b1d5"},
 ]
 
 [package.dependencies]
@@ -1361,10 +1361,10 @@ numpy = ">=1.26.0"
 ping3 = "4.0.3"
 pysoem = ">=1.1.13,<1.2.0"
 python-can = "4.4.2"
-virtual_drive = {version = "0.0.0+pr24b17", optional = true, markers = "extra == \"virtual-drive\""}
+virtual_drive = {version = "0.0.0+pr30b5", optional = true, markers = "extra == \"virtual-drive\""}
 
 [package.extras]
-virtual-drive = ["virtual_drive (==0.0.0+pr24b17)"]
+virtual-drive = ["virtual_drive (==0.0.0+pr30b5)"]
 
 [package.source]
 type = "legacy"
@@ -4433,13 +4433,13 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtual-drive"
-version = "0.0.0+pr24b17"
+version = "0.0.0+pr30b5"
 description = "Emulates a Summit drive for development and testing purposes."
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "virtual_drive-0.0.0+pr24b17-py3-none-any.whl", hash = "sha256:a9e9ce343e10372786cdf8b20273764b6756855434e17af5aef8c0dacf774f70"},
+    {file = "virtual_drive-0.0.0+pr30b5-py3-none-any.whl", hash = "sha256:045f7fe21d8eb83d5cff53a0bcc05dbc0654005a83009de7a2f9111871d6532d"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "9ab69c748040c1ef0b8bdfbc45d08b1e213c9987dd19872268f5f66cf2c66447"
+content-hash = "efe6a5837467270f6a2810b93de45bd224a4e0f0445577ed4a74dfb279e72307"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1338,18 +1338,18 @@ reference = "novanta"
 
 [[package]]
 name = "ingenialink"
-version = "7.5.2+pr742b8"
+version = "7.5.2+pr742b17"
 description = "IngeniaLink Communications Library"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "tests"]
 files = [
-    {file = "ingenialink-7.5.2+pr742b8-cp310-cp310-win_amd64.whl", hash = "sha256:b5e57a57eb15ad84664ed38ce126c9c303a505479c6d3ee365cc756c32bdec26"},
-    {file = "ingenialink-7.5.2+pr742b8-cp311-cp311-win_amd64.whl", hash = "sha256:25c0aa8ae25a48b91ef51c324009f98942e1d710590a2f3e131542f140f9483b"},
-    {file = "ingenialink-7.5.2+pr742b8-cp312-cp312-win_amd64.whl", hash = "sha256:e593a249c67b2a5c4ae9ab03583a8484f321c7e9d7313244df295a042f835c98"},
-    {file = "ingenialink-7.5.2+pr742b8-cp39-cp39-win_amd64.whl", hash = "sha256:dda8ce0bcda073408a3f9f2f0af44c1bcda4f7012665c42e7f007d4a80a630fe"},
-    {file = "ingenialink-7.5.2+pr742b8-py3-none-any.whl", hash = "sha256:a3b00152b965c4c94754d093da12c94b6a1ae7f09b1441497103ed5297751a9b"},
-    {file = "ingenialink-7.5.2+pr742b8.tar.gz", hash = "sha256:2b658c47c0bacd7a9cd242087f230e5cc59e92f0a609a28650ebef7e7ad9b1d5"},
+    {file = "ingenialink-7.5.2+pr742b17-cp310-cp310-win_amd64.whl", hash = "sha256:b939376a58eb4bd46fa08235463e8f5cfecae02771cb3ed6a63f1ca232f5dada"},
+    {file = "ingenialink-7.5.2+pr742b17-cp311-cp311-win_amd64.whl", hash = "sha256:812120799ded4c6222ce3f699438d3e7d85ab8541cc87a98fbbc497b323abd29"},
+    {file = "ingenialink-7.5.2+pr742b17-cp312-cp312-win_amd64.whl", hash = "sha256:25a8f2dc0b0cf571d54ca9147d4029ec5943b7614191b378b2321dc63d1f82f2"},
+    {file = "ingenialink-7.5.2+pr742b17-cp39-cp39-win_amd64.whl", hash = "sha256:071c3774b1f6f6128634653d6ebc99efb02ebc877ceb3455bf100a124b1e4633"},
+    {file = "ingenialink-7.5.2+pr742b17-py3-none-any.whl", hash = "sha256:a72343e5a18d5426ea6674afb2e5e0afed5e391fd90313cdc0fcba3102494829"},
+    {file = "ingenialink-7.5.2+pr742b17.tar.gz", hash = "sha256:0212f7bd9523f6200ada45da93cc36f7484f6a2c80d4adf7a04504f054cd1db3"},
 ]
 
 [package.dependencies]
@@ -1361,10 +1361,10 @@ numpy = ">=1.26.0"
 ping3 = "4.0.3"
 pysoem = ">=1.1.13,<1.2.0"
 python-can = "4.4.2"
-virtual_drive = {version = "0.0.0+pr30b5", optional = true, markers = "extra == \"virtual-drive\""}
+virtual_drive = {version = "0.0.0+g331cf1c3d", optional = true, markers = "extra == \"virtual-drive\""}
 
 [package.extras]
-virtual-drive = ["virtual_drive (==0.0.0+pr30b5)"]
+virtual-drive = ["virtual_drive (==0.0.0+g331cf1c3d)"]
 
 [package.source]
 type = "legacy"
@@ -4433,13 +4433,13 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtual-drive"
-version = "0.0.0+pr30b5"
+version = "0.0+g331cf1c3d"
 description = "Emulates a Summit drive for development and testing purposes."
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "virtual_drive-0.0.0+pr30b5-py3-none-any.whl", hash = "sha256:045f7fe21d8eb83d5cff53a0bcc05dbc0654005a83009de7a2f9111871d6532d"},
+    {file = "virtual_drive-0.0+g331cf1c3d-py3-none-any.whl", hash = "sha256:879f203ee5af07325760e2038c29fa67cab905d253d7688fa51d8c87f67c3e96"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "9bbe629e5c25c4c4dee42dfdde40e13259ae9b50255bbd47e9c93b451aea6f1d"
+content-hash = "5adfb0eafb62312da57eafb34ac74e44411d88fad3c30c895bab3f1d88fdba73"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
 ingenialink = {extras = ["virtual_drive"], version = "7.5.2+pr742b8"}
-summit-testing-framework = {version = "==0.2.0+pr80b6"}
+summit-testing-framework = {version = "==0.2.0+pr83b1"}
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ pytest-mock = "==3.6.1"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-ingenialink = {extras = ["virtual_drive"], version = "7.5.2+pr734b1"}
+ingenialink = {extras = ["virtual_drive"], version = "7.5.2+pr742b8"}
 summit-testing-framework = {version = "==0.2.0+pr80b6"}
 
 # -----------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ pytest-mock = "==3.6.1"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-ingenialink = {extras = ["virtual_drive"], version = "7.5.2+pr742b8"}
+ingenialink = {extras = ["virtual_drive"], version = "7.5.2+pr742b17"}
 summit-testing-framework = {version = "==0.2.0+pr83b1"}
 
 # -----------------------------------------------------------------------

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -24,6 +24,7 @@ from summit_testing_framework.setups.descriptors import (
     EthernetSetup,
     SetupDescriptor,
 )
+from virtual_drive.resources import VIRTUAL_DRIVE_CAN_V2_XDF
 
 from ingeniamotion import MotionController
 from ingeniamotion.exceptions import (
@@ -395,6 +396,14 @@ def test_connect_servo_virtual_ethercat():
     assert mc.communication._Communication__virtual_drive_ethercat is not None
     mc.communication.disconnect()
     assert mc.communication._Communication__virtual_drive_ethercat is None
+
+
+def test_connect_servo_virtual_canopen():
+    mc = MotionController()
+    mc.communication.connect_servo_virtual_canopen(VIRTUAL_DRIVE_CAN_V2_XDF)
+    assert mc.communication._Communication__virtual_drive_canopen is not None
+    mc.communication.disconnect()
+    assert mc.communication._Communication__virtual_drive_canopen is None
 
 
 def test_scan_servos_canopen_with_info(mocker):


### PR DESCRIPTION
This pull request adds support for connecting to virtual CANopen drives in the `ingeniamotion` library. The main changes include introducing a new method for connecting to virtual CANopen drives, updating internal state management to handle CANopen connections, and adding corresponding tests. Additionally, dependencies are updated to ensure compatibility with the new features.

**Virtual CANopen support:**

* Added import for `VirtualCanopenNetwork` and type checking for `VirtualCanopenServo` in `communication.py` to support CANopen simulation. [[1]](diffhunk://#diff-34f3310a3a8e917ba0461ab5acc1390055016fd44f69297182f15442c6330302R29) [[2]](diffhunk://#diff-34f3310a3a8e917ba0461ab5acc1390055016fd44f69297182f15442c6330302R40)
* Introduced the `__virtual_drive_canopen` attribute to manage the CANopen virtual drive instance in the `Communication` class.
* Implemented the `connect_servo_virtual_canopen` method to allow connecting to a simulated CANopen drive, including argument validation and resource management.

**Resource management and cleanup:**

* Updated the `_disconnect_callback` method to properly stop and clean up the CANopen virtual drive when disconnecting.

**Testing and dependencies:**

* Added a new test, `test_connect_servo_virtual_canopen`, to verify CANopen connection and disconnection behavior, and imported the required CANopen dictionary resource. [[1]](diffhunk://#diff-6be9652b1d840a39ce87a727eac6825748c0ec63ad32ba0011cc6f3a16cef059R27) [[2]](diffhunk://#diff-6be9652b1d840a39ce87a727eac6825748c0ec63ad32ba0011cc6f3a16cef059R401-R408)
* Updated dependencies in `pyproject.toml` to compatible versions of `ingenialink` and `summit-testing-framework` for CANopen support.