### PR TITLE
INGM-751 Virtual drive server is reused for different connections

### DIFF
--- a/ingeniamotion/communication.py
+++ b/ingeniamotion/communication.py
@@ -106,9 +106,7 @@ class Communication:
     def __init__(self, motion_controller: "MotionController") -> None:
         self.mc = motion_controller
         self.logger = logger
-        self.__virtual_drive_ethernet: Optional[VirtualDrive] = None
-        self.__virtual_drive_ethercat: Optional[VirtualDrive] = None
-        self.__virtual_drive_canopen: Optional[VirtualDrive] = None
+        self.__virtual_drives: dict[str, VirtualDrive] = {}
         self.register_update_observers: dict[Servo, list[IMRegisterUpdateObserver]] = {}
         self.emergency_messages_observers: dict[Servo, list[IMEmergencyMessageObserver]] = {}
 
@@ -120,16 +118,9 @@ class Communication:
                 break
         if alias is None:
             raise ValueError("Servo not found in the communication controller.")
-        network = self.mc._get_network(alias)
-        if isinstance(network, VirtualEthernetNetwork) and self.__virtual_drive_ethernet:
-            self.__virtual_drive_ethernet.stop()
-            self.__virtual_drive_ethernet = None
-        if isinstance(network, VirtualEthercatNetwork) and self.__virtual_drive_ethercat:
-            self.__virtual_drive_ethercat.stop()
-            self.__virtual_drive_ethercat = None
-        if isinstance(network, VirtualCanopenNetwork) and self.__virtual_drive_canopen:
-            self.__virtual_drive_canopen.stop()
-            self.__virtual_drive_canopen = None
+        if alias in self.__virtual_drives:
+            self.__virtual_drives[alias].stop()
+            del self.__virtual_drives[alias]
 
         # Delegate actual removal/cleanup to MotionController
         self.mc.remove_motion_node(alias)
@@ -396,16 +387,16 @@ class Communication:
         if dict_path is not None and not path.isfile(dict_path):
             raise FileNotFoundError(f"{dict_path} file does not exist!")
 
