### PR TITLE
Ingm 769 dynamic forced phasing test 2

### DIFF
--- a/ingeniamotion/wizard_tests/dynamic_forced_phasing.py
+++ b/ingeniamotion/wizard_tests/dynamic_forced_phasing.py
@@ -246,6 +246,43 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
         )
         self.logger.info("Reference angle offset set to zero", axis=self.axis)
 
+    def __calculate_monitoring_max_time(
+        self, frequency_divider: int, mapped_registers: list[dict[str, Union[int, str]]]
+    ) -> float:
+        """Calculate the maximum monitoring time.
+
+        Args:
+            frequency_divider: The frequency divider for the monitoring.
+            mapped_registers: The list of mapped registers for the monitoring.
+
+        Returns:
+            The maximum monitoring time in seconds.
+
+        Raises:
+            ValueError: The frequency divider is not valid or the mapped registers list is empty.
+        """
+        if frequency_divider <= 0:
+            raise ValueError("Frequency divider must be positive.")
+        if not mapped_registers:
+            raise ValueError("Mapped registers list must not be empty.")
+        frequency = (
+            self.mc.configuration.get_position_and_velocity_loop_rate(
+                servo=self.servo, axis=self.axis
+            )
+            / frequency_divider
+        )
+        max_sample_size_bits = self.mc.capture.monitoring_max_sample_size(servo=self.servo) * 8
+        map_reg_size = 0
+        for reg in mapped_registers:
+            reg_name = reg.get("name")
+            reg_axis = reg.get("axis", 1)
+            if not isinstance(reg_name, str) or not isinstance(reg_axis, int):
+                raise ValueError(f"Invalid register mapping: {reg}")
+            reg_info = self.mc.info.register_info(reg_name, reg_axis, servo=self.servo)
+            map_reg_size += reg_info.bit_length
+        max_time = max_sample_size_bits / map_reg_size / frequency
+        return max_time
+
     @BaseTest.stoppable
     def __configure_monitoring(self) -> None:
         """Configure the monitoring for the test."""
@@ -255,10 +292,17 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
             {"name": COMMUTATION_ANGLE_VALUE_REGISTER, "axis": self.axis},
             {"name": REFERENCE_ANGLE_VALUE_REGISTER, "axis": self.axis},
         ]
+        frequency_divider = 20
+        max_time = self.__calculate_monitoring_max_time(
+            frequency_divider=frequency_divider, mapped_registers=mon_registers
+        )
+        self.logger.debug(
+            f"Sample time for monitoring: {max_time:.3f} s, frequency divider: {frequency_divider}"
+        )
         self.__monitoring = self.mc.capture.create_monitoring(
             registers=mon_registers,
-            prescaler=50,
-            sample_time=1,
+            prescaler=frequency_divider,
+            sample_time=max_time,
             trigger_mode=MonitoringSoCType.TRIGGER_EVENT_AUTO,
             servo=self.servo,
             start=True,
@@ -396,7 +440,8 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
             direction.value, 1, self.spin_frequency, servo=self.servo, axis=self.axis
         )
         self.logger.info(
-            f"Rotate motor one mechanical revolution, frequency {self.spin_frequency:.3g} Hz, direction {direction.name}",
+            f"Rotate motor one mechanical revolution, frequency {self.spin_frequency:.3g} Hz, "
+            f"direction {direction.name}",
             axis=self.axis,
         )
 

--- a/ingeniamotion/wizard_tests/dynamic_forced_phasing.py
+++ b/ingeniamotion/wizard_tests/dynamic_forced_phasing.py
@@ -30,6 +30,7 @@ REFERENCE_ANGLE_VALUE_REGISTER = "COMMU_ANGLE_REF_VALUE"
 REFERENCE_ANGLE_OFFSET_REGISTER = "COMMU_ANGLE_REF_OFFSET"
 MAX_CURRENT_REGISTER = "CL_CUR_REF_MAX"
 PEAK_CURRENT_REGISTER = "DRV_PROT_I2T_PEAK_VALUE"
