### PR TITLE
MOT3-5526 Unhandled on incremental encoder 1 resolution test if resolution is set to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.10.3] - 2026-MM-DD
+### Fixed
+- Added validation for zero feedback resolution in `DCFeedbacksResolutionTest` and `DCFeedbacksPolarityTest`.
+
 ## [0.10.2] - 2026-03-20
 ### Added
 - Extended error queue manager (`ServoErrorQueue`) to support standard drive errors (MOCO/COCO/SYSTEM).

--- a/ingeniamotion/wizard_tests/base_test.py
+++ b/ingeniamotion/wizard_tests/base_test.py
@@ -19,6 +19,10 @@ class TestError(Exception):
     """Test error exception."""
 
 
+class TestConfigurationError(TestError):
+    """Test configuration exception."""
+
+
 LegacyDictReportType = dict[str, Union[SeverityLevel, dict[str, Union[int, float, str]], str]]
 
 

--- a/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_polarity_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_polarity_test.py
@@ -2,6 +2,7 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, ClassVar, Optional
 
 import ingenialogger
+from ingenialink.exceptions import ILConfigurationError
 from typing_extensions import override
 
 from ingeniamotion.enums import FeedbackPolarity, OperationMode, SensorType, SeverityLevel
@@ -68,6 +69,10 @@ class DCFeedbacksPolarityTest(BaseTest[LegacyDictReportType]):
         self.feedback_resolution = self.mc.configuration.get_feedback_resolution(
             self.sensor, servo=self.servo, axis=self.axis
         )
+        if self.feedback_resolution == 0:
+            raise ILConfigurationError(
+                "The feedback resolution must be greater than 0. Please adjust it accordingly."
+            )
         self.mc.configuration.set_feedback_polarity(
             FeedbackPolarity.NORMAL, self.sensor, servo=self.servo, axis=self.axis
         )

--- a/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_polarity_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_polarity_test.py
@@ -2,11 +2,15 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, ClassVar, Optional
 
 import ingenialogger
-from ingenialink.exceptions import ILConfigurationError
 from typing_extensions import override
 
 from ingeniamotion.enums import FeedbackPolarity, OperationMode, SensorType, SeverityLevel
-from ingeniamotion.wizard_tests.base_test import BaseTest, LegacyDictReportType, TestError
+from ingeniamotion.wizard_tests.base_test import (
+    BaseTest,
+    LegacyDictReportType,
+    TestConfigurationError,
+    TestError,
+)
 
 if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
@@ -70,7 +74,7 @@ class DCFeedbacksPolarityTest(BaseTest[LegacyDictReportType]):
             self.sensor, servo=self.servo, axis=self.axis
         )
         if self.feedback_resolution == 0:
