### PR TITLE
MOT3-5540 Fix disturbance V1 enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.10.3] - 2026-MM-DD
 ### Fixed
 - Added validation for zero feedback resolution in `DCFeedbacksResolutionTest` and `DCFeedbacksPolarityTest`.
+- Fix enable disturbance for Disturbance V1.
 
 ## [0.10.2] - 2026-03-20
 ### Added

--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -377,10 +377,8 @@ class Capture:
             # mechanism. Bypass enable_monitoring() mapped-register check
             # because disturbance-only mapped registers are sufficient.
             drive.monitoring_enable()
-            if not self.is_monitoring_enabled(servo=servo):
-                raise IMMonitoringError("Error enabling disturbance.")
-            return
-        drive.disturbance_enable()
+        else:
+            drive.disturbance_enable()
         # Check disturbance status
         if not self.is_disturbance_enabled(servo=servo):
             raise IMMonitoringError("Error enabling disturbance.")

--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -373,7 +373,13 @@ class Capture:
         if version is None:
             version = self._check_version(servo)
         if version < MonitoringVersion.MONITORING_V3:
-            return self.enable_monitoring(servo=servo)
+            # V1: monitoring and disturbance share the same enable
+            # mechanism. Bypass enable_monitoring() mapped-register check
+            # because disturbance-only mapped registers are sufficient.
+            drive.monitoring_enable()
+            if not self.is_monitoring_enabled(servo=servo):
+                raise IMMonitoringError("Error enabling disturbance.")
+            return
         drive.disturbance_enable()
         # Check disturbance status
         if not self.is_disturbance_enabled(servo=servo):


### PR DESCRIPTION
## Problem

On drives supporting V1 monitoring/disturbance, using the disturbance (signal generator) in standalone mode fails with the error **"There are no registers mapped for monitoring"** if monitoring was previously used and cleaned up.

### Steps to reproduce

1. Connect to a drive that supports monitoring/disturbance V1.
2. Use the signal generator (disturbance) in isolation — it works.
3. Use the tune button (which starts both monitoring and disturbance).
4. Disable tune (monitoring is cleaned up).
5. Try to use the signal generator in isolation again — **it fails**.

### Root cause

On V1, monitoring and disturbance share the same firmware enable mechanism. Enabling disturbance actually enables the shared monitoring/disturbance subsystem.

When monitoring is cleaned up (e.g., after tune), all monitoring-mapped registers are removed from the drive. Subsequent standalone disturbance attempts fail because the enable path checked only for monitoring-mapped registers, even though disturbance-mapped registers were present and sufficient to enable the shared mechanism.