+RATED_CURRENT_REGISTER = "MOT_RATED_CURRENT"
 GENERATOR_VALUE_REGISTER = "FBK_GEN_VALUE"
 
 
@@ -329,10 +330,15 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
         current_motor_peak = self.mc.communication.get_register(
             PEAK_CURRENT_REGISTER, servo=self.servo, axis=self.axis
         )
+        rated_current = self.mc.communication.get_register(
+            RATED_CURRENT_REGISTER, servo=self.servo, axis=self.axis
+        )
         if not isinstance(max_current_drive, float):
             raise ValueError(f"Invalid type for max_current_drive: {type(max_current_drive)}")
         if not isinstance(current_motor_peak, float):
             raise ValueError(f"Invalid type for current_motor_peak: {type(current_motor_peak)}")
+        if not isinstance(rated_current, float):
+            raise ValueError(f"Invalid type for rated_current: {type(rated_current)}")
         limit_current = min(current_motor_peak, max_current_drive)
 
         if self._phasing_max_current_override is not None:
@@ -342,9 +348,9 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
                 servo=self.servo, axis=self.axis
             )
             if pos_vel_ratio == 1:
-                self.phasing_max_current = self.PHASING_CURRENT_PERCENTAGE * limit_current
+                self.phasing_max_current = self.PHASING_CURRENT_PERCENTAGE * rated_current
             else:
-                self.phasing_max_current = self.PHASING_CURRENT_PERCENTAGE_GEAR * limit_current
+                self.phasing_max_current = self.PHASING_CURRENT_PERCENTAGE_GEAR * rated_current
 
         if self.phasing_max_current > limit_current:
             raise TestError(

--- a/ingeniamotion/wizard_tests/dynamic_forced_phasing.py
+++ b/ingeniamotion/wizard_tests/dynamic_forced_phasing.py
@@ -81,6 +81,9 @@ class DynamicForcedPhasingReport(ReportBase):
     commutation_phasing_mode: PhasingMode
     """Commutation phasing mode."""
 
+    phasing_max_current: float
+    """Phasing maximum current used in the test."""
+
 
 class PhasingDirection(IntEnum):
     """Direction of the phasing movement."""
@@ -517,6 +520,7 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
             result_message=msg,
             commutation_angle=commutation_angle,
             commutation_phasing_mode=PhasingMode.NO_PHASING,
+            phasing_max_current=self.phasing_max_current,
         )
 
     @override

--- a/ingeniamotion/wizard_tests/dynamic_forced_phasing.py
+++ b/ingeniamotion/wizard_tests/dynamic_forced_phasing.py
@@ -1,14 +1,14 @@
 import math
