### PR TITLE
Ingm 752 update ingm firmware version to latest match ingk

### DIFF
--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -32,12 +32,27 @@ ETH_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "ETH_TEST_SESSIONS": PyTestConfig(
                             markers="ethernet",
                             run_test_stage_uid="ethernet_everest_2.4.0",
                             stage_name="Ethernet Everest - FW. 2.4.0",
+                        )
+                    },
+                },
+            ),
+            "2.8.1": VersionConfig.from_version(
+                version="2.8.1",
+                config_file=_config_files.EVE_XCR_C_CONFIG,
+                dictionary_type=DictionaryType.XDF_V2,
+                extra_data={
+                    __EXECUTION_POLICY_KEY: "always",
+                    __TEST_CONFIGS_KEY: {
+                        "ETH_TEST_SESSIONS": PyTestConfig(
+                            markers="ethernet",
+                            run_test_stage_uid="ethernet_everest_2.8.1",
+                            stage_name="Ethernet Everest - FW. 2.8.1",
                         )
                     },
                 },
@@ -53,12 +68,27 @@ ETH_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "ETH_TEST_SESSIONS": PyTestConfig(
                             markers="ethernet",
                             run_test_stage_uid="ethernet_capitan_2.4.0",
                             stage_name="Ethernet Capitan - FW. 2.4.0",
+                        )
+                    },
+                },
+            ),
+            "2.10.0": VersionConfig.from_version(
+                version="2.10.0",
+                config_file=_config_files.CAP_XCR_C_CONFIG,
+                dictionary_type=DictionaryType.XDF_V2,
+                extra_data={
+                    __EXECUTION_POLICY_KEY: "always",
+                    __TEST_CONFIGS_KEY: {
+                        "ETH_TEST_SESSIONS": PyTestConfig(
+                            markers="ethernet",
+                            run_test_stage_uid="ethernet_capitan_2.10.0",
+                            stage_name="Ethernet Capitan - FW. 2.10.0",
                         )
                     },
                 },
@@ -77,12 +107,27 @@ ECAT_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_E_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="soem",
                             run_test_stage_uid="ethercat_everest_2.6.0",
                             stage_name="EtherCAT Everest - FW. 2.6.0",
+                        )
+                    },
+                },
+            ),
+            "2.8.1": VersionConfig.from_version(
+                version="2.8.1",
+                config_file=_config_files.EVE_XCR_E_CONFIG,
+                dictionary_type=DictionaryType.XDF_V2,
+                extra_data={
+                    __EXECUTION_POLICY_KEY: "always",
+                    __TEST_CONFIGS_KEY: {
+                        "ECAT_TEST_SESSIONS": PyTestConfig(
+                            markers="soem",
+                            run_test_stage_uid="ethercat_everest_2.8.1",
+                            stage_name="EtherCAT Everest - FW. 2.8.1",
                         )
                     },
                 },
@@ -98,12 +143,27 @@ ECAT_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_E_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="soem",
                             run_test_stage_uid="ethercat_capitan_2.6.0",
                             stage_name="EtherCAT Capitan - FW. 2.6.0",
+                        )
+                    },
+                },
+            ),
+            "2.10.0": VersionConfig.from_version(
+                version="2.10.0",
+                config_file=_config_files.CAP_XCR_E_CONFIG,
+                dictionary_type=DictionaryType.XDF_V2,
+                extra_data={
+                    __EXECUTION_POLICY_KEY: "always",
+                    __TEST_CONFIGS_KEY: {
+                        "ECAT_TEST_SESSIONS": PyTestConfig(
+                            markers="soem",
+                            run_test_stage_uid="ethercat_capitan_2.10.0",
+                            stage_name="EtherCAT Capitan - FW. 2.10.0",
                         )
                     },
                 },
@@ -165,12 +225,27 @@ CAN_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",
                             run_test_stage_uid="canopen_everest_2.4.0",
                             stage_name="CANopen Everest - FW. 2.4.0",
+                        )
+                    },
+                },
+            ),
+            "2.8.1": VersionConfig.from_version(
+                version="2.8.1",
+                config_file=_config_files.EVE_XCR_C_CONFIG,
+                dictionary_type=DictionaryType.XDF_V2,
+                extra_data={
+                    __EXECUTION_POLICY_KEY: "always",
+                    __TEST_CONFIGS_KEY: {
+                        "CAN_TEST_SESSIONS": PyTestConfig(
+                            markers="canopen",
+                            run_test_stage_uid="canopen_everest_2.8.1",
+                            stage_name="CANopen Everest - FW. 2.8.1",
                         )
                     },
                 },
@@ -186,12 +261,27 @@ CAN_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",
                             run_test_stage_uid="canopen_capitan_2.4.0",
                             stage_name="CANopen Capitan - FW. 2.4.0",
+                        )
+                    },
+                },
+            ),
+            "2.10.0": VersionConfig.from_version(
+                version="2.10.0",
+                config_file=_config_files.CAP_XCR_C_CONFIG,
+                dictionary_type=DictionaryType.XDF_V2,
+                extra_data={
+                    __EXECUTION_POLICY_KEY: "always",
+                    __TEST_CONFIGS_KEY: {
+                        "CAN_TEST_SESSIONS": PyTestConfig(
+                            markers="canopen",
+                            run_test_stage_uid="canopen_capitan_2.10.0",
+                            stage_name="CANopen Capitan - FW. 2.10.0",
                         )
                     },
                 },
@@ -205,10 +295,10 @@ ECAT_MULTISLAVE_SETUP = MultiRackServiceConfigSpecifier.create(
     identifier="ECAT_MULTISLAVE",
     specifiers=[
         ECAT_SETUP.get_specifier_by_identifier_with_version(
-            identifier=PartNumber.EVE_XCR_E, version="2.6.0"
+            identifier=PartNumber.EVE_XCR_E, version="2.8.1"
         ),
         ECAT_SETUP.get_specifier_by_identifier_with_version(
-            identifier=PartNumber.CAP_XCR_E, version="2.6.0"
+            identifier=PartNumber.CAP_XCR_E, version="2.10.0"
         ),
     ],
     extra_data={
@@ -216,8 +306,8 @@ ECAT_MULTISLAVE_SETUP = MultiRackServiceConfigSpecifier.create(
         __TEST_CONFIGS_KEY: {
             "ECAT_TEST_SESSIONS": PyTestConfig(
                 markers="soem_multislave",
-                run_test_stage_uid="ethercat_multislave_2.6.0",
-                stage_name="EtherCAT Multislave - FW. 2.6.0",
+                run_test_stage_uid="ethercat_multislave",
+                stage_name="EtherCAT Multislave",
             )
         },
     },

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,5 +1,4 @@
 import pytest
-from summit_testing_framework.product_constants import PartNumber
 from summit_testing_framework.setups import (
     MultiRackServiceConfigSpecifier,
     RackServiceConfigSpecifier,
@@ -7,7 +6,6 @@ from summit_testing_framework.setups import (
 
 from ingeniamotion.enums import GPI, GPO, DigitalVoltageLevel, GPIOPolarity
 from ingeniamotion.exceptions import IMError
-from tests.setups.rack_specifiers import CAN_SETUP, ECAT_SETUP, ETH_SETUP
 
 
 @pytest.mark.virtual
@@ -46,18 +44,14 @@ def test_set_get_gpi_polarity(mc, alias, gpi_id, polarity):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.virtual
+# Capitan rack setups do not have gpio control
+@pytest.mark.not_valid_for_product(part_number="CAP-XCR-E")
+@pytest.mark.not_valid_for_product(part_number="CAP-XCR-C")
 def test_get_gpi_voltage_level(mc, alias, environment, setup_specifier):
     if not isinstance(
         setup_specifier, (RackServiceConfigSpecifier, MultiRackServiceConfigSpecifier)
     ):
         pytest.skip("Skipping test for local configurations")
-
-    if setup_specifier in [
-        ETH_SETUP.get_specifier_by_identifier(PartNumber.CAP_XCR_C),
-        ECAT_SETUP.get_specifier_by_identifier(PartNumber.CAP_XCR_E),
-        CAN_SETUP.get_specifier_by_identifier(PartNumber.CAP_XCR_C),
-    ]:
-        pytest.skip("Capitan rack setups do not have gpio control")
 
     environment.set_gpi(number=1, value=False)
     environment.set_gpi(number=2, value=True)


### PR DESCRIPTION
This pull request updates the test rack configuration specifications to add support for new firmware versions and adjust execution policies for existing versions. The main changes include adding new configurations for firmware versions 2.8.1 and 2.10.0 across multiple part numbers and protocols, and changing the execution policy for older versions from "always" to "nightly".

**New firmware version support:**

* Added `2.8.1` and `2.10.0` configurations for Ethernet, EtherCAT, and CANopen protocols in the following part numbers: `EVE_XCR_C`, `CAP_XCR_C`, `EVE_XCR_E`, and `CAP_XCR_E`, each with appropriate test session details and execution policies set to "always". [[1]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925R45-R59) [[2]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925R81-R95) [[3]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925R120-R134) [[4]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925R156-R170) [[5]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925R238-R252) [[6]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925R274-R288)

**Execution policy updates:**

* Changed the execution policy for existing versions (prior to 2.8.1/2.10.0) from "always" to "nightly" for all affected part numbers and protocols. [[1]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L35-R35) [[2]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L56-R71) [[3]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L80-R110) [[4]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L101-R146) [[5]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L168-R228) [[6]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L189-R264)

**Test setup updates:**

* Updated the `ECAT_MULTISLAVE` test setup to use the new versions (`2.8.1` for `EVE_XCR_E` and `2.10.0` for `CAP_XCR_E`) and simplified the test stage UID and name.