### PR TITLE
INGM-760: Update phase II firmware of tests

### DIFF
--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -134,7 +134,7 @@ ECAT_DEN_S_NET_E_SETUP = RackServiceConfigSpecifier.from_version_configs(
             },
         ),
         "PHASE2": VersionConfig.from_version(
-            version="2.10.0",
+            version="2.9.1",
             config_file=None,
             dictionary_type=DictionaryType.XDF_V3,
             extra_data={
@@ -142,8 +142,8 @@ ECAT_DEN_S_NET_E_SETUP = RackServiceConfigSpecifier.from_version_configs(
                 __TEST_CONFIGS_KEY: {
                     "ECAT_TEST_SESSIONS": PyTestConfig(
                         markers="fsoe or fsoe_phase2",
-                        run_test_stage_uid="fsoe_phase2_2.10.0",
-                        stage_name="Safety Denali Phase II - FW. 2.10.0",
+                        run_test_stage_uid="fsoe_phase2_2.9.1",
+                        stage_name="Safety Denali Phase II - FW. 2.9.1",
                     )
                 },
             },

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -133,22 +133,17 @@ ECAT_DEN_S_NET_E_SETUP = RackServiceConfigSpecifier.from_version_configs(
                 },
             },
         ),
-        "PHASE2": VersionConfig.from_files(
-            version="2.9.0.16",
+        "PHASE2": VersionConfig.from_version(
+            version="2.10.0",
             config_file=None,
-            firmware=Path(
-                "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.lfu"
-            ),
-            dictionary=Path(
-                "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.016.xdf3"
-            ),
+            dictionary_type=DictionaryType.XDF_V3,
             extra_data={
                 __EXECUTION_POLICY_KEY: "always",
                 __TEST_CONFIGS_KEY: {
                     "ECAT_TEST_SESSIONS": PyTestConfig(
                         markers="fsoe or fsoe_phase2",
-                        run_test_stage_uid="fsoe_phase2_2.9.0",
-                        stage_name="Safety Denali Phase II - FW. 2.9.0",
+                        run_test_stage_uid="fsoe_phase2_2.10.0",
+                        stage_name="Safety Denali Phase II - FW. 2.10.0",
                     )
                 },
             },


### PR DESCRIPTION
This pull request updates the `PHASE2` test setup in `rack_specifiers.py` to use version 2.10.0 and simplifies the configuration by switching from file-based to version-based initialization. It also updates related test identifiers to match the new version.

Version and configuration updates:

* Changed `PHASE2` setup to use `VersionConfig.from_version` with version "2.10.0" instead of `from_files` with version "2.9.0.16", removing explicit firmware and dictionary file paths and specifying `dictionary_type=DictionaryType.XDF_V3`.

Test metadata updates:

* Updated test configuration identifiers such as `run_test_stage_uid` and `stage_name` to reflect the new firmware version "2.10.0".