+import time
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import TYPE_CHECKING, Final, Optional, Union, cast
+from typing import TYPE_CHECKING, Final, Optional, Union
 
 import ingenialogger
 from typing_extensions import override
 
 from ingeniamotion.enums import (
     MonitoringProcessStage,
-    MonitoringSoCConfig,
     MonitoringSoCType,
     OperationMode,
     PhasingMode,
@@ -30,6 +30,7 @@ REFERENCE_ANGLE_VALUE_REGISTER = "COMMU_ANGLE_REF_VALUE"
 REFERENCE_ANGLE_OFFSET_REGISTER = "COMMU_ANGLE_REF_OFFSET"
 MAX_CURRENT_REGISTER = "CL_CUR_REF_MAX"
 PEAK_CURRENT_REGISTER = "DRV_PROT_I2T_PEAK_VALUE"
+GENERATOR_VALUE_REGISTER = "FBK_GEN_VALUE"
 
 
 def circular_mean(values: list[float]) -> float:
@@ -44,7 +45,12 @@ def circular_mean(values: list[float]) -> float:
 
     Returns:
         The circular mean in ``[0, 1)``.
+
+    Raises:
+        ValueError: If ``values`` is empty.
     """
+    if not values:
+        raise ValueError("values must not be empty.")
     angles = [v * 2 * math.pi for v in values]
     mean_sin = sum(math.sin(a) for a in angles) / len(angles)
     mean_cos = sum(math.cos(a) for a in angles) / len(angles)
@@ -90,10 +96,8 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
     Commutation and reference feedbacks must be the same and absolute.
     """
 
-    GENERATOR_FREQUENCIES: Final[list[float]] = [0.1, 0.03, 0.01]
-    """Logarithmically spaced frequencies (Hz) tried in descending order."""
-    MAX_ATTEMPTS_PER_FREQUENCY: Final[int] = 2
-    """Number of monitoring reads attempted at each frequency before escalating."""
+    DEFAULT_FREQUENCY: Final[float] = 0.03
+    """Default frequency (Hz) for the test."""
     NORM_TOLERANCE: Final[float] = 0.02
     """Maximum allowed difference between the signals to consider them constant."""
     SYMMETRY_ERROR_TOLERANCE: Final[float] = 0.10
@@ -148,11 +152,11 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
         self._phasing_max_current_override = phasing_max_current
         self.phasing_max_current: float = 0.0
         if spin_frequency is None:
-            self.spin_frequency = self.GENERATOR_FREQUENCIES
+            self.spin_frequency = self.DEFAULT_FREQUENCY
         elif spin_frequency <= 0:
             raise ValueError("Spin frequency must be positive.")
         else:
-            self.spin_frequency = [spin_frequency]
+            self.spin_frequency = spin_frequency
 
     @property
     def monitoring(self) -> "Monitoring":
@@ -190,7 +194,6 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
             - The drive should support monitoring.
             - The selected current must not exceed the current limits.
             - Commutation and reference feedback sensors must be the same and absolute.
-
 
         Raises:
             TestError: If the motor is not in a valid state to start the test.
@@ -239,14 +242,9 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
         )
 
     @BaseTest.stoppable
-    def __configure_monitoring(self, direction: PhasingDirection) -> None:
-        """Configure the monitoring for the test based on the direction."""
+    def __configure_monitoring(self) -> None:
+        """Configure the monitoring for the test."""
         self.mc.capture.disable_monitoring(servo=self.servo)
-        trigger_config = (
-            MonitoringSoCConfig.TRIGGER_CONFIG_RISING
-            if direction == PhasingDirection.POSITIVE
-            else MonitoringSoCConfig.TRIGGER_CONFIG_FALLING
-        )
         mon_registers: list[dict[str, Union[int, str]]] = [
             {"name": COMMUTATION_ANGLE_VALUE_REGISTER, "axis": self.axis},
             {"name": REFERENCE_ANGLE_VALUE_REGISTER, "axis": self.axis},
@@ -255,10 +253,7 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
             registers=mon_registers,
             prescaler=50,
             sample_time=1,
-            trigger_mode=MonitoringSoCType.TRIGGER_EVENT_EDGE,
-            trigger_config=trigger_config,
-            trigger_signal={"name": COMMUTATION_ANGLE_VALUE_REGISTER, "axis": self.axis},
-            trigger_value=0.5,
+            trigger_mode=MonitoringSoCType.TRIGGER_EVENT_AUTO,
             servo=self.servo,
             start=True,
         )
@@ -311,11 +306,12 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
         self.mc.motion.motor_disable(servo=self.servo, axis=self.axis)
         self.__set_error_event_to_warning()
         self.__configure_open_loop_movement()
