### PR TITLE
Ingm 761 update safety to release version skip broken tests

### DIFF
--- a/tests/fsoe/test_process_image.py
+++ b/tests/fsoe/test_process_image.py
@@ -744,8 +744,8 @@ def test_map_safety_input_output_random(
 
 @pytest.mark.fsoe_phase2
 # https://novantamotion.atlassian.net/browse/COMOCOAPP-597
-@pytest.valid_versions_for_product(part_number="EVS-S-NET-E", max="2.0.9.16")
-@pytest.valid_versions_for_product(part_number="DEN-S-NET-E", max="2.0.9.16")
+@pytest.mark.valid_versions_for_product(part_number="EVS-S-NET-E", max="2.0.9.016")
+@pytest.mark.valid_versions_for_product(part_number="DEN-S-NET-E", max="2.0.9.016")
 def test_map_all_safety_functions(
     mc_with_fsoe_with_sra_and_feedback_scenario: tuple[MotionController, "FSoEMasterHandler"],
     timeout_for_data_sra: float,

--- a/tests/fsoe/test_process_image.py
+++ b/tests/fsoe/test_process_image.py
@@ -743,6 +743,9 @@ def test_map_safety_input_output_random(
 
 
 @pytest.mark.fsoe_phase2
+# https://novantamotion.atlassian.net/browse/COMOCOAPP-597
+@pytest.valid_versions_for_product(part_number="EVS-S-NET-E", max="2.0.9.16")
+@pytest.valid_versions_for_product(part_number="DEN-S-NET-E", max="2.0.9.16")
 def test_map_all_safety_functions(
     mc_with_fsoe_with_sra_and_feedback_scenario: tuple[MotionController, "FSoEMasterHandler"],
     timeout_for_data_sra: float,

--- a/tests/fsoe/test_safety_errors.py
+++ b/tests/fsoe/test_safety_errors.py
@@ -342,8 +342,8 @@ class TestFeedbackScenario0:
 
     @pytest.mark.fsoe_phase2
     # https://novantamotion.atlassian.net/browse/COMOCOAPP-597
-    @pytest.valid_versions_for_product(part_number="EVS-S-NET-E", max="2.0.9.16")
-    @pytest.valid_versions_for_product(part_number="DEN-S-NET-E", max="2.0.9.16")
+    @pytest.mark.valid_versions_for_product(part_number="EVS-S-NET-E", max="2.0.9.016")
+    @pytest.mark.valid_versions_for_product(part_number="DEN-S-NET-E", max="2.0.9.016")
     def test_safe_input_mapped_to_ss2_not_allowed(
         self,
         configured_handler: tuple["MotionController", "FSoEMasterHandler"],

--- a/tests/fsoe/test_safety_errors.py
+++ b/tests/fsoe/test_safety_errors.py
@@ -341,6 +341,9 @@ class TestFeedbackScenario0:
         )
 
     @pytest.mark.fsoe_phase2
+    # https://novantamotion.atlassian.net/browse/COMOCOAPP-597
+    @pytest.valid_versions_for_product(part_number="EVS-S-NET-E", max="2.0.9.16")
+    @pytest.valid_versions_for_product(part_number="DEN-S-NET-E", max="2.0.9.16")
     def test_safe_input_mapped_to_ss2_not_allowed(
         self,
         configured_handler: tuple["MotionController", "FSoEMasterHandler"],

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -193,22 +193,17 @@ ECAT_DEN_S_NET_E_SETUP = RackServiceConfigSpecifier.from_version_configs(
                 },
             },
         ),
-        "PHASE2": VersionConfig.from_files(
-            version="2.9.0.16",
+        "PHASE2": VersionConfig.from_version(
+            version="2.10.0",
             config_file=None,
-            firmware=Path(
-                "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.lfu"
-            ),
-            dictionary=Path(
-                "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.16/den-s-net-e_2.9.0.016.xdf3"
-            ),
+            dictionary_type=DictionaryType.XDF_V3,
             extra_data={
                 __EXECUTION_POLICY_KEY: "always",
                 __TEST_CONFIGS_KEY: {
                     "ECAT_TEST_SESSIONS": PyTestConfig(
                         markers="fsoe or fsoe_phase2",
-                        run_test_stage_uid="fsoe_phase2_2.9.0",
-                        stage_name="Safety Denali Phase II - FW. 2.9.0",
+                        run_test_stage_uid="fsoe_phase2_2.10.0",
+                        stage_name="Safety Denali Phase II - FW. 2.10.0",
                     )
                 },
             },


### PR DESCRIPTION
This pull request updates the configuration for the "PHASE2" test setup to use the new firmware version 2.10.0 and simplifies how the configuration is constructed. The most important changes are:

**Test Configuration Updates:**

* Updated the "PHASE2" configuration in `rack_specifiers.py` to use firmware version `2.10.0` instead of `2.9.0.16`, and updated related test stage identifiers and names accordingly.

**Code Simplification:**

* Switched from using `VersionConfig.from_files` with explicit firmware and dictionary file paths to `VersionConfig.from_version` with a specified `dictionary_type`, simplifying the configuration setup.