### PR TITLE
Ingm 794 fix test stop master while pdos are still active

### DIFF
--- a/ingeniamotion/fsoe.py
+++ b/ingeniamotion/fsoe.py
@@ -1,3 +1,4 @@
+import time
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Callable, Optional, cast
@@ -123,12 +124,23 @@ class FSoEMaster:
             stop_pdos: if ``True``, stop the PDO exchange. ``False`` by default.
 
         """
+        max_watchdog_timeout = 0.0
         for master_handler in self._handlers.values():
             if master_handler.running:
+                max_watchdog_timeout = max(max_watchdog_timeout, master_handler.watchdog_timeout)
                 master_handler.stop()
         if stop_pdos:
             for servo in self._handlers:
                 self.__mc.capture.pdo.stop_pdos(servo=servo)
+        elif max_watchdog_timeout > 0:
+            # PDOs are still active, so the safety PDU bytes keep being sent to the
+            # slave with frozen content (same command/sequence/CRC) since the master
+            # stopped updating them. The slave will not detect the master is gone
+            # until its own watchdog expires. Wait for it here so that a new FSoE
+            # master session started right after this call does not race against a
+            # slave that still believes the previous session is alive, which would
+            # surface as spurious CRC/connection-id errors (e.g. DATA_FAIL1).
+            time.sleep(max_watchdog_timeout)
 
     def sto_deactivate(self, servo: str = DEFAULT_SERVO) -> None:
         """Deactivate the Safety Torque Off.

