### PR TITLE
Restore weekend policy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,14 +72,14 @@ def reassignFilePermissions() {
  *   19:00, 21:00, 23:00 UTC (21:00, 23:00, 01:00 Barcelona Time)
  *   → Sets RUN_POLICY_NIGHTLY=true so that tests gated on the 'nightly' policy will run.
  *
- * Friday+Saturday extra builds (Friday & Saturday only):
+ * Weekend extra builds (Saturday & Sunday only):
  *   08:00, 14:00 UTC (10:00, 16:00 Barcelona Time)
  *   → Sets RUN_POLICY_NIGHTLY=true and RUN_POLICY_WEEKEND=true so that tests gated on
  *     either 'nightly' or 'weekends' policy will run.
  */
-NIGHTLY_CRON = '0 19,21,23 * * * % PYTHON_VERSIONS=All;WIRESHARK_LOGGING=true;RUN_POLICY_NIGHTLY=true'
-WEEKEND_CRON = '0 8,14 * * 5,6 % PYTHON_VERSIONS=All;WIRESHARK_LOGGING=true;RUN_POLICY_NIGHTLY=true;RUN_POLICY_WEEKEND=true'
-CRON_SETTINGS = BRANCH_NAME == "develop" ? "${NIGHTLY_CRON}\n${WEEKEND_CRON}" : ""
+def NIGHTLY_CRON = '0 19,21,23 * * * % PYTHON_VERSIONS=All;WIRESHARK_LOGGING=true;RUN_POLICY_NIGHTLY=true'
+def WEEKEND_CRON   = '0 8,14 * * 6-7 % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true;RUN_POLICY_WEEKEND=true'
+def CRON_SETTINGS = BRANCH_NAME == "develop" ? "${NIGHTLY_CRON}\n${WEEKEND_CRON}" : ""
 
 pipeline {
     agent none


### PR DESCRIPTION
This pull request updates the scheduled build configuration in the `Jenkinsfile` to clarify and adjust when nightly and weekend builds are triggered. The main changes involve correcting the weekend build days, updating the associated comments, and aligning environment variables.

**Build schedule and configuration updates:**

* Updated the weekend extra builds to run on Saturday and Sunday instead of Friday and Saturday, both in the comments and the `WEEKEND_CRON` schedule.
* Changed the `WEEKEND_CRON` schedule from using days 5 and 6 (Friday & Saturday) to 6-7 (Saturday & Sunday) for clarity and correctness.
* Modified the weekend build environment variables to remove `WIRESHARK_LOGGING=true`, aligning them with intended usage.
* Updated variable declarations to use `def` for consistency and clarity.