-        if self.__virtual_drive_ethernet is None:
-            self.__virtual_drive_ethernet = VirtualDrive(port, dictionary_path=dict_path)
-            self.__virtual_drive_ethernet.start()
+        virtual_drive = VirtualDrive(port, dictionary_path=dict_path)
+        virtual_drive.start()
+        self.__virtual_drives[alias] = virtual_drive
 
         net = VirtualEthernetNetwork()
         self.mc.register_network(alias, net)
 
         servo = net.connect_to_slave(
-            self.__virtual_drive_ethernet.dictionary_path,
-            self.__virtual_drive_ethernet.port,
+            virtual_drive.dictionary_path,
+            virtual_drive.port,
             connection_timeout,
             servo_status_listener=servo_status_listener,
             net_status_listener=net_status_listener,
@@ -448,19 +439,17 @@ class Communication:
         if dict_path is not None and not path.isfile(dict_path):
             raise FileNotFoundError(f"{dict_path} file does not exist!")
 
-        if self.__virtual_drive_ethercat is None:
-            self.__virtual_drive_ethercat = VirtualDrive(
-                port, dictionary_path=dict_path, protocol=Interface.ECAT
-            )
-            self.__virtual_drive_ethercat.start()
+        virtual_drive = VirtualDrive(port, dictionary_path=dict_path, protocol=Interface.ECAT)
+        virtual_drive.start()
+        self.__virtual_drives[alias] = virtual_drive
 
         net = VirtualEthercatNetwork()
         self.mc.register_network(alias, net)
 
         servo = net.connect_to_slave(
             1,
-            self.__virtual_drive_ethercat.dictionary_path,
-            self.__virtual_drive_ethercat.port,
+            virtual_drive.dictionary_path,
+            virtual_drive.port,
             connection_timeout,
             servo_status_listener=servo_status_listener,
             net_status_listener=net_status_listener,
@@ -503,19 +492,17 @@ class Communication:
         if dict_path is not None and not path.isfile(dict_path):
             raise FileNotFoundError(f"{dict_path} file does not exist!")
 
-        if self.__virtual_drive_canopen is None:
-            self.__virtual_drive_canopen = VirtualDrive(
-                port, dictionary_path=dict_path, protocol=Interface.CAN
-            )
-            self.__virtual_drive_canopen.start()
+        virtual_drive = VirtualDrive(port, dictionary_path=dict_path, protocol=Interface.CAN)
+        virtual_drive.start()
+        self.__virtual_drives[alias] = virtual_drive
 
         net = VirtualCanopenNetwork()
         self.mc.register_network(alias, net)
 
         servo = net.connect_to_slave(
             1,
-            self.__virtual_drive_canopen.dictionary_path,
-            self.__virtual_drive_canopen.port,
+            virtual_drive.dictionary_path,
+            virtual_drive.port,
             connection_timeout,
             servo_status_listener=servo_status_listener,
             net_status_listener=net_status_listener,

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -375,9 +375,9 @@ def test_load_firmware_moco_exception(mocker, mc, alias):
 def test_connect_servo_virtual():
     mc = MotionController()
     mc.communication.connect_servo_virtual_ethernet(port=1062)
-    assert mc.communication._Communication__virtual_drive_ethernet is not None
+    assert "default" in mc.communication._Communication__virtual_drives
     mc.communication.disconnect()
-    assert mc.communication._Communication__virtual_drive_ethernet is None
+    assert "default" not in mc.communication._Communication__virtual_drives
 
 
 @pytest.mark.virtual
@@ -386,25 +386,53 @@ def test_connect_servo_virtual_custom_dictionary(setup_descriptor: SetupDescript
     mc.communication.connect_servo_virtual_ethernet(
         dict_path=setup_descriptor.dictionary, port=1062
     )
-    assert mc.communication._Communication__virtual_drive_ethernet is not None
+    assert "default" in mc.communication._Communication__virtual_drives
     mc.communication.disconnect()
-    assert mc.communication._Communication__virtual_drive_ethernet is None
+    assert "default" not in mc.communication._Communication__virtual_drives
 
 
 def test_connect_servo_virtual_ethercat():
     mc = MotionController()
     mc.communication.connect_servo_virtual_ethercat(SAMPLE_SAFE_PH2_XDFV3_DICTIONARY)
-    assert mc.communication._Communication__virtual_drive_ethercat is not None
+    assert "default" in mc.communication._Communication__virtual_drives
     mc.communication.disconnect()
-    assert mc.communication._Communication__virtual_drive_ethercat is None
+    assert "default" not in mc.communication._Communication__virtual_drives
 
 
 def test_connect_servo_virtual_canopen():
     mc = MotionController()
     mc.communication.connect_servo_virtual_canopen(VIRTUAL_DRIVE_CAN_V2_XDF)
-    assert mc.communication._Communication__virtual_drive_canopen is not None
+    assert "default" in mc.communication._Communication__virtual_drives
     mc.communication.disconnect()
-    assert mc.communication._Communication__virtual_drive_canopen is None
+    assert "default" not in mc.communication._Communication__virtual_drives
+
+
+def test_connect_servo_virtual_separate_drives_per_alias():
+    """Each connect call must spawn an independent VirtualDrive with its own dictionary.
+
+    Regression test: previously the VirtualDrive was created only once, so a second
+    connection would silently reuse the first drive's dictionary and internal state.
+    """
+    alias_a = "drive_a"
+    alias_b = "drive_b"
+    mc = MotionController()
+    mc.communication.connect_servo_virtual_ethernet(alias=alias_a)
+    mc.communication.connect_servo_virtual_ethernet(alias=alias_b)
+
+    drives = mc.communication._Communication__virtual_drives
+    assert alias_a in drives
+    assert alias_b in drives
+    # Each alias must own a distinct VirtualDrive instance
+    assert drives[alias_a] is not drives[alias_b]
+    # Each drive must have its own running port (no sharing)
+    assert drives[alias_a].port != drives[alias_b].port
+
+    mc.communication.disconnect(alias_a)
+    assert alias_a not in drives
+    assert alias_b in drives
+
+    mc.communication.disconnect(alias_b)
+    assert alias_b not in drives
 
 
 def test_scan_servos_canopen_with_info(mocker):


### PR DESCRIPTION
This pull request refactors how virtual drives are managed in the `Communication` class by switching from individual attributes for each protocol to a unified dictionary keyed by alias. This change improves scalability, prevents state sharing between connections, and ensures each alias gets its own independent `VirtualDrive`. The tests have been updated and expanded to verify this behavior.

Virtual drive management refactor:

* Replaced protocol-specific attributes (`__virtual_drive_ethernet`, `__virtual_drive_ethercat`, `__virtual_drive_canopen`) with a single `__virtual_drives` dictionary keyed by alias in the `Communication` class, enabling multiple independent virtual drives.
* Updated connection and disconnection logic to use the `__virtual_drives` dictionary, ensuring proper creation and cleanup of drives per alias. [[1]](diffhunk://#diff-34f3310a3a8e917ba0461ab5acc1390055016fd44f69297182f15442c6330302L123-R123) [[2]](diffhunk://#diff-34f3310a3a8e917ba0461ab5acc1390055016fd44f69297182f15442c6330302L399-R399) [[3]](diffhunk://#diff-34f3310a3a8e917ba0461ab5acc1390055016fd44f69297182f15442c6330302L451-R452) [[4]](diffhunk://#diff-34f3310a3a8e917ba0461ab5acc1390055016fd44f69297182f15442c6330302L506-R505)

Testing improvements:

* Modified existing tests to assert presence and absence of drives in the `__virtual_drives` dictionary instead of protocol-specific attributes. [[1]](diffhunk://#diff-6be9652b1d840a39ce87a727eac6825748c0ec63ad32ba0011cc6f3a16cef059L378-R380) [[2]](diffhunk://#diff-6be9652b1d840a39ce87a727eac6825748c0ec63ad32ba0011cc6f3a16cef059L389-R435)
* Added a new regression test (`test_connect_servo_virtual_separate_drives_per_alias`) to verify that multiple connections create distinct `VirtualDrive` instances with separate ports and state, and that disconnecting cleans up only the targeted drive.