### PR TITLE
Update execution policies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,21 @@ def reassignFilePermissions() {
 }
 
 /* Build develop everyday 3 times starting at 19:00 UTC (21:00 Barcelona Time), running all python versions */
-CRON_SETTINGS = BRANCH_NAME == "develop" ? "0 19,21,23 * * * % PYTHON_VERSIONS=All;WIRESHARK_LOGGING=true" : ""
+/*
+ * Cron schedules for the develop branch:
+ *
+ * Nightly builds (every day):
+ *   19:00, 21:00, 23:00 UTC (21:00, 23:00, 01:00 Barcelona Time)
+ *   → Sets RUN_POLICY_NIGHTLY=true so that tests gated on the 'nightly' policy will run.
+ *
+ * Friday+Saturday extra builds (Friday & Saturday only):
+ *   08:00, 14:00 UTC (10:00, 16:00 Barcelona Time)
+ *   → Sets RUN_POLICY_NIGHTLY=true and RUN_POLICY_WEEKEND=true so that tests gated on
+ *     either 'nightly' or 'weekends' policy will run.
+ */
+NIGHTLY_CRON = '0 19,21,23 * * * % PYTHON_VERSIONS=All;WIRESHARK_LOGGING=true;RUN_POLICY_NIGHTLY=true'
+WEEKEND_CRON = '0 8,14 * * 5,6 % PYTHON_VERSIONS=All;WIRESHARK_LOGGING=true;RUN_POLICY_NIGHTLY=true;RUN_POLICY_WEEKEND=true'
+CRON_SETTINGS = BRANCH_NAME == "develop" ? "${NIGHTLY_CRON}\n${WEEKEND_CRON}" : ""
 
 pipeline {
     agent none
@@ -108,6 +122,8 @@ pipeline {
             name: 'WIRESHARK_LOGGING_SCOPE'
         )
         booleanParam(name: 'CLEAR_SUCCESSFUL_WIRESHARK_LOGS', defaultValue: true, description: 'Clears Wireshark logs if the test passed')
+        booleanParam(name: 'RUN_POLICY_NIGHTLY', defaultValue: false, description: 'Tag this build as a nightly build (set automatically by cron triggers)')
+        booleanParam(name: 'RUN_POLICY_WEEKEND', defaultValue: false, description: 'Tag this build as a weekend build (set automatically by weekend cron triggers)')
     }
     stages {
         stage('Prepare test sessions') {
@@ -160,6 +176,12 @@ pipeline {
                     )
 
                     testManager.testSessionFilter = params.test_session_filter
+
+                    // Parse run policy tags from boolean parameters
+                    def runPolicyTags = [] as Set
+                    if (params.RUN_POLICY_NIGHTLY) { runPolicyTags.add("nightly") }
+                    if (params.RUN_POLICY_WEEKEND) { runPolicyTags.add("weekends") }
+                    testManager.runPolicyTags = runPolicyTags
 
                     echo("Test sessions have been configured to run with the following base configuration:\n${TEST_SESSIONS.configSummary()}")
 

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -32,7 +32,7 @@ ETH_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",
+                    __EXECUTION_POLICY_KEY: "weekends",
                     __TEST_CONFIGS_KEY: {
                         "ETH_TEST_SESSIONS": PyTestConfig(
                             markers="ethernet",
@@ -109,7 +109,7 @@ ECAT_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_E_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",
+                    __EXECUTION_POLICY_KEY: "weekends",
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="soem",
@@ -145,7 +145,7 @@ ECAT_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_E_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",
+                    __EXECUTION_POLICY_KEY: "weekends",
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="soem",
@@ -227,7 +227,7 @@ CAN_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",
+                    __EXECUTION_POLICY_KEY: "weekends",
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",
@@ -263,7 +263,7 @@ CAN_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",
+                    __EXECUTION_POLICY_KEY: "weekends",
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",


### PR DESCRIPTION
This pull request updates the Jenkins pipeline to improve scheduling and tagging of nightly and weekend test runs, and aligns test execution policies in the test setup configuration. The most important changes are:

**Jenkins pipeline scheduling and parameters:**

* Split the `develop` branch cron schedule into two: one for nightly builds and one for additional weekend builds, each setting appropriate environment variables (`RUN_POLICY_NIGHTLY`, `RUN_POLICY_WEEKEND`) to tag the builds.
* Added new boolean parameters `RUN_POLICY_NIGHTLY` and `RUN_POLICY_WEEKEND` to the pipeline, which are set automatically by the cron triggers to tag builds as nightly or weekend runs.
* Updated the test session preparation logic to collect run policy tags from the new boolean parameters and assign them to the test manager, allowing tests to be gated on these policies.

**Test execution policy alignment:**

* Changed the execution policy for several test rack specifiers in `tests/setups/rack_specifiers.py` from `"nightly"` to `"weekends"`, ensuring these tests only run during weekend builds. [[1]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L35-R35) [[2]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L112-R112) [[3]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L148-R148) [[4]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L230-R230) [[5]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L266-R266)