### PR TITLE
Enable Wireshark logging for nightly develop builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,7 @@ def createVirtualEnvironments(String workingDir = null, String pythonVersionList
 }
 
 /* Build develop everyday 3 times starting at 19:00 UTC (21:00 Barcelona Time), running all python versions */
-CRON_SETTINGS = BRANCH_NAME == "develop" ? '''0 19,21,23 * * * % PYTHON_VERSIONS=All''' : ""
+CRON_SETTINGS = BRANCH_NAME == "develop" ? '''0 19,21,23 * * * % PYTHON_VERSIONS=All;WIRESHARK_LOGGING=true''' : ""
 
 pipeline {
     agent none


### PR DESCRIPTION
We have a too high failure rate on develop that needs to be investigated, many of them are related to ethercat, that now it's running on a brand new machine that we cannot blame.

Adding WIRESHARK_LOGGING=true to parameterizedCron so nightly builds capture pcap files for all EtherCAT/FSoE stages.

Related: INGM-758