### PR TITLE
INGM-792 ILRegisterAccessError bad constructor usage undetected

### DIFF
--- a/ingeniamotion/motion.py
+++ b/ingeniamotion/motion.py
@@ -1,6 +1,7 @@
 import time
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Optional, Union
+import sys
 
 import ingenialogger
 from ingenialink.exceptions import ILError, ILTimeoutError
@@ -10,6 +11,7 @@ if TYPE_CHECKING:
 from ingeniamotion.enums import GeneratorMode, OperationMode, PhasingMode, SensorType
 from ingeniamotion.exceptions import IMTimeoutError
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
+
 
 DEFAULT_MOTOR_ERROR_TIMEOUT_S = 6
 
@@ -149,22 +151,26 @@ class Motion:
         try:
             drive.enable(subnode=axis)
         except ILError as e:
-            timeout = error_timeout
-            start_time = time.time()
-            error_raised = False
-            while not error_raised and (time.time() < (start_time + timeout)):
-                error_raised = (
-                    self.mc.errors.get_number_total_errors(servo=servo, axis=axis) != num_errors
-                )
-            if error_raised:
-                error_code, _subnode, _warning = self.mc.errors.get_last_buffer_error(
-                    servo=servo, axis=axis
-                )
-                _error_id, _, _, error_msg = self.mc.errors.get_error_data(error_code, servo=servo)
-            else:
-                raise ILTimeoutError("Error trigger timeout exceeded.")
-            exception_type = type(e)
-            raise exception_type(error_msg)
+            if sys.version_info >= (3, 11):
+                # Adds a note to the exception with the error last error message from the queues
+                # Only available in Python 3.11+ (add_note method)
+                timeout = error_timeout
+                start_time = time.time()
+                error_raised = False
+                while not error_raised and (time.time() < (start_time + timeout)):
+                    error_raised = (
+                        self.mc.errors.get_number_total_errors(servo=servo, axis=axis) != num_errors
+                    )
+                if error_raised:
+                    error_code, _subnode, _warning = self.mc.errors.get_last_buffer_error(
+                        servo=servo, axis=axis
+                    )
+                    _error_id, _, _, error_msg = self.mc.errors.get_error_data(error_code, servo=servo)                    
+                    e.add_note(f"Error message: {error_msg}")
+                else:
+                    raise ILTimeoutError("Error trigger timeout exceeded.")
+
+            raise e
 
     def motor_disable(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> None:
         """Disable motor.

--- a/ingeniamotion/motion.py
+++ b/ingeniamotion/motion.py
@@ -1,7 +1,7 @@
+import sys
 import time
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Optional, Union
-import sys
 
 import ingenialogger
 from ingenialink.exceptions import ILError, ILTimeoutError
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 from ingeniamotion.enums import GeneratorMode, OperationMode, PhasingMode, SensorType
 from ingeniamotion.exceptions import IMTimeoutError
 from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO
-
 
 DEFAULT_MOTOR_ERROR_TIMEOUT_S = 6
 
@@ -165,7 +164,9 @@ class Motion:
                     error_code, _subnode, _warning = self.mc.errors.get_last_buffer_error(
                         servo=servo, axis=axis
                     )
-                    _error_id, _, _, error_msg = self.mc.errors.get_error_data(error_code, servo=servo)                    
+                    _error_id, _, _, error_msg = self.mc.errors.get_error_data(
+                        error_code, servo=servo
+                    )
                     e.add_note(f"Error message: {error_msg}")
                 else:
                     raise ILTimeoutError("Error trigger timeout exceeded.")

--- a/ingeniamotion/motion.py
+++ b/ingeniamotion/motion.py
@@ -150,28 +150,26 @@ class Motion:
         try:
             drive.enable(subnode=axis)
         except ILError as e:
-            if sys.version_info >= (3, 11):
-                # Adds a note to the exception with the error last error message from the queues
-                # Only available in Python 3.11+ (add_note method)
-                timeout = error_timeout
-                start_time = time.time()
-                error_raised = False
-                while not error_raised and (time.time() < (start_time + timeout)):
-                    error_raised = (
-                        self.mc.errors.get_number_total_errors(servo=servo, axis=axis) != num_errors
-                    )
-                if error_raised:
-                    error_code, _subnode, _warning = self.mc.errors.get_last_buffer_error(
-                        servo=servo, axis=axis
-                    )
-                    _error_id, _, _, error_msg = self.mc.errors.get_error_data(
-                        error_code, servo=servo
-                    )
+            timeout = error_timeout
+            start_time = time.time()
+            error_raised = False
+            while not error_raised and (time.time() < (start_time + timeout)):
+                error_raised = (
+                    self.mc.errors.get_number_total_errors(servo=servo, axis=axis) != num_errors
+                )
+            if error_raised:
+                error_code, _subnode, _warning = self.mc.errors.get_last_buffer_error(
+                    servo=servo, axis=axis
+                )
+                _error_id, _, _, error_msg = self.mc.errors.get_error_data(error_code, servo=servo)
+                if sys.version_info >= (3, 11):
+                    # Adds a note to the exception with the error last error message from the queues
+                    # Only available in Python 3.11+ (add_note method)
                     e.add_note(f"Error message: {error_msg}")
-                else:
-                    raise ILTimeoutError("Error trigger timeout exceeded.")
+            else:
+                raise ILTimeoutError("Error trigger timeout exceeded.")
 
-            raise e
+            raise
 
     def motor_disable(self, servo: str = DEFAULT_SERVO, axis: int = DEFAULT_AXIS) -> None:
         """Disable motor.

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -168,8 +168,10 @@ def test_motor_enable_with_fault(
             "DRV_PROT_USER_UNDER_VOLT",
             100,
             exceptions.ILError,
-            ("The subnode 1 could not be enabled within 1000 ms. "
-             "The current subnode state is ServoState.FAULT"),
+            (
+                "The subnode 1 could not be enabled within 1000 ms. "
+                "The current subnode state is ServoState.FAULT"
+            ),
             "Error message: User Under-voltage detected",
             6,
         ),

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -179,10 +179,10 @@ def test_motor_enable_with_delayed_fault(
     with pytest.raises(exception_type) as excinfo:
         mc.motion.motor_enable(servo=alias, error_timeout=timeout)
 
-        assert str(excinfo.value) == (
-            "The subnode 1 could not be enabled within 1000 ms. "
-            "The current subnode state is ServoState.FAULT"
-        )
+    assert str(excinfo.value) == (
+        "The subnode 1 could not be enabled within 1000 ms. "
+        "The current subnode state is ServoState.FAULT"
+    )
 
     if sys.version_info >= (3, 11):
         assert excinfo.value.__notes__[0] == note

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -1,3 +1,4 @@
+import sys
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -101,7 +102,7 @@ def test_motor_enable(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize(
-    "uid, value, exception_type, message",
+    "uid, value, exception_type, note",
     [
         ("DRV_PROT_USER_UNDER_VOLT", 100, exceptions.ILError, "User Under-voltage detected"),
         (
@@ -119,7 +120,7 @@ def test_motor_enable_with_fault(
     uid: str,
     value: int,
     exception_type: Exception,
-    message: str,
+    note: str,
 ) -> None:
     mc.communication.set_register(uid, value, alias)
     with pytest.raises(exception_type) as excinfo:
@@ -128,14 +129,20 @@ def test_motor_enable_with_fault(
         # Retrieving the error code failed. Check INGM-522.
         with pytest.raises(exception_type) as excinfo:
             mc.motion.motor_enable(servo=alias)
-    assert str(excinfo.value) == message
+    assert str(excinfo.value) == (
+        "The subnode 1 could not be enabled within 1000 ms. "
+        "The current subnode state is ServoState.FAULT"
+    )
+
+    if sys.version_info >= (3, 11):
+        assert excinfo.value.__notes__[0] == note
 
 
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize(
-    "uid, value, exception_type, message, timeout",
+    "uid, value, exception_type, note, timeout",
     [
         # Under-Voltage Error is not triggered due to timeout error
         (
@@ -156,7 +163,7 @@ def test_motor_enable_with_delayed_fault(
     uid: str,
     value: int,
     exception_type: Exception,
-    message: str,
+    note: str,
     timeout: int,
 ):
     # Mock function response with delay
@@ -171,7 +178,14 @@ def test_motor_enable_with_delayed_fault(
     mc.communication.set_register(uid, value, alias)
     with pytest.raises(exception_type) as excinfo:
         mc.motion.motor_enable(servo=alias, error_timeout=timeout)
-    assert str(excinfo.value) == message
+
+        assert str(excinfo.value) == (
+            "The subnode 1 could not be enabled within 1000 ms. "
+            "The current subnode state is ServoState.FAULT"
+        )
+
+    if sys.version_info >= (3, 11):
+        assert excinfo.value.__notes__[0] == note
 
 
 @pytest.mark.ethernet

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -1,6 +1,6 @@
 import sys
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 import pytest
@@ -104,14 +104,24 @@ def test_motor_enable(mc, alias):
 @pytest.mark.parametrize(
     "uid, value, exception_type, note",
     [
-        ("DRV_PROT_USER_UNDER_VOLT", 100, exceptions.ILError, "User Under-voltage detected"),
+        (
+            "DRV_PROT_USER_UNDER_VOLT",
+            100,
+            exceptions.ILError,
+            "Error message: User Under-voltage detected",
+        ),
         (
             "DRV_PROT_USER_OVER_TEMP",
             1,
             exceptions.ILError,
-            "Over-temperature detected (user limit)",
+            "Error message: Over-temperature detected (user limit)",
         ),
-        ("DRV_PROT_USER_OVER_VOLT", 1, exceptions.ILError, "User Over-voltage detected"),
+        (
+            "DRV_PROT_USER_OVER_VOLT",
+            1,
+            exceptions.ILError,
+            "Error message: User Over-voltage detected",
+        ),
     ],
 )
 def test_motor_enable_with_fault(
@@ -142,7 +152,7 @@ def test_motor_enable_with_fault(
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize(
-    "uid, value, exception_type, note, timeout",
+    "uid, value, exception_type, expected_message, note, timeout",
     [
         # Under-Voltage Error is not triggered due to timeout error
         (
@@ -150,10 +160,19 @@ def test_motor_enable_with_fault(
             100,
             exceptions.ILTimeoutError,
             "Error trigger timeout exceeded.",
+            None,
             2,
         ),
         # Under-Voltage Error is triggered successfully
-        ("DRV_PROT_USER_UNDER_VOLT", 100, exceptions.ILError, "User Under-voltage detected", 6),
+        (
+            "DRV_PROT_USER_UNDER_VOLT",
+            100,
+            exceptions.ILError,
+            ("The subnode 1 could not be enabled within 1000 ms. "
+             "The current subnode state is ServoState.FAULT"),
+            "Error message: User Under-voltage detected",
+            6,
+        ),
     ],
 )
 def test_motor_enable_with_delayed_fault(
@@ -163,7 +182,8 @@ def test_motor_enable_with_delayed_fault(
     uid: str,
     value: int,
     exception_type: Exception,
-    note: str,
+    expected_message: str,
+    note: Optional[str],
     timeout: int,
 ):
     # Mock function response with delay
@@ -179,12 +199,9 @@ def test_motor_enable_with_delayed_fault(
     with pytest.raises(exception_type) as excinfo:
         mc.motion.motor_enable(servo=alias, error_timeout=timeout)
 
-    assert str(excinfo.value) == (
-        "The subnode 1 could not be enabled within 1000 ms. "
-        "The current subnode state is ServoState.FAULT"
-    )
+    assert str(excinfo.value) == expected_message
 
-    if sys.version_info >= (3, 11):
+    if sys.version_info >= (3, 11) and note is not None:
         assert excinfo.value.__notes__[0] == note
 
 


### PR DESCRIPTION
https://github.com/ingeniamc/ingeniamotion/pull/607/changes#diff-fcbde3c3d82bd1dcdfb33993bada0c78eb690048040c22b7ecf9adc1473bce29L166

motor enable was re-creating exceptions to add information about the last error of the error queue. It was extracting the type and calling the constructor, assuming it didn't have arguments. This is wrong and I don't even know how to detect it with mypy, but we should not do this. I'm not sure how to modify the exception in py 3.9 so it includes more information, but this is a perfect fit for Exception notes, which were added in 3.11, and allow to add a bit of context in each unrolling layer of the exception stack.

Since python 3.9 is already deprecated and 3.10 will be deprecated on october, i have taken the simple route of making this nicety of adding information of the last error on the queue exclusive to >= py 3.11. The guards will be removable once we drop support for those pythons.