### PR TITLE
INGM-763 Monitoring conversion uses platform dependent format

### DIFF
--- a/ingeniamotion/monitoring/base_monitoring.py
+++ b/ingeniamotion/monitoring/base_monitoring.py
@@ -258,12 +258,12 @@ class Monitoring(ABC):
         if dtype == RegDtype.U16:
             return int(np.array([int(value)], dtype="int64").astype("uint16")[0])
         if dtype == RegDtype.U32:
-            return int(struct.unpack("L", struct.pack("I", int(value)))[0])
+            return int(struct.unpack("I", struct.pack("I", int(value)))[0])
         if dtype == RegDtype.S32:
             if value < 0:
                 return int(value + (1 << 32))
             return int(np.array([int(value)], dtype="int64").astype("int32")[0])
-        return int(struct.unpack("L", struct.pack("f", value))[0])
+        return int(struct.unpack("I", struct.pack("f", value))[0])
 
     @abstractmethod
     @check_monitoring_disabled

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,11 +1,14 @@
 import time
 from functools import partial
 from threading import Thread
+import struct
 
 import pytest
 
 from ingeniamotion.enums import MonitoringSoCConfig, MonitoringSoCType
 from ingeniamotion.exceptions import IMMonitoringError
+from ingeniamotion.monitoring.base_monitoring import Monitoring
+from ingenialink.enums.register import RegDtype
 from tests.conftest import not_valid_for_eve_can_ecat_products
 
 MONITOR_START_CONDITION_TYPE_REGISTER = "MON_CFG_SOC_TYPE"
@@ -500,3 +503,17 @@ def test_get_trigger_type_exception(mocker, mc, monitoring):
 @pytest.mark.skip("Check INGM-584")
 def test_dummy():
     pass
+
+
+@pytest.mark.virtual
+def test_unpack_trigger_value_float_no_struct_error():
+    """Regression test: struct.unpack must not raise on Linux 64-bit for FLOAT dtype."""
+    result = Monitoring._unpack_trigger_value(0.5, RegDtype.FLOAT)
+    assert result == struct.unpack("I", struct.pack("f", 0.5))[0]
+
+
+@pytest.mark.virtual
+def test_unpack_trigger_value_u32_no_struct_error():
+    """Regression test: struct.unpack must not raise on Linux 64-bit for U32 dtype."""
+    result = Monitoring._unpack_trigger_value(42, RegDtype.U32)
+    assert result == 42

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,14 +1,14 @@
+import struct
 import time
 from functools import partial
 from threading import Thread
-import struct
 
 import pytest
+from ingenialink.enums.register import RegDtype
 
 from ingeniamotion.enums import MonitoringSoCConfig, MonitoringSoCType
 from ingeniamotion.exceptions import IMMonitoringError
 from ingeniamotion.monitoring.base_monitoring import Monitoring
-from ingenialink.enums.register import RegDtype
 from tests.conftest import not_valid_for_eve_can_ecat_products
 
 MONITOR_START_CONDITION_TYPE_REGISTER = "MON_CFG_SOC_TYPE"


### PR DESCRIPTION
## Fix platform-dependent `struct.unpack` crash on Linux 64-bit

### Problem

`_unpack_trigger_value()` in `base_monitoring.py` uses `struct.unpack("L", ...)` to reinterpret values as UINT32. The `"L"` format specifier is **platform-dependent**:

| Platform | `"L"` size | `"f"` / `"I"` size |
|----------|-----------|---------------------|
| Windows (32/64-bit) | 4 bytes | 4 bytes |
| Linux 64-bit | **8 bytes** | 4 bytes |

This causes `struct.error: unpack requires a buffer of 8 bytes` on Linux 64-bit, crashing `test_current_integration` on Jenkins CI.

### Traceback

```
base_monitoring.py:266: in _unpack_trigger_value
    return int(struct.unpack("L", struct.pack("f", value))[0])
E   struct.error: unpack requires a buffer of 8 bytes
```

### Fix

Replace `"L"` with `"I"` in both `struct.unpack` calls. `"I"` (unsigned 32-bit int) is always 4 bytes on all platforms, correctly matching the 4-byte buffers from `struct.pack("f", ...)` and `struct.pack("I", ...)`.