+        self.__configure_monitoring()
 
     @BaseTest.stoppable
     def __check_signals_difference_is_constant(
         self, signal1: list[float], signal2: list[float], tolerance_norm: float
-    ) -> tuple[Optional[float], Optional[float]]:
+    ) -> Optional[float]:
         """This function check if the difference between two signals is constant.
 
         Calculates the mean difference between two signals and checks if the relative
@@ -328,8 +324,8 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
 
 
         Returns:
-            float | None: The mean difference.
-            float | None: The maximum difference error.
+            The mean difference, or ``None`` if any sample deviates from the mean by more
+            than ``tolerance_norm``.
 
         Raises:
             ValueError: If the signals have different lengths.
@@ -337,7 +333,7 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
         if len(signal1) != len(signal2):
             raise ValueError("Signals must have the same length.")
         if len(signal1) == 0:
-            return None, None
+            return None
 
         differences = [(s1 - s2) % 1 for s1, s2 in zip(signal1, signal2)]
         mean_difference = circular_mean(differences)
@@ -351,12 +347,12 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
                 self.logger.debug(
                     f"mean difference: {mean_difference:.4f}, difference: {difference:.4f}"
                 )
-                return None, None
+                return None
 
         self.logger.debug(
             f"mean difference: {mean_difference:.4f}, max difference: {max_difference:.4f}"
         )
-        return mean_difference, max_difference
+        return mean_difference
 
     def __monitoring_stopper(
         self, _mon_process_stage: MonitoringProcessStage, _current_progress: float
@@ -366,11 +362,12 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
 
     @BaseTest.stoppable
     def _collect_mean_difference(self, direction: PhasingDirection, tolerance_norm: float) -> float:
-        """Move the motor and collect a stable mean angle difference.
+        """Move the motor one mechanical revolution and collect data across the entire revolution.
 
-        Tries up to ``MAX_ATTEMPTS_PER_FREQUENCY`` monitoring reads at each
-        frequency in ``spin_frequency``. Returns the mean angle difference
-        with the lowest maximum difference error.
+        Starts the internal generator movement and collect monitoring data along all the movement.
+        When the internal generator is set to 0 again, the movement stops and the mean between
+        all the data collected is calculated. The mean difference between the commutation and
+        reference signals is calculated and returned.
 
         Args:
             direction: The direction of the movement.
@@ -380,41 +377,45 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
             Mean angle difference between commutation and reference signals.
 
         Raises:
-            TestError: If no constant difference is found at any frequency.
+            TestError: If no constant difference is found.
 
         """