--- a/ingeniamotion/fsoe_master/fsoe.py
+++ b/ingeniamotion/fsoe_master/fsoe.py
@@ -11,6 +11,7 @@ __all__ = [
     "FSoEDictionaryMappedItem",
     "BaseMasterHandler",
     "StateData",
+    "StateReset",
     "State",
     "calculate_sra_crc",
     "align_bits",
@@ -47,7 +48,7 @@ try:
     from fsoe_master.fsoe_master import (
         MasterHandler as BaseMasterHandler,
     )
-    from fsoe_master.fsoe_master import State, StateData, align_bits, calculate_sra_crc
+    from fsoe_master.fsoe_master import State, StateData, StateReset, align_bits, calculate_sra_crc
 
 
 except ImportError:

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -101,6 +101,7 @@ class FSoEMasterHandler:
         self.__uses_sra: bool = use_sra
         self.__is_subscribed_to_process_data_events: bool = False
         self.__watchdog_timeout = watchdog_timeout
+        self.__last_slave_reply: Optional[bytes] = None
 
         self.net.pdo_manager.subscribe_to_exceptions(self._pdo_thread_exception_handler)
 
@@ -249,6 +250,11 @@ class FSoEMasterHandler:
         self.logger.error(
             f"An exception occurred during the PDO exchange: {exc}. FSoE Master will be stopped."
         )
+        if self.__last_slave_reply is not None:
+            self.logger.warning(
+                "REPLY_TRACE last_reply=%s",
+                self.__last_slave_reply.hex(),
+            )
         if self.running:
             self.stop()
 
@@ -465,6 +471,8 @@ class FSoEMasterHandler:
         It is extracted from the Safety Slave PDU PDOMap and set to the FSoE master handler.
         """
         reply = self.safety_slave_pdu_map.get_item_bytes()
+        self.__last_slave_reply = reply
+        self.logger.info("REPLY_TRACE reply=%s", reply.hex())
         # Do not act on late replies when stopping or not running
         if self.__stopping or not self.__running:
             return

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -102,6 +102,7 @@ class FSoEMasterHandler:
         self.net.pdo_manager.subscribe_to_exceptions(self._pdo_thread_exception_handler)
 
         self.__state_is_data = threading.Event()
+        self.__stopping = False
 
         # The saco slave might take a while to answer with a valid command
         # During it's initialization it will respond with 0's, that are ignored
@@ -341,6 +342,7 @@ class FSoEMasterHandler:
 
     def stop(self) -> None:
         """Stop the master handler."""
+        self.__stopping = True
         self._master_handler.stop()
         self.__in_initial_reset = False
         self.__running = False
@@ -348,6 +350,7 @@ class FSoEMasterHandler:
         self.safety_master_pdu_map.unsubscribe_to_process_data_event()
         self.safety_slave_pdu_map.unsubscribe_to_process_data_event()
         self.__is_subscribed_to_process_data_events = False
+        self.__stopping = False
 
     def delete(self) -> None:
         """Delete the master handler."""
@@ -435,6 +438,12 @@ class FSoEMasterHandler:
         It is extracted from the Safety Slave PDU PDOMap and set to the FSoE master handler.
         """
         reply = self.safety_slave_pdu_map.get_item_bytes()
+        if self.__stopping or not self.__running:
+            self.logger.warning(
+                f"Late FSoE reply received during shutdown: running={self.__running} "
+                f"stopping={self.__stopping} initial_reset={self.__in_initial_reset} "
+                f"command=0x{reply[0]:02x} reply={reply.hex()}"
+            )
         if self.__in_initial_reset:
             if reply[0] == 0:
                 # Byte 0 of FSoE frame should always be the command
@@ -443,7 +452,19 @@ class FSoEMasterHandler:
             else:
                 self.__in_initial_reset = False
 
-        self._master_handler.set_reply(reply)
+        try:
+            self._master_handler.set_reply(reply)
+        except Exception:
+            self.logger.exception(
+                "FSoE reply processing failed: running=%s stopping=%s initial_reset=%s "
+                "command=0x%02x reply=%s",
+                self.__running,
+                self.__stopping,
+                self.__in_initial_reset,
+                reply[0],
+                reply.hex(),
+            )
+            raise
 
     def get_mismatched_parameters(
         self,

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -228,6 +228,17 @@ class FSoEMasterHandler:
             transition_name: The name of the FSoE state transition that failed.
             error: A description of the error.
         """
+        if self.__stopping or not self.__running:
+            # The upstream watchdog callback may race with stop(): while the
+            # handler is intentionally being stopped, it can still report the
+            # state it was in just before the reset (for example DATA_WD). That
+            # is teardown noise, not a user-visible FSoE failure.
+            self.logger.debug(
+                "Suppressed FSoE error while stopping: %s: %s",
+                transition_name,
+                error,
+            )
+            return
         if self.__in_initial_reset:
             self.logger.debug(
                 "Suppressed FSoE error during initial connection: %s: %s",

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -101,7 +101,6 @@ class FSoEMasterHandler:
         self.__uses_sra: bool = use_sra
         self.__is_subscribed_to_process_data_events: bool = False
         self.__watchdog_timeout = watchdog_timeout
-        self.__last_slave_reply: Optional[bytes] = None
 
         self.net.pdo_manager.subscribe_to_exceptions(self._pdo_thread_exception_handler)
 
@@ -250,11 +249,6 @@ class FSoEMasterHandler:
         self.logger.error(
             f"An exception occurred during the PDO exchange: {exc}. FSoE Master will be stopped."
         )
-        if self.__last_slave_reply is not None:
-            self.logger.warning(
-                "REPLY_TRACE last_reply=%s",
-                self.__last_slave_reply.hex(),
-            )
         if self.running:
             self.stop()
 
@@ -471,8 +465,6 @@ class FSoEMasterHandler:
         It is extracted from the Safety Slave PDU PDOMap and set to the FSoE master handler.
         """
         reply = self.safety_slave_pdu_map.get_item_bytes()
-        self.__last_slave_reply = reply
-        self.logger.info("REPLY_TRACE reply=%s", reply.hex())
         # Do not act on late replies when stopping or not running
         if self.__stopping or not self.__running:
             return

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -29,6 +29,7 @@ from ingeniamotion.fsoe_master.fsoe import (
     FSoEDictionaryItemOutput,
     State,
     StateData,
+    StateReset,
     calculate_sra_crc,
 )
 from ingeniamotion.fsoe_master.parameters import (
@@ -93,6 +94,7 @@ class FSoEMasterHandler:
         self.logger = ingenialogger.get_logger(__name__)
 
         self.__state_change_callback = state_change_callback
+        self.__user_report_error_callback = report_error_callback
         self.__servo = servo
         self.__net = net
         self.__running: bool = False
@@ -184,7 +186,7 @@ class FSoEMasterHandler:
             connection_id=connection_id,
             watchdog_timeout_s=watchdog_timeout,
             application_parameters=fsoe_application_parameters,
-            report_error_callback=report_error_callback,
+            report_error_callback=self.__report_error_callback,
             state_change_callback=self.__internal_state_change_callback,
             dictionary_map_is_editable=map_editable,
         )
@@ -210,6 +212,30 @@ class FSoEMasterHandler:
         self.safety_master_pdu_map.subscribe_to_process_data_event(self.get_request)
         self.safety_slave_pdu_map.subscribe_to_process_data_event(self.set_reply)
         self.__is_subscribed_to_process_data_events = True
+
+    def __report_error_callback(self, transition_name: str, error: str) -> None:
+        """Forward FSoE errors to the user callback.
+
+        While the master is still completing its initial handshake with the
+        slave (``__in_initial_reset``), the slave may still be echoing stale
+        data from a previous session (e.g. a frozen safety PDU) or replying
+        with all-zero data before it is ready. This can trigger expected,
+        transient errors (e.g. ``RESET_STAY1``) that resolve on their own once
+        the slave catches up. These are suppressed here instead of being
+        forwarded, to avoid reporting spurious errors during startup.
+
+        Args:
+            transition_name: The name of the FSoE state transition that failed.
+            error: A description of the error.
+        """
+        if self.__in_initial_reset:
+            self.logger.debug(
+                "Suppressed FSoE error during initial connection: %s: %s",
+                transition_name,
+                error,
+            )
+            return
+        self.__user_report_error_callback(transition_name, error)
 
     def _pdo_thread_exception_handler(self, exc: Exception) -> None:
         """Callback method for the PDO thread exceptions.
@@ -442,13 +468,6 @@ class FSoEMasterHandler:
         # Do not act on late replies when stopping or not running
         if self.__stopping or not self.__running:
             return
-        if self.__in_initial_reset:
-            if reply[0] == 0:
-                # Byte 0 of FSoE frame should always be the command
-                # 0 is not a valid command
-                return
-            else:
-                self.__in_initial_reset = False
 
         self._master_handler.set_reply(reply)
 
@@ -734,6 +753,13 @@ class FSoEMasterHandler:
         return sto_command
 
     def __internal_state_change_callback(self, state: "State") -> None:
+        if self.__in_initial_reset and state != StateReset:
+            # The master has moved past the initial handshake with the slave.
+            # Errors reported from now on are no longer expected transients
+            # (e.g. stale frozen frames from a previous session) and should
+            # be forwarded normally.
+            self.__in_initial_reset = False
+
         if state == StateData:
             self.__state_is_data.set()
         else:

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -98,6 +98,7 @@ class FSoEMasterHandler:
         self.__running: bool = False
         self.__uses_sra: bool = use_sra
         self.__is_subscribed_to_process_data_events: bool = False
+        self.__watchdog_timeout = watchdog_timeout
 
         self.net.pdo_manager.subscribe_to_exceptions(self._pdo_thread_exception_handler)
 
@@ -438,12 +439,9 @@ class FSoEMasterHandler:
         It is extracted from the Safety Slave PDU PDOMap and set to the FSoE master handler.
         """
         reply = self.safety_slave_pdu_map.get_item_bytes()
+        # Do not act on late replies when stopping or not running
         if self.__stopping or not self.__running:
-            self.logger.warning(
-                f"Late FSoE reply received during shutdown: running={self.__running} "
-                f"stopping={self.__stopping} initial_reset={self.__in_initial_reset} "
-                f"command=0x{reply[0]:02x} reply={reply.hex()}"
-            )
+            return
         if self.__in_initial_reset:
             if reply[0] == 0:
                 # Byte 0 of FSoE frame should always be the command
@@ -452,19 +450,7 @@ class FSoEMasterHandler:
             else:
                 self.__in_initial_reset = False
 
-        try:
-            self._master_handler.set_reply(reply)
-        except Exception:
-            self.logger.exception(
-                "FSoE reply processing failed: running=%s stopping=%s initial_reset=%s "
-                "command=0x%02x reply=%s",
-                self.__running,
-                self.__stopping,
-                self.__in_initial_reset,
-                reply[0],
-                reply.hex(),
-            )
-            raise
+        self._master_handler.set_reply(reply)
 
     def get_mismatched_parameters(
         self,
@@ -912,3 +898,8 @@ class FSoEMasterHandler:
     def running(self) -> bool:
         """True if FSoE Master is started, else False."""
         return self.__running
+
+    @property
+    def watchdog_timeout(self) -> float:
+        """The FSoE master watchdog timeout in seconds."""
+        return self.__watchdog_timeout

--- a/tests/fsoe/conftest.py
+++ b/tests/fsoe/conftest.py
@@ -201,6 +201,8 @@ def mc_with_fsoe_factory(
 
     yield factory
 
+    mc.communication.unsubscribe_emergency_message(emergency_handler)
+
     # Stop the master, PDOs are stopped on mc teardown
     mc.fsoe.stop_master(stop_pdos=False)
     mc.fsoe._delete_master_handler()

--- a/tests/fsoe/conftest.py
+++ b/tests/fsoe/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import random
 from collections import OrderedDict
 from collections.abc import Iterator
@@ -26,6 +27,8 @@ from ingeniamotion.errors import (
 from ingeniamotion.exceptions import IMErrorQueueNotExistsError
 from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED, FSoEError
 from tests.dictionaries import SAMPLE_SAFE_PH2_XDFV3_DICTIONARY
+
+logger = logging.getLogger(__name__)
 
 if FSOE_MASTER_INSTALLED:
     from ingeniamotion.fsoe_master import (
@@ -118,6 +121,10 @@ def fsoe_error_monitor(
     def error_handler(error: FSoEError) -> None:
         # WARNING: This callback runs in the PDO thread. Avoid heavy processing
         # (e.g. SDO reads) to prevent SM watchdog trips.
+        logger.error(
+            "Captured FSoE error during test: %s",
+            FSoEErrorDisplay(error, fsoe_states.copy()).display,
+        )
         errors.append(
             FSoEErrorDisplay(
                 error=error,

--- a/tests/fsoe/conftest.py
+++ b/tests/fsoe/conftest.py
@@ -1,4 +1,3 @@
-import logging
 import random
 from collections import OrderedDict
 from collections.abc import Iterator
@@ -27,8 +26,6 @@ from ingeniamotion.errors import (
 from ingeniamotion.exceptions import IMErrorQueueNotExistsError
 from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED, FSoEError
 from tests.dictionaries import SAMPLE_SAFE_PH2_XDFV3_DICTIONARY
-
-logger = logging.getLogger(__name__)
 
 if FSOE_MASTER_INSTALLED:
     from ingeniamotion.fsoe_master import (
@@ -121,10 +118,6 @@ def fsoe_error_monitor(
     def error_handler(error: FSoEError) -> None:
         # WARNING: This callback runs in the PDO thread. Avoid heavy processing
         # (e.g. SDO reads) to prevent SM watchdog trips.
-        logger.error(
-            "Captured FSoE error during test: %s",
-            FSoEErrorDisplay(error, fsoe_states.copy()).display,
-        )
         errors.append(
             FSoEErrorDisplay(
                 error=error,

--- a/tests/fsoe/test_safety_pdos.py
+++ b/tests/fsoe/test_safety_pdos.py
@@ -95,7 +95,6 @@ def test_start_pdos_without_starting_safety_master(
 
 
 @pytest.mark.fsoe
-@pytest.mark.repeat(100)
 def test_stop_master_while_pdos_are_still_active(
     mc_with_fsoe_with_sra: tuple["MotionController", "FSoEMasterHandler"],
     timeout_for_data_sra: float,

--- a/tests/fsoe/test_safety_pdos.py
+++ b/tests/fsoe/test_safety_pdos.py
@@ -95,7 +95,6 @@ def test_start_pdos_without_starting_safety_master(
 
 
 @pytest.mark.fsoe
-@pytest.mark.repeat(300)
 def test_stop_master_while_pdos_are_still_active(
     mc_with_fsoe_with_sra: tuple["MotionController", "FSoEMasterHandler"],
     timeout_for_data_sra: float,

--- a/tests/fsoe/test_safety_pdos.py
+++ b/tests/fsoe/test_safety_pdos.py
@@ -95,6 +95,7 @@ def test_start_pdos_without_starting_safety_master(
 
 
 @pytest.mark.fsoe
+@pytest.mark.repeat(100)
 def test_stop_master_while_pdos_are_still_active(
     mc_with_fsoe_with_sra: tuple["MotionController", "FSoEMasterHandler"],
     timeout_for_data_sra: float,

--- a/tests/fsoe/test_safety_pdos.py
+++ b/tests/fsoe/test_safety_pdos.py
@@ -95,6 +95,7 @@ def test_start_pdos_without_starting_safety_master(
 
 
 @pytest.mark.fsoe
+@pytest.mark.repeat(300)
 def test_stop_master_while_pdos_are_still_active(
     mc_with_fsoe_with_sra: tuple["MotionController", "FSoEMasterHandler"],
     timeout_for_data_sra: float,


### PR DESCRIPTION
# Description

Fix FSoE master teardown issues. The analysis was done for `test_stop_master_while_pdos_are_still_active`, but it will probably fix other failing tests too.

While debugging it, several issues were found:

* `FSoEMasterHandler.set_reply()` was receiving data while the master was shutting down (check commit https://github.com/ingeniamc/ingeniamotion/pull/617/changes/c74e2927c64fdd1445e5b07db2ff97114c998d35 for logs).
`test_stop_master_while_pdos_are_still_active` calls `stop_master(stop_pdos=False)`. This unsubscribes `get_request`, but PDOs keep cycling, so the RPDO safety bytes going out to the slave are now frozen at their last value (same command, same sequence number, same CRC, forever).
<img width="1380" height="623" alt="image" src="https://github.com/user-attachments/assets/08243a7d-d167-49c4-a021-0a75db7b320c" />


* `DATA_FAIL1` appeared in the teardown. Per FSoE, the slave detects the master isn't advancing and should trip its own watchdog (default 1 s) and fall back to Reset. But the test only waits `2 * refresh_rate` (tens of ms) before the fixture tears down, and the fixture teardown in `conftest.py` calls `stop_master()` with no additional wait either.

  The next repeat immediately creates a new `FSoEMasterHandler` and starts a new session. If the slave's watchdog for the previous session hasn't expired yet, it's still effectively "connected" to the old session (old connection id/sequence/CRC reference), so it rejects/mismatches the new master's frames — that shows up as `DATA_FAIL1` (or `DATA_FAIL2`) until the slave's watchdog finally trips and it resets, at which point the new session succeeds.
<img width="1083" height="112" alt="image" src="https://github.com/user-attachments/assets/3e8e7ae8-5d17-45e4-a502-fba87e1296f7" />


* Errors triggered during initial reset: `RESET_STAY1 / Invalid slave frame command`. That's actually a normal, expected part of the handshake; a new master sends its Reset command, but the slave's very first reply can still be one stale/leftover frame (e.g. all-zero) before it locks onto the new session. Check existing code comment: https://github.com/ingeniamc/ingeniamotion/blob/77a9fcad98f946e47bba23e7163d9e6cfbca019d/ingeniamotion/fsoe_master/handler.py#L107.

  The low-level state machine handles this gracefully (it just stays in `StateReset` and retries), but it still calls `report_error_callback` for that transition, and that callback was wired directly to the test's `fsoe_error_monitor`], bypassing the handler's own `__in_initial_reset` suppression logic.

```
E           Failed: FSoE errors occurred:
E           FSoEError(servo='default', transition_name='RESET_STAY1', description='Invalid slave frame command')
E             FSoE States: [<FSoEState.SESSION: 1>, <FSoEState.CONNECTION: 2>, <FSoEState.PARAMETER: 3>, <FSoEState.DATA: 4>, <FSoEState.RESET: 0>]
```


# Fixes
* Added an early return in `FSoEMasterHandler.set_reply()` to stop the current master from acting on frames arriving after `FSoEMasterHandler.stop()` 
*  `FSoEMasterHandler` now stores `watchdog_timeout` and exposes it via a public `watchdog_timeout` property.
* `FSoEMaster.stop_master()` now waits for the max watchdog timeout across the handlers being stopped, but only when `stop_pdos=False` (PDOs are left running). This gives the physical slave time to detect the master is gone and reset itself before a new master session is created, instead of racing a stale slave session and producing the `DATA_FAIL1` / Invalid slave CRC.
* The raw `report_error_callback` is no longer passed straight to `BaseMasterHandler`; it's wrapped in `__report_error_callback`, which suppresses any error reported while `__in_initial_reset` is still True or while the master is not running. The flag is now cleared in `__internal_state_change_callback` once the master's state actually leaves `StateReset` for the first time — a real signal that the handshake succeeded — rather than being cleared speculatively based on the first non-zero reply byte in `set_reply()` (which cleared too early and let `RESET_STAY1` through unsuppressed).

# Tests
* Tested with a lot of local runs + [300 runs pipeline](http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingeniamotion/view/change-requests/job/PR-617/10/stages/?selected-node=577).
<img width="802" height="54" alt="image" src="https://github.com/user-attachments/assets/d0b4c457-c7bc-44dd-b4c1-bd55f2792b34" />

