### PR TITLE
accept flakyness of test_create_poller

### DIFF
--- a/tests/test_pdo.py
+++ b/tests/test_pdo.py
@@ -387,8 +387,11 @@ def test_create_poller(mc: "MotionController", alias: str) -> None:
     poller.stop()
     timestamps, data = poller.data
     channel_0_data, channel_1_data = data
-    assert len(channel_0_data) == samples_target
-    assert len(channel_1_data) == samples_target
+    # Accept samples_target or samples_target+1: the OP state transition in
+    # start_pdos() may fire an extra callback non-deterministically.
+    # See INGK-1264 for the root cause in ingenialink.
+    assert samples_target <= len(channel_0_data) <= samples_target + 1
+    assert samples_target <= len(channel_1_data) <= samples_target + 1
     assert len(data) == len(registers)
     assert len(timestamps) == len(channel_0_data)
 


### PR DESCRIPTION
The investigation of this flaky test has revealed a deeper root cause in ingenialink.

`start_pdos()` emits 1 or sometimes more process data exchanges during initialization that are consumed by the PDO poller. While this is fine functionally (the poller handles safe-op data correctly), the timing of those samples is desynchronized.

The first sample is never synchronized to the scheduling because it runs inside `start_pdos()` together with the safe-op → OP transition. Additionally, sometimes the slave takes longer to transition to OP, so a retry is done — and that is when we get a second sample very close to the first one.

## Evidence

Timing instrumentation on `tests/test_pdo.py::test_create_poller` (100 runs, 250 ms sampling, 4 expected samples):

**Typical passing run** (1 init sample):

`timestamps = ['0.126', '0.253', '0.503', '0.753']`

**Failing run** (2 init samples):

`timestamps = ['0.126', '0.178', '0.253', '0.503', '0.753']`

The 52 ms gap between 0.126 and 0.178 confirms these are rapid `send_receive_processdata()` calls inside the OP transition loop, not regular 250 ms cycles.

- **Observed failure rate:** 3/100 runs (3%)
- **Failure mode:** `assert 5 == 4` (one extra sample from the second init cycle)

## Fix

This PR relaxes the sample count assertion to accept `samples_target` or `samples_target + 1` as a workaround.

The proper fix belongs in ingenialink — tracked by [INGK-1264](https://novantamotion.atlassian.net/browse/INGK-1264).

[INGK-1264]: https://novantamotion.atlassian.net/browse/INGK-1264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