-        mean_tuples: list[tuple[float, float]] = []
-        for frequency in self.spin_frequency:
-            self.logger.debug(
-                f"Trying generator frequency {frequency:.3g} Hz, direction {direction.name}"
+        monitoring_samples: list[list[list[float]]] = []
+        timeout_time = 1 / self.spin_frequency
+        self.logger.debug(
+            f"Trying generator frequency {self.spin_frequency:.3g} Hz, direction {direction.name}"
+        )
+        self.mc.motion.internal_generator_saw_tooth_move(
+            direction.value, 1, self.spin_frequency, servo=self.servo, axis=self.axis
+        )
+        init_time = time.time()
+        movement_ends = False
+        while not movement_ends and time.time() - init_time < timeout_time:
+            self.check_stop()
+            self.monitoring.rearm_monitoring()
+            data = self.monitoring.read_monitoring_data(
+                timeout=timeout_time, progress_callback=self.__monitoring_stopper
             )
-            self.mc.motion.internal_generator_saw_tooth_move(
-                direction.value, 0, frequency, servo=self.servo, axis=self.axis
+            monitoring_samples.append(data)
+            gen_val = self.mc.communication.get_register(
+                GENERATOR_VALUE_REGISTER, servo=self.servo, axis=self.axis
             )
-            for attempt in range(1, self.MAX_ATTEMPTS_PER_FREQUENCY + 1):
-                self.check_stop()
-                data = self.monitoring.read_monitoring_data(
-                    timeout=1 / frequency, progress_callback=self.__monitoring_stopper
-                )
-                iter_mean_tuple = self.__check_signals_difference_is_constant(
-                    data[0], data[1], tolerance_norm
-                )
-                self.monitoring.rearm_monitoring()
-                if iter_mean_tuple[0] is not None and iter_mean_tuple[1] is not None:
-                    iter_mean_tuple = cast("tuple[float, float]", iter_mean_tuple)
-                    self.logger.debug(
-                        f"Constant difference found at {frequency:.3g} Hz "
-                        f"(attempt {attempt}/{self.MAX_ATTEMPTS_PER_FREQUENCY})"
-                    )
-                    mean_tuples.append(iter_mean_tuple)
-                    break
-        if len(mean_tuples) == 0:
+            movement_ends = gen_val == 0
+
+        mean_list: list[float] = []
+        for mon_data in monitoring_samples:
+            iter_mean = self.__check_signals_difference_is_constant(
+                mon_data[0], mon_data[1], tolerance_norm
+            )
+            if iter_mean is None:
+                continue
+            mean_list.append(iter_mean)
+        if len(mean_list) == 0:
             raise TestError(
-                f"Could not find a constant signal difference after trying all "
-                f"frequencies: {self.spin_frequency}"
+                f"Could not find a constant signal difference after"
+                f" trying frequency: {self.spin_frequency}"
             )
-        mean_tuples.sort(key=lambda x: x[1])
-        return mean_tuples[0][0]
+        return circular_mean(mean_list)
 
     @override
     def loop(self) -> DynamicForcedPhasingReport:
@@ -423,11 +424,10 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
         self.mc.motion.current_direct_ramp(
             self.phasing_max_current, self.CURRENT_RAMP_TIME_S, servo=self.servo, axis=self.axis
         )
-        self.__configure_monitoring(direction=PhasingDirection.POSITIVE)
+
         mean_difference_pos = self._collect_mean_difference(
             direction=PhasingDirection.POSITIVE, tolerance_norm=self.NORM_TOLERANCE
         )
-        self.__configure_monitoring(direction=PhasingDirection.NEGATIVE)
         mean_difference_neg = self._collect_mean_difference(
             direction=PhasingDirection.NEGATIVE, tolerance_norm=self.NORM_TOLERANCE
         )
@@ -475,6 +475,6 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
         """Generate report.
 
         Returns:
-            The current tuning results.
+            The phasing test report.
         """
         return output

--- a/ingeniamotion/wizard_tests/dynamic_forced_phasing.py
+++ b/ingeniamotion/wizard_tests/dynamic_forced_phasing.py
@@ -199,6 +199,7 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
             TestError: If the motor is not in a valid state to start the test.
             ValueError: If the max current drive or current motor peak are not floats.
         """
+        self.logger.debug("Checking input data")
         try:
             self.mc.capture._check_version(servo=self.servo)
         except NotImplementedError as e:
@@ -233,17 +234,22 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
             pair_poles=pair_poles,
         )
         self.mc.motion.set_current_direct(0, servo=self.servo, axis=self.axis)
+        self.logger.info("Target direct current set to zero", axis=self.axis)
         self.mc.motion.set_current_quadrature(0, servo=self.servo, axis=self.axis)
+        self.logger.info("Target quadrature current set to zero", axis=self.axis)
         self.mc.communication.set_register(
             COMMUTATION_ANGLE_OFFSET_REGISTER, 0, servo=self.servo, axis=self.axis
         )
+        self.logger.info("Commutation angle offset set to zero", axis=self.axis)
         self.mc.communication.set_register(
             REFERENCE_ANGLE_OFFSET_REGISTER, 0, servo=self.servo, axis=self.axis
         )
+        self.logger.info("Reference angle offset set to zero", axis=self.axis)
 
     @BaseTest.stoppable
     def __configure_monitoring(self) -> None:
         """Configure the monitoring for the test."""
+        self.logger.info("Configuring monitoring")
         self.mc.capture.disable_monitoring(servo=self.servo)
         mon_registers: list[dict[str, Union[int, str]]] = [
             {"name": COMMUTATION_ANGLE_VALUE_REGISTER, "axis": self.axis},
@@ -303,6 +309,7 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
     @override
     def setup(self) -> None:
         self.__check_initial_state()
+        self.logger.info("CONFIGURATION OF THE TEST", axis=self.axis)
         self.mc.motion.motor_disable(servo=self.servo, axis=self.axis)
         self.__set_error_event_to_warning()
         self.__configure_open_loop_movement()
@@ -388,6 +395,11 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
         self.mc.motion.internal_generator_saw_tooth_move(
             direction.value, 1, self.spin_frequency, servo=self.servo, axis=self.axis
         )
+        self.logger.info(
+            f"Rotate motor one mechanical revolution, frequency {self.spin_frequency:.3g} Hz, direction {direction.name}",
+            axis=self.axis,
+        )
+
         init_time = time.time()
         movement_ends = False
         while not movement_ends and time.time() - init_time < timeout_time:
@@ -419,8 +431,13 @@ class DynamicForcedPhasing(BaseTest[DynamicForcedPhasingReport]):
 
     @override
     def loop(self) -> DynamicForcedPhasingReport:
+        self.logger.info("Enable motor", axis=self.axis)
         self.mc.motion.motor_enable(servo=self.servo, axis=self.axis)
         self.check_stop()
+
+        self.logger.info(
+            f"Increasing direct current to {self.phasing_max_current:.4f} A", axis=self.axis
+        )
         self.mc.motion.current_direct_ramp(
             self.phasing_max_current, self.CURRENT_RAMP_TIME_S, servo=self.servo, axis=self.axis
         )

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -391,11 +391,12 @@ def test_dynamic_forced_phasing(mc, alias):
         alias,
         1,
         apply_changes=False,
-        phasing_max_current=rated_current,  # don't persist registers
+        phasing_max_current=rated_current,
     )
     assert result.result_severity == SeverityLevel.SUCCESS
     assert result.result_message == "Success"
     assert result.commutation_phasing_mode == PhasingMode.NO_PHASING
+    assert result.phasing_max_current == rated_current
     assert 0 <= result.commutation_angle <= 1
 
 

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -12,6 +12,8 @@ from ingeniamotion.enums import PhasingMode, SensorType, SeverityLevel
 from ingeniamotion.exceptions import IMRegisterNotExistError
 from ingeniamotion.wizard_tests.base_test import TestError
 from ingeniamotion.wizard_tests.dynamic_forced_phasing import (
+    COMMUTATION_ANGLE_VALUE_REGISTER,
+    REFERENCE_ANGLE_VALUE_REGISTER,
     DynamicForcedPhasing,
     circular_distance,
 )
@@ -522,3 +524,22 @@ def test_dynamic_forced_phasing_signals_with_noise(mc, alias, offset, noise_ampl
     assert mean_diff is not None
     # Compare in the circular [0, 1) domain so the wrap-around boundary is handled.
     assert circular_distance(mean_diff, offset) < noise_amplitude + 1e-6
+
+
+@pytest.mark.virtual
+def test_calculate_monitoring_max_time(mc, alias, mocker):
+    mocker.patch.object(
+        mc.configuration, "get_position_and_velocity_loop_rate", return_value=20000.0
+    )
+    mocker.patch.object(mc.capture, "monitoring_max_sample_size", return_value=8192)
+    dfp = DynamicForcedPhasing(mc, alias, 1)
+    mapped_registers = [
+        {"name": COMMUTATION_ANGLE_VALUE_REGISTER, "axis": 1},
+        {"name": REFERENCE_ANGLE_VALUE_REGISTER, "axis": 1},
+    ]
+    result = dfp._DynamicForcedPhasing__calculate_monitoring_max_time(
+        frequency_divider=20,
+        mapped_registers=mapped_registers,
+    )
+    expected = 1.024
+    assert result == pytest.approx(expected)

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -382,7 +382,7 @@ def test_dynamic_forced_phasing(mc, alias):
     """Run the test on a real drive and check it succeeds, leaving the drive in NO_PHASING.
 
     Reads the motor rated current, runs the phasing without writing registers, and verifies
-    the result is SUCCESS with a normalised commutation angle in [0, 1).
+    the result is SUCCESS with a normalized commutation angle in [0, 1).
     """
     rated_current = mc.communication.get_register(RATED_CURRENT_REGISTER, servo=alias, axis=1)
     result = mc.tests.dynamic_forced_phasing(
@@ -507,20 +507,18 @@ def test_dynamic_forced_phasing_signals_with_noise(mc, alias, offset, noise_ampl
     test = DynamicForcedPhasing(mc, alias, 1)
     num_points = 200
 
-    # signal1 is a normalised ramp; signal2 is the same ramp shifted by `offset` plus noise
+    # signal1 is a normalized ramp; signal2 is the same ramp shifted by `offset` plus noise
     signal1 = [i / num_points for i in range(num_points)]
     signal2 = [
         (s1 - offset + random.uniform(-noise_amplitude, noise_amplitude)) % 1 for s1 in signal1
     ]
 
-    tolerance = DynamicForcedPhasing.NORM_TOLERANCE
-    mean_diff, max_diff = test._DynamicForcedPhasing__check_signals_difference_is_constant(
-        signal1, signal2, tolerance
+    # Points deviate from the mean by at most the noise span (each side of it).
+    tolerance = 2 * noise_amplitude + 1e-6
+    mean_diff = test._DynamicForcedPhasing__check_signals_difference_is_constant(
+        signal1, signal2, tolerance_norm=tolerance
     )
 
     assert mean_diff is not None
-    assert max_diff is not None
     # Compare in the circular [0, 1) domain so the wrap-around boundary is handled.
     assert circular_distance(mean_diff, offset) < noise_amplitude + 1e-6
-    # Points deviate from the mean by at most the noise span (each side of it).
-    assert max_diff <= 2 * noise_amplitude + 1e-6

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -545,7 +545,6 @@ def test_calculate_monitoring_max_time(mc, alias, mocker):
         mapped_registers=mapped_registers,
     )
     # The expected max time is calculated as:
-    # max_time = (max_sample_size / map_reg_size) / frequency
     # map_reg_size = 2*4 bytes (two float registers)
     # max_sample_size = 8192 bytes
     # frequency = loop_rate / frequency_divider = 20000 Hz / 20 = 1000 Hz

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -529,6 +529,8 @@ def test_dynamic_forced_phasing_signals_with_noise(mc, alias, offset, noise_ampl
 
 @pytest.mark.virtual
 def test_calculate_monitoring_max_time(mc, alias, mocker):
+    """Check the monitoring max time calculation returns the expected value."""
+    # Mock the loop rate and max sample size to known values so the calculation is deterministic.
     mocker.patch.object(
         mc.configuration, "get_position_and_velocity_loop_rate", return_value=20000.0
     )
@@ -542,5 +544,11 @@ def test_calculate_monitoring_max_time(mc, alias, mocker):
         frequency_divider=20,
         mapped_registers=mapped_registers,
     )
+    # The expected max time is calculated as:
+    # max_time = (max_sample_size / map_reg_size) / frequency
+    # map_reg_size = 2*4 bytes (two float registers)
+    # max_sample_size = 8192 bytes
+    # frequency = loop_rate / frequency_divider = 20000 Hz / 20 = 1000 Hz
+    # max_time = (8192 bytes / 8 bytes) / 1000 Hz = 1.024 seconds
     expected = 1.024
     assert result == pytest.approx(expected)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -317,6 +317,7 @@ def test_dynamic_forced_phasing_example(
                 result_message="Success",
                 commutation_phasing_mode=PhasingMode.NO_PHASING,
                 commutation_angle=0.5,
+                phasing_max_current=1.0,
             )
 
     # Patch the MotionController.tests attribute to use the MockDriveTests class


### PR DESCRIPTION
Improve dynamic forced phasing. The dynamic forced phasing test must perform a mechanical revolution and collect data from all the electrical revolutions to calculate the mean.

### Type of change

- [x] Perform a mechanical revolution and collect data from all the electrical revolutions to calculate the mean
- [x] Add logs during the test
- [x] Use the maximum monitoring data size

### Tests
- [x] Add new unit tests if it applies.

### Documentation

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).