### PR TITLE
Enable EVE-XCR-E in pipeline

### DIFF
--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -53,8 +53,7 @@ ETH_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    # Disabled pending INGK-982
-                    __EXECUTION_POLICY_KEY: "never",
+                    __EXECUTION_POLICY_KEY: "always",
                     __TEST_CONFIGS_KEY: {
                         "ETH_TEST_SESSIONS": PyTestConfig(
                             markers="ethernet",
@@ -78,8 +77,7 @@ ECAT_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_E_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    # Disabled pending INGK-983
-                    __EXECUTION_POLICY_KEY: "never",
+                    __EXECUTION_POLICY_KEY: "always",
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="soem",

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -53,7 +53,8 @@ ETH_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",
+                    # Disabled pending INGK-982
+                    __EXECUTION_POLICY_KEY: "never",
                     __TEST_CONFIGS_KEY: {
                         "ETH_TEST_SESSIONS": PyTestConfig(
                             markers="ethernet",


### PR DESCRIPTION
This pull request makes a targeted update to the `tests/setups/rack_specifiers.py` test setup. The execution policy for a specific configuration has been changed from "never" to "always," which will likely affect when or how certain tests are executed.

- Test Configuration Change:
  * Updated the value of `__EXECUTION_POLICY_KEY` from `"never"` to `"always"` in the extra data for a test setup, enabling the execution policy that was previously disabled.