### PR TITLE
INGM-757 Add test for PDO poller with FSoE active

### DIFF
--- a/ingeniamotion/pdo.py
+++ b/ingeniamotion/pdo.py
@@ -56,20 +56,41 @@ class PDOPoller:
         self.__fill_rpdo_map()
         self.__exception_callbacks: list[Callable[[ILError], None]] = []
 
-    def start(self) -> None:
-        """Start the poller."""
+    def set_pdo_maps(self) -> None:
+        """Set the poller PDO maps to the servo.
+
+        If the maps are already registered on the servo, this is a no-op
+        (``set_pdo_maps_to_slave`` skips duplicates).
+        """
         self.__mc.capture.pdo.set_pdo_maps_to_slave(
             rpdo_maps=self.__rpdo_map, tpdo_maps=self.__tpdo_map, servo=self.__servo
         )
+
+    def __start_pdos(self) -> None:
+        """Start the PDO exchange if not already active."""
+        if not self.__mc.capture.pdo.is_active(servo=self.__servo):
+            self.__mc.capture.pdo.start_pdos(
+                refresh_rate=self.__refresh_time,
+                watchdog_timeout=self.__watchdog_timeout,
+                servo=self.__servo,
+            )
+
+    def __subscribe_to_events(self) -> None:
+        """Subscribe to process data and exception events."""
         self.__tpdo_map.subscribe_to_process_data_event(self._new_data_available)
         for callback in self.__exception_callbacks:
             self.__mc.capture.pdo.subscribe_to_exceptions(callback, servo=self.__servo)
         self.__start_time = time.time()
-        self.__mc.capture.pdo.start_pdos(
-            refresh_rate=self.__refresh_time,
-            watchdog_timeout=self.__watchdog_timeout,
-            servo=self.__servo,
-        )
+
+    def start(self) -> None:
+        """Start the poller.
+
+        Sets the PDO maps (if not already set), starts the PDO exchange
+        (if not already active), and subscribes to process data events.
+        """
+        self.set_pdo_maps()
+        self.__start_pdos()
+        self.__subscribe_to_events()
 
     def stop(self) -> None:
         """Stop the poller."""
@@ -795,6 +816,8 @@ class PDONetworkManager:
         poller.add_channels(registers)
         if start:
             poller.start()
+        else:
+            poller.set_pdo_maps()
         return poller
 
     def unsubscribe_to_exceptions(

--- a/poetry.lock
+++ b/poetry.lock
@@ -1306,18 +1306,18 @@ reference = "novanta"
 
 [[package]]
 name = "ingenialink"
-version = "7.6.0.post116+develop.e533b9a"
+version = "7.6.0.post118+ingk.1257.multiple.pdo.6e66e78"
 description = "IngeniaLink Communications Library"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "tests"]
 files = [
-    {file = "ingenialink-7.6.0.post116+develop.e533b9a-cp310-cp310-win_amd64.whl", hash = "sha256:ceb8d127d91c254fc52ca4efb72181e36dcd3d9749adc2448d35cae87a5d168d"},
-    {file = "ingenialink-7.6.0.post116+develop.e533b9a-cp311-cp311-win_amd64.whl", hash = "sha256:1a17a2c3b9b5b0ec6c7e53d2649a66a6a32b2564019bcddc7d3a8e273d919792"},
-    {file = "ingenialink-7.6.0.post116+develop.e533b9a-cp312-cp312-win_amd64.whl", hash = "sha256:bb5dd1cdfd8723c858e2cd73e2b921dd2c6236d64632e75aee500189084b212d"},
-    {file = "ingenialink-7.6.0.post116+develop.e533b9a-cp39-cp39-win_amd64.whl", hash = "sha256:62b26a79aa0156b746bae327ca8a18bdac55371866819c73b199499854a87227"},
-    {file = "ingenialink-7.6.0.post116+develop.e533b9a-py3-none-any.whl", hash = "sha256:edd1a620d816600d1602a2350fd4d328c09ce77bf71db962ac0bc463cf7de190"},
-    {file = "ingenialink-7.6.0.post116+develop.e533b9a.tar.gz", hash = "sha256:6aad24f8258d3e05961c8218af52a285d8fec7f6f1b90e37c6454a1862ae2620"},
+    {file = "ingenialink-7.6.0.post118+ingk.1257.multiple.pdo.6e66e78-cp310-cp310-win_amd64.whl", hash = "sha256:585f633525d0a9c881fed86274795d40a4691872056bbfa4b797365184346f9e"},
+    {file = "ingenialink-7.6.0.post118+ingk.1257.multiple.pdo.6e66e78-cp311-cp311-win_amd64.whl", hash = "sha256:8604545225e7c6d5b2c5ac979f89ecb272fcdb7968645b3e471aa24e78f6a288"},
+    {file = "ingenialink-7.6.0.post118+ingk.1257.multiple.pdo.6e66e78-cp312-cp312-win_amd64.whl", hash = "sha256:f717367b027cb8048cce943f3c46fe59601c5e47b3ed1d7e64fa1d3723ee65b4"},
+    {file = "ingenialink-7.6.0.post118+ingk.1257.multiple.pdo.6e66e78-cp39-cp39-win_amd64.whl", hash = "sha256:f5fd2aee84dde02adf3d9361318fae60ed79fc8629f574406efa1bdbda87540f"},
+    {file = "ingenialink-7.6.0.post118+ingk.1257.multiple.pdo.6e66e78-py3-none-any.whl", hash = "sha256:28453322bfa07ea816f0dacf34b65968fdf6a2af4d2e125d2565e0bfd5d9a6f9"},
+    {file = "ingenialink-7.6.0.post118+ingk.1257.multiple.pdo.6e66e78.tar.gz", hash = "sha256:8f2f6d09a694dbf26c6be8e65037b3c8c7b9692eddb74ca459f34b266bfd8a9e"},
 ]
 
 [package.dependencies]