-            raise ILConfigurationError(
+            raise TestConfigurationError(
                 "The feedback resolution must be greater than 0. Please adjust it accordingly."
             )
         self.mc.configuration.set_feedback_polarity(

--- a/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_resolution_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_resolution_test.py
@@ -3,6 +3,7 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, ClassVar, Optional
 
 import ingenialogger
+from ingenialink.exceptions import ILConfigurationError
 from typing_extensions import override
 
 from ingeniamotion.enums import OperationMode, SensorType, SeverityLevel
@@ -88,6 +89,10 @@ class DCFeedbacksResolutionTest(BaseTest[LegacyDictReportType]):
         self.feedback_resolution = self.mc.configuration.get_feedback_resolution(
             self.sensor, servo=self.servo, axis=self.axis
         )
+        if self.feedback_resolution == 0:
+            raise ILConfigurationError(
+                "The feedback resolution must be greater than 0. Please adjust it accordingly."
+            )
         self.mc.configuration.set_velocity_feedback(self.sensor, servo=self.servo, axis=self.axis)
         self.mc.configuration.set_position_feedback(self.sensor, servo=self.servo, axis=self.axis)
         if self.sensor == SensorType.BISSC2:

--- a/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_resolution_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_resolution_test.py
@@ -3,12 +3,16 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, ClassVar, Optional
 
 import ingenialogger
-from ingenialink.exceptions import ILConfigurationError
 from typing_extensions import override
 
 from ingeniamotion.enums import OperationMode, SensorType, SeverityLevel
 from ingeniamotion.exceptions import IMTimeoutError
-from ingeniamotion.wizard_tests.base_test import BaseTest, LegacyDictReportType, TestError
+from ingeniamotion.wizard_tests.base_test import (
+    BaseTest,
+    LegacyDictReportType,
+    TestConfigurationError,
+    TestError,
+)
 
 if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
@@ -90,7 +94,7 @@ class DCFeedbacksResolutionTest(BaseTest[LegacyDictReportType]):
             self.sensor, servo=self.servo, axis=self.axis
         )
         if self.feedback_resolution == 0:
-            raise ILConfigurationError(
+            raise TestConfigurationError(
                 "The feedback resolution must be greater than 0. Please adjust it accordingly."
             )
         self.mc.configuration.set_velocity_feedback(self.sensor, servo=self.servo, axis=self.axis)

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -4,7 +4,7 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, ClassVar, Optional
 
 import ingenialogger
-from ingenialink.exceptions import ILConfigurationError, ILIOError, ILStateError, ILTimeoutError
+from ingenialink.exceptions import ILIOError, ILStateError, ILTimeoutError
 from typing_extensions import override
 
 if TYPE_CHECKING:
@@ -20,6 +20,7 @@ from ingeniamotion.exceptions import IMRegisterNotExistError
 from ingeniamotion.wizard_tests.base_test import (
     BaseTest,
     LegacyDictReportType,
+    TestConfigurationError,
     TestError,
 )
 
@@ -186,7 +187,7 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
         """Set the feedback for the test.
 
         Raises:
-            ILConfigurationError: If the feedback resolution is not greater than 0.
+            TestConfigurationError: If the feedback resolution is not greater than 0.
         """
         # First set all feedback to feedback in test, so there won't be
         # more than 5 feedback at the same time
@@ -210,7 +211,7 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
             self.sensor, servo=self.servo, axis=self.axis
         )
         if self.feedback_resolution == 0:
-            raise ILConfigurationError(
+            raise TestConfigurationError(
                 "The feedback resolution must be greater than 0. Please adjust it accordingly."
             )
 

--- a/tests/test_feedback_test.py
+++ b/tests/test_feedback_test.py
@@ -1,10 +1,18 @@
 import pytest
+from ingenialink.exceptions import ILConfigurationError
 
+from ingeniamotion.enums import SensorType
 from ingeniamotion.wizard_tests.feedbacks_tests.absolute_encoder1_test import (
     AbsoluteEncoder1Test,
 )
 from ingeniamotion.wizard_tests.feedbacks_tests.absolute_encoder2_test import (
     AbsoluteEncoder2Test,
+)
+from ingeniamotion.wizard_tests.feedbacks_tests.dc_feedback_polarity_test import (
+    DCFeedbacksPolarityTest,
+)
+from ingeniamotion.wizard_tests.feedbacks_tests.dc_feedback_resolution_test import (
+    DCFeedbacksResolutionTest,
 )
 from ingeniamotion.wizard_tests.feedbacks_tests.digital_hall_test import DigitalHallTest
 from ingeniamotion.wizard_tests.feedbacks_tests.digital_incremental1_test import (
@@ -16,6 +24,8 @@ from ingeniamotion.wizard_tests.feedbacks_tests.digital_incremental2_test import
 from ingeniamotion.wizard_tests.feedbacks_tests.secondary_ssi_test import (
     SecondarySSITest,
 )
+
+INCREMENTAL_ENCODER_1_RESOLUTION_REGISTER = "FBK_DIGENC1_RESOLUTION"
 
 
 @pytest.mark.virtual
@@ -80,3 +90,39 @@ def test_save_backup_registers(mc, alias, feedback_test_type):
     assert "PROF_POS_OPTION_CODE" in saved_backup_registers
     assert "CL_POS_REF_MAX_RANGE" in saved_backup_registers
     assert "CL_POS_REF_MIN_RANGE" in saved_backup_registers
+
+
+@pytest.mark.virtual
+def test_bldc_feedback_setting_raises_on_zero_resolution(mc, alias):
+    """BLDC feedback setup must raise ILConfigurationError when resolution is zero."""
+    axis = 1
+    mc.communication.set_register(
+        INCREMENTAL_ENCODER_1_RESOLUTION_REGISTER, 0, servo=alias, axis=axis
+    )
+    feedback_test = DigitalIncremental1Test(mc, alias, axis)
+    with pytest.raises(ILConfigurationError, match="resolution must be greater than 0"):
+        feedback_test.setup()
+
+
+@pytest.mark.virtual
+def test_dc_resolution_test_raises_on_zero_resolution(mc, alias):
+    """DC resolution test setup must raise ILConfigurationError when resolution is zero."""
+    axis = 1
+    mc.communication.set_register(
+        INCREMENTAL_ENCODER_1_RESOLUTION_REGISTER, 0, servo=alias, axis=axis
+    )
+    dc_test = DCFeedbacksResolutionTest(mc, SensorType.QEI, alias, axis)
+    with pytest.raises(ILConfigurationError, match="resolution must be greater than 0"):
+        dc_test.setup()
+
+
+@pytest.mark.virtual
+def test_dc_polarity_test_raises_on_zero_resolution(mc, alias):
+    """DC polarity test setup must raise ILConfigurationError when resolution is zero."""
+    axis = 1
+    mc.communication.set_register(
+        INCREMENTAL_ENCODER_1_RESOLUTION_REGISTER, 0, servo=alias, axis=axis
+    )
+    dc_test = DCFeedbacksPolarityTest(mc, SensorType.QEI, alias, axis)
+    with pytest.raises(ILConfigurationError, match="resolution must be greater than 0"):
+        dc_test.setup()

--- a/tests/test_feedback_test.py
+++ b/tests/test_feedback_test.py
@@ -1,7 +1,7 @@
 import pytest
-from ingenialink.exceptions import ILConfigurationError
 
 from ingeniamotion.enums import SensorType
+from ingeniamotion.wizard_tests.base_test import TestConfigurationError
 from ingeniamotion.wizard_tests.feedbacks_tests.absolute_encoder1_test import (
     AbsoluteEncoder1Test,
 )
@@ -94,35 +94,35 @@ def test_save_backup_registers(mc, alias, feedback_test_type):
 
 @pytest.mark.virtual
 def test_bldc_feedback_setting_raises_on_zero_resolution(mc, alias):
-    """BLDC feedback setup must raise ILConfigurationError when resolution is zero."""
+    """BLDC feedback setup must raise TestConfigurationError when resolution is zero."""
     axis = 1
     mc.communication.set_register(
         INCREMENTAL_ENCODER_1_RESOLUTION_REGISTER, 0, servo=alias, axis=axis
     )
     feedback_test = DigitalIncremental1Test(mc, alias, axis)
-    with pytest.raises(ILConfigurationError, match="resolution must be greater than 0"):
+    with pytest.raises(TestConfigurationError, match="resolution must be greater than 0"):
         feedback_test.setup()
 
 
 @pytest.mark.virtual
 def test_dc_resolution_test_raises_on_zero_resolution(mc, alias):
-    """DC resolution test setup must raise ILConfigurationError when resolution is zero."""
+    """DC resolution test setup must raise TestConfigurationError when resolution is zero."""
     axis = 1
     mc.communication.set_register(
         INCREMENTAL_ENCODER_1_RESOLUTION_REGISTER, 0, servo=alias, axis=axis
     )
     dc_test = DCFeedbacksResolutionTest(mc, SensorType.QEI, alias, axis)
-    with pytest.raises(ILConfigurationError, match="resolution must be greater than 0"):
+    with pytest.raises(TestConfigurationError, match="resolution must be greater than 0"):
         dc_test.setup()
 
 
 @pytest.mark.virtual
 def test_dc_polarity_test_raises_on_zero_resolution(mc, alias):
-    """DC polarity test setup must raise ILConfigurationError when resolution is zero."""
+    """DC polarity test setup must raise TestConfigurationError when resolution is zero."""
     axis = 1
     mc.communication.set_register(
         INCREMENTAL_ENCODER_1_RESOLUTION_REGISTER, 0, servo=alias, axis=axis
     )
     dc_test = DCFeedbacksPolarityTest(mc, SensorType.QEI, alias, axis)
-    with pytest.raises(ILConfigurationError, match="resolution must be greater than 0"):
+    with pytest.raises(TestConfigurationError, match="resolution must be greater than 0"):
         dc_test.setup()


### PR DESCRIPTION
## Fix: DC feedback tests raise unhandled `ZeroDivisionError` when resolution is 0

### Problem

When the feedback resolution is `0`, `DCFeedbacksResolutionTest` raises an unhandled `ZeroDivisionError` during setup because it divides by the resolution without validating it first. `DCFeedbacksPolarityTest` also lacks this validation, allowing it to operate with a meaningless resolution value.

The BLDC feedback test (`Feedbacks.feedback_setting()`) already guards against this by raising `ILConfigurationError` when resolution is 0. The DC test classes were missing the same check.

### Fix

Added a resolution-is-zero validation in `setup()` of both `DCFeedbacksResolutionTest` and `DCFeedbacksPolarityTest`, raising `ILConfigurationError` consistently with the existing BLDC guard.

Added virtual tests covering the zero-resolution case for BLDC, DC resolution, and DC polarity tests.
