### PR TITLE
MOT3-5499 Create the restore_configuration method

### DIFF
--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -287,9 +287,18 @@ class FSoEMasterHandler:
         if module_ident is None:
             raise RuntimeError("Module ident value to write could not be retrieved.")
 
-        self.__servo.write(self.MDP_CONFIGURED_MODULE_1, data=module_ident, subnode=0)
+        self.__module_ident = module_ident
+        self.__servo.write(self.MDP_CONFIGURED_MODULE_1, data=self.__module_ident, subnode=0)
 
         return self.__servo.dictionary.get_safety_module(module_ident=module_ident)
+
+    def restore_configuration(self) -> None:
+        """Restore drive configuration that is lost after a power cycle.
+
+        Re-writes runtime registers (e.g. ``MDP_CONFIGURED_MODULE_1``) that the
+        drive needs but does not persist across reboots.
+        """
+        self.__servo.write(self.MDP_CONFIGURED_MODULE_1, data=self.__module_ident, subnode=0)
 
     def __get_configured_module_ident_1(self) -> Union[int, float, str, bytes]:
         """Gets the configured Module Ident 1.

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -288,7 +288,7 @@ class FSoEMasterHandler:
             raise RuntimeError("Module ident value to write could not be retrieved.")
 
         self.__module_ident = module_ident
-        self.__servo.write(self.MDP_CONFIGURED_MODULE_1, data=self.__module_ident, subnode=0)
+        self.restore_configuration()
 
         return self.__servo.dictionary.get_safety_module(module_ident=module_ident)
 


### PR DESCRIPTION
# Add `restore_configuration()` to `FSoEMasterHandler`

## Problem

When a drive power cycle occurs, all runtime register values are lost — including `MDP_CONFIGURED_MODULE_1`. This register tells the drive which safety module is active and is required for the FSoE state machine to function.

The register is only written during `FSoEMasterHandler.__init__()` (inside `__set_configured_module_ident_1()`). If the handler object survives a power cycle (e.g. EtherCAT CoE drops and recovers), subsequent calls to `start()` will fail because the drive no longer knows which safety module to use.

## Solution

- Store the resolved `module_ident` as `self.__module_ident` during `__init__`
- Expose a new public method `restore_configuration()` that re-writes `MDP_CONFIGURED_MODULE_1` via SDO using the stored value