@@ -4745,4 +4745,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "c29b1d221a9a9a27b7411ffe0326d92a68bfd3108d1986ebcfb8aa1a59891566"
+content-hash = "636e8d7c2f0f94e70d6d01a2c62eb405c48eb953aeb88660c435670ee7c88781"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
 summit-testing-framework = {version = "==0.3.0.post49+develop.d6a7699"}
-ingenialink = {version = "==7.6.0.post116+develop.e533b9a"}
+ingenialink = {version = "==7.6.0.post118+ingk.1257.multiple.pdo.6e66e78"}
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/tests/fsoe/test_safety_pdos.py
+++ b/tests/fsoe/test_safety_pdos.py
@@ -148,7 +148,7 @@ def test_pdo_poller_with_fsoe_active(
     # Configure FSoE maps without starting PDOs or master
     mc.fsoe.configure_pdos(start_pdos=False, start_master=False)
 
-    # Create the poller without starting it (sets maps only)
+    # Create the poller without starting it (maps are set to the servo)
     registers = [{"name": "CL_POS_FBK_VALUE", "axis": 1}]
     sampling_time = 0.25
     samples_target = 4
@@ -156,10 +156,12 @@ def test_pdo_poller_with_fsoe_active(
         registers=registers, servo=alias, sampling_time=sampling_time, start=False
     )
 
-    # Start the FSoE master first, then start PDOs
+    # Start the FSoE master with PDOs, then start the poller.
+    # Since PDOs are already active, start() just subscribes to events.
     mc.fsoe.start_master(start_pdos=True)
     mc.fsoe.wait_for_state_data(timeout=timeout_for_data_sra)
     assert mc.fsoe.get_fsoe_master_state(servo=alias) is FSoEState.DATA
+    poller.start()
 
     time.sleep((samples_target - 0.5) * sampling_time)
 
@@ -170,6 +172,6 @@ def test_pdo_poller_with_fsoe_active(
     mc.fsoe.stop_master(stop_pdos=False)
 
     poller.stop()
-    timestamps, data = poller.data
+    _timestamps, data = poller.data
     assert len(data) == len(registers)
     assert len(data[0]) >= samples_target

--- a/tests/fsoe/test_safety_pdos.py
+++ b/tests/fsoe/test_safety_pdos.py
@@ -129,3 +129,47 @@ def test_stop_master_while_pdos_are_still_active(
     time.sleep(2 * refresh_rate)
     assert len(exceptions) == 0
     assert len(received_data) > n_received_data
+
+
+@pytest.mark.fsoe
+def test_pdo_poller_with_fsoe_active(
+    mc_with_fsoe_with_sra: tuple["MotionController", "FSoEMasterHandler"],
+    timeout_for_data_sra: float,
+    alias: str,
+) -> None:
+    """Test that a PDO poller can collect data while the FSoE master is active.
+
+    The FSoE maps are configured first, then the poller sets its own maps without
+    starting PDOs. The FSoE master is started, and only then PDOs are started so
+    the safety callbacks find the master already running.
+    """
+    mc, _handler = mc_with_fsoe_with_sra
+
+    # Configure FSoE maps without starting PDOs or master
+    mc.fsoe.configure_pdos(start_pdos=False, start_master=False)
+
+    # Create the poller without starting it (sets maps only)
+    registers = [{"name": "CL_POS_FBK_VALUE", "axis": 1}]
+    sampling_time = 0.25
+    samples_target = 4
+    poller = mc.capture.pdo.create_poller(
+        registers=registers, servo=alias, sampling_time=sampling_time, start=False
+    )
+
+    # Start the FSoE master first, then start PDOs
+    mc.fsoe.start_master(start_pdos=True)
+    mc.fsoe.wait_for_state_data(timeout=timeout_for_data_sra)
+    assert mc.fsoe.get_fsoe_master_state(servo=alias) is FSoEState.DATA
+
+    time.sleep((samples_target - 0.5) * sampling_time)
+
+    # FSoE should still be in DATA while poller is running
+    assert mc.fsoe.get_fsoe_master_state(servo=alias) is FSoEState.DATA
+
+    # Stop FSoE master before stopping PDOs to avoid safety errors
+    mc.fsoe.stop_master(stop_pdos=False)
+
+    poller.stop()
+    timestamps, data = poller.data
+    assert len(data) == len(registers)
+    assert len(data[0]) >= samples_target


### PR DESCRIPTION
This PR adds coverage for running a PDO poller while FSoE is active and adjusts poller startup behavior so both systems can coexist safely.

**What changed**
- Added a new FSoE integration test to verify a PDO poller can collect data while FSoE master remains in DATA state.
Refactored poller startup flow to separate:
    - map registration
    - PDO exchange startup
    - event subscription
- Ensured poller startup can be done when PDOs are already active (no duplicate PDO start).
- Updated poller creation flow so maps can be set even when start is disabled.
- Updated with https://github.com/ingeniamc/ingenialink-python/pull/796

**Validation**
- New integration test covers the FSoE + PDO poller coexistence scenario.