### PR TITLE
Ingm 788 fix startup with stale commands

### DIFF
--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -223,7 +223,7 @@ class FSoEMasterHandler:
         While the master is still completing its initial handshake with the
         slave (``__in_initial_reset``), the slave may still be echoing stale
         data from a previous session (e.g. a frozen safety PDU) or replying
-        with all-zero or stale data before it is ready. This can trigger expected,
+        with all-zero data before it is ready. This can trigger expected,
         transient errors (e.g. ``RESET_STAY1``) that resolve on their own once
         the slave catches up. These are suppressed here instead of being
         forwarded, to avoid reporting spurious errors during startup.

--- a/ingeniamotion/fsoe_master/handler.py
+++ b/ingeniamotion/fsoe_master/handler.py
@@ -29,7 +29,6 @@ from ingeniamotion.fsoe_master.fsoe import (
     FSoEDictionaryItemOutput,
     State,
     StateData,
-    StateReset,
     calculate_sra_crc,
 )
 from ingeniamotion.fsoe_master.parameters import (
@@ -107,9 +106,14 @@ class FSoEMasterHandler:
         self.__state_is_data = threading.Event()
         self.__stopping = False
 
-        # The saco slave might take a while to answer with a valid command
-        # During it's initialization it will respond with 0's, that are ignored
-        # To avoid triggering additional errors
+        # Baseline slave reply established since start(), or None if none has
+        # been seen yet. A reply that matches it isn't a new answer - whether
+        # that's a frame left over from a previous session or the slave still
+        # booting (e.g. answering with 0's before it's ready). It's still fed
+        # to the master handler as normal; __in_initial_reset reflects, per
+        # reply, whether it matched this baseline - see set_reply() and
+        # __report_error_callback().
+        self.__last_slave_message: Optional[bytes] = None
         self.__in_initial_reset = False
 
         # Parameters that are part of the system
@@ -219,7 +223,7 @@ class FSoEMasterHandler:
         While the master is still completing its initial handshake with the
         slave (``__in_initial_reset``), the slave may still be echoing stale
         data from a previous session (e.g. a frozen safety PDU) or replying
-        with all-zero data before it is ready. This can trigger expected,
+        with all-zero or stale data before it is ready. This can trigger expected,
         transient errors (e.g. ``RESET_STAY1``) that resolve on their own once
         the slave catches up. These are suppressed here instead of being
         forwarded, to avoid reporting spurious errors during startup.
@@ -370,7 +374,7 @@ class FSoEMasterHandler:
         """
         if self.running:
             raise RuntimeError("FSoE Master is already running.")
-        self.__in_initial_reset = True
+        self.__last_slave_message = None
         # Recalculate the SRA crc in case it changed
         if self._sra_fsoe_application_parameter is not None:
             self._sra_fsoe_application_parameter.set(self.get_application_parameters_sra_crc())
@@ -382,7 +386,6 @@ class FSoEMasterHandler:
         """Stop the master handler."""
         self.__stopping = True
         self._master_handler.stop()
-        self.__in_initial_reset = False
         self.__running = False
 
         self.safety_master_pdu_map.unsubscribe_to_process_data_event()
@@ -479,6 +482,15 @@ class FSoEMasterHandler:
         # Do not act on late replies when stopping or not running
         if self.__stopping or not self.__running:
             return
+
+        # First reply since start() can't yet correspond to anything this
+        # session asked for, and there's nothing prior to compare it to
+        # either - treat it the same as a genuine repeat.
+        self.__in_initial_reset = (
+            self.__last_slave_message is None or reply == self.__last_slave_message
+        )
+        if self.__last_slave_message is None:
+            self.__last_slave_message = reply
 
         self._master_handler.set_reply(reply)
 
@@ -764,13 +776,6 @@ class FSoEMasterHandler:
         return sto_command
 
     def __internal_state_change_callback(self, state: "State") -> None:
-        if self.__in_initial_reset and state != StateReset:
-            # The master has moved past the initial handshake with the slave.
-            # Errors reported from now on are no longer expected transients
-            # (e.g. stale frozen frames from a previous session) and should
-            # be forwarded normally.
-            self.__in_initial_reset = False
-
         if state == StateData:
             self.__state_is_data.set()
         else:

--- a/tests/fsoe/test_fsoe.py
+++ b/tests/fsoe/test_fsoe.py
@@ -234,8 +234,6 @@ def test_start_master_if_master_already_running(
 
 
 @pytest.mark.fsoe
-# https://novantamotion.atlassian.net/browse/INGM-788
-@pytest.mark.not_valid_for_product(part_number="DEN-S-NET-E")
 def test_start_stop_master(
     mc_with_fsoe_with_sra: tuple["MotionController", "FSoEMasterHandler"],
     fsoe_states: list["FSoEState"],

--- a/tests/fsoe/test_handler.py
+++ b/tests/fsoe/test_handler.py
@@ -297,8 +297,9 @@ class FSoESlave:
     slave doesn't contain a master, it only exchanges bytes with one over the
     wire - see ``FSoENetwork`` below, the only object that needs a reference
     to both sides. Because it outlives any one master connection (it's never
-    power-cycled), it can hold onto a stale reply from a previous session for
-    a test to feed to a later one.
+    power-cycled), it can hold onto a stale reply from a previous session and
+    deliver it as the response to the first non-Reset request after a Reset,
+    exactly what a PDO thread would briefly deliver right after a restart.
 
     The reply formula:
       - The safe data is an exact echo of the request's safe data.
@@ -324,16 +325,27 @@ class FSoESlave:
     None of ``sequence_number``/``crc0`` is transmitted on the wire - each
     side tracks them independently - so ``FSOEFrame.generate_crcs()`` only
     produces a CRC the real master will accept when fed the values above.
+
+    On a Reset request, the slave captures its own last Session-state reply
+    as a stale reply, to be returned automatically on the first non-Reset
+    request of the new session. Once that stale reply has been delivered, the
+    previous session's memory is forgotten so the next fresh startup (e.g.
+    a different master handler connecting to the same physical slave) does
+    not re-deliver it.
     """
 
     def __init__(self) -> None:
         self._replies_ever = 0
         self._replies_this_session = 0
         self._session_reply: Optional[bytes] = None
-        self.stale_reply_from_previous_session: Optional[bytes] = None
+        self._stale_reply: Optional[bytes] = None
 
     def compute_reply(self, request_bytes: bytes) -> bytes:
         """Compute the reply for one request.
+
+        On the first non-Reset request after a Reset, returns the stale reply
+        from the previous session (if any) instead of computing a fresh one.
+        All other requests are answered with a freshly computed reply.
 
         Args:
             request_bytes: The master's current request, as raw bytes.
@@ -351,10 +363,19 @@ class FSoESlave:
             # it transmitted - exactly what a PDO thread would briefly
             # deliver right after a restart, since the device is never
             # power-cycled between sessions.
-            self.stale_reply_from_previous_session = self._session_reply
+            self._stale_reply = self._session_reply
             self._replies_this_session = 0
             sequence_number = self._replies_ever
             connection_id = 0
+        elif self._stale_reply is not None and command != FSOECommand.RESET:
+            # First non-Reset request after a Reset: deliver the stale reply
+            # from the previous session, then forget that previous session
+            # entirely so the next fresh startup does not re-deliver it.
+            stale_reply = self._stale_reply
+            self._stale_reply = None
+            self._session_reply = None
+            self._replies_ever += 1
+            return stale_reply
         elif command == FSOECommand.SESSION:
             sequence_number = self._replies_this_session
             connection_id = 0
@@ -396,25 +417,6 @@ class FSoENetwork:
     def replace_master(self, handler: "FSoEMasterHandler") -> None:
         """Connect a different master handler to the same slave."""
         self.master = handler
-
-    def deliver(self, reply_bytes: bytes) -> None:
-        """Deliver these exact reply bytes to the master, without computing a
-        fresh one - e.g. to replay a stale reply still sitting on the slave.
-        """
-        self.master.safety_slave_pdu_map.set_item_bytes(reply_bytes)
-        self.master.set_reply()
-
-    def replay_stale_reply_from_previous_session(self) -> bytes:
-        """Feed the slave's own leftover reply from a previous session to the
-        master, exactly as a PDO thread would right after a restart, since
-        the slave is never power-cycled between sessions.
-
-        Returns:
-            The stale reply bytes delivered.
-        """
-        stale_reply = self.slave.stale_reply_from_previous_session
-        self.deliver(stale_reply)
-        return stale_reply
 
     def exchange_one_round(self) -> bytes:
         """Exchange one request/reply round.
@@ -486,7 +488,6 @@ def test_startup_replay_filter_is_not_shared_between_handler_instances() -> None
         report_error_callback=lambda name, err: errors_a.append((name, err)),
     )
     network = FSoENetwork(handler_a, FSoESlave())
-    stale_reply: bytes
     try:
         # handler_a completes one full, real startup, is stopped, and
         # restarted - genuinely progressing past its own Reset state for
@@ -502,26 +503,32 @@ def test_startup_replay_filter_is_not_shared_between_handler_instances() -> None
         handler_a.stop()
 
         handler_a.start()
-        network.exchange_one_round()
+        network.exchange_one_round()  # Reset -> fresh Reset reply, state -> SESSION
         assert handler_a.state == FSoEState.SESSION
 
         # The slave is never power-cycled: it still has its own Session-state
         # reply from the session that just ended as its last output, exactly
         # what a real device would still be transmitting right after a
-        # restart. handler_a recognizes it as its own previously-seen reply
-        # and suppresses it: no user-visible error is reported, and its
-        # state is undisturbed.
-        stale_reply = network.replay_stale_reply_from_previous_session()
+        # restart. The slave auto-delivers its previous Session reply on the
+        # next round; handler_a recognizes it as its own previously-seen reply
+        # and suppresses it: no user-visible error is reported, and its state
+        # is undisturbed.
+        network.exchange_one_round()  # Session -> stale reply auto-delivered
         assert errors_a == []
         assert handler_a.state == FSoEState.SESSION
+
+        # Complete the new session so the slave has a current Session reply
+        # ready to replay when the next master connects.
+        network.exchange_to_data()
+        assert handler_a.state == FSoEState.DATA
+        handler_a.stop()
     finally:
         handler_a.stop()
         handler_a.delete()
 
     # handler_a has fully disconnected from the slave. A second, independent
     # master instance now takes over the SAME slave (never power-cycled),
-    # which still has handler_a's own last reply (captured above, before
-    # handler_b's own session traffic updates the slave's memory) as output.
+    # which still has handler_a's current Session reply as its last output.
     errors_b: list[tuple[str, str]] = []
     handler_b = FSoEMasterHandler(
         servo=mock_servo,
@@ -532,21 +539,14 @@ def test_startup_replay_filter_is_not_shared_between_handler_instances() -> None
     try:
         network.replace_master(handler_b)
         handler_b.start()
-        network.exchange_to_data()
-        assert handler_b.state == FSoEState.DATA
-        handler_b.stop()
-
-        handler_b.start()
-        network.exchange_one_round()
+        network.exchange_one_round()  # Reset -> fresh Reset reply, state -> SESSION
         assert handler_b.state == FSoEState.SESSION
 
-        # handler_b has never seen handler_a's stale reply - it's traffic
-        # from a different handler instance - so its own filter doesn't
-        # catch it: it reaches the real master, which (correctly) rejects it
-        # as invalid for this session, and that rejection IS reported to the
-        # user. This is the actual gap this mechanism doesn't close:
-        # cross-instance replay.
-        network.deliver(stale_reply)
+        # The slave automatically replays handler_a's Session reply. handler_b
+        # has never seen it, so its own filter does not catch it: it reaches
+        # the real master, which correctly rejects it as invalid for this
+        # session, and that rejection is reported to the user.
+        network.exchange_one_round()  # Session -> handler_a's reply replayed
         assert errors_b == [("SESSION_STAY2", "Invalid slave CRC")]
     finally:
         handler_b.delete()

--- a/tests/fsoe/test_handler.py
+++ b/tests/fsoe/test_handler.py
@@ -1,9 +1,8 @@
 import logging
-import os
 import random
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional, TextIO
+from typing import TYPE_CHECKING, Callable
 
 import pytest
 from ingenialink.dictionary import DictionarySafetyModule
@@ -14,6 +13,7 @@ from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED, FSoEError, FSoEMaster
 from tests.conftest import refresh_registers_for_test_rollback
 from tests.dictionaries import SAMPLE_SAFE_PH1_XDFV3_DICTIONARY, SAMPLE_SAFE_PH2_XDFV3_DICTIONARY
 from tests.fsoe.conftest import MockNetwork, MockServo
+from tests.fsoe.utils.fsoe_emulation import FSoENetwork, FSoESlave
 
 if FSOE_MASTER_INSTALLED:
     from ingeniamotion.fsoe_master.fsoe import FSoEApplicationParameter
@@ -22,6 +22,7 @@ if FSOE_MASTER_INSTALLED:
 if TYPE_CHECKING:
     from ingenialink.ethercat.servo import EthercatServo
     from pytest_mock import MockerFixture
+    from summit_testing_framework.pytest_helpers.pytest_output_handler import PytestOutputHandler
 
     from ingeniamotion.motion_controller import MotionController
 
@@ -286,244 +287,6 @@ def test_handler_is_stopped_if_error_in_pdo_thread(
     assert fsoe_states[-1] == FSoEState.RESET
 
 
-if FSOE_MASTER_INSTALLED:
-    from fsoe_master.fsoe_master import FSOECommand, FSOEFrame
-
-
-class FSoESlave:
-    """Represents a physical FSoE slave device, computing genuine replies via
-    the ``fsoe_master`` library for framing/CRC generation - so the replies
-    are real protocol traffic, not fabricated constants.
-
-    Deliberately holds no reference to any ``FSoEMasterHandler``: a real FSoE
-    slave doesn't contain a master, it only exchanges bytes with one over the
-    wire - see ``FSoENetwork`` below, the only object that needs a reference
-    to both sides. Because it outlives any one master connection (it's never
-    power-cycled), it can hold onto a stale reply from a previous session and
-    deliver it as the response to the first non-Reset request after a Reset,
-    exactly what a PDO thread would briefly deliver right after a restart.
-
-    The reply formula:
-      - The safe data is an exact echo of the request's safe data.
-      - The command matches the request's command.
-      - ``crc0`` is the crc0 of the request being answered.
-      - The frame header's connection_id is 0 during Reset/Session (before a
-        session is established); from Connection state onward, the master's
-        own request already carries the now-established connection_id in its
-        header, so it's read directly off each request rather than tracked
-        separately - no need to peek at the master's internal session object.
-      - ``sequence_number`` is the number of replies already sent *in the
-        current session* (0-indexed, reset every time a new Reset request
-        starts a fresh session): confirmed via gdb that the compiled master
-        checks it against replies accepted since the current session began,
-        not a lifetime total. Reset itself doesn't validate
-        sequence_number/crc0 at all (any command-matching frame is accepted)
-        - but it does reject an exact byte-for-byte repeat of a
-        previously-accepted frame, so a separate, never-resetting counter is
-        used just for Reset's own crc/seq input, purely to keep its output
-        bytes from colliding with an earlier session's Reset reply when the
-        same handler restarts.
-
-    None of ``sequence_number``/``crc0`` is transmitted on the wire - each
-    side tracks them independently - so ``FSOEFrame.generate_crcs()`` only
-    produces a CRC the real master will accept when fed the values above.
-
-    When a new Reset request arrives, the slave first returns its previous
-    output buffer, if any, before processing the Reset. The preserved output
-    remains available for three exchange iterations, until the simulated PDO
-    buffer is replaced by fresh output.
-    """
-
-    def __init__(self) -> None:
-        self._replies_ever = 0
-        self._replies_this_session = 0
-        self._outgoing_reply: Optional[bytes] = None
-        self._held_stale_reply: Optional[bytes] = None
-        self._stale_replies_remaining = 0
-        self._last_reply_source = "fresh"
-
-    def _consume_stale_reply(self) -> Optional[bytes]:
-        """Return the preserved reply while its simulated buffer is held."""
-        if self._held_stale_reply is None or self._stale_replies_remaining == 0:
-            return None
-        stale_reply = self._held_stale_reply
-        self._stale_replies_remaining -= 1
-        if self._stale_replies_remaining == 0:
-            self._held_stale_reply = None
-        self._last_reply_source = "stale"
-        self._replies_ever += 1
-        return stale_reply
-
-    @property
-    def last_reply_source(self) -> str:
-        """Return whether the last reply was fresh or stale."""
-        return self._last_reply_source
-
-    def compute_reply(self, request_bytes: bytes) -> bytes:
-        """Compute the reply for one request.
-
-        On the first non-Reset request after a Reset, returns the stale reply
-        from the previous session (if any) instead of computing a fresh one.
-        All other requests are answered with a freshly computed reply.
-
-        Args:
-            request_bytes: The master's current request, as raw bytes.
-
-        Returns:
-            The reply bytes.
-        """
-        request = FSOEFrame.frame_from_array(request_bytes)
-        data = request.get_safe_data_bytes()[: request.safe_data_size_bytes]
-        command = request.control.command
-        self._last_reply_source = "fresh"
-
-        if command == FSOECommand.RESET and self._outgoing_reply is not None:
-            # The first PDO cycle after a restart can deliver the previous
-            # output before the slave has processed the new Reset request.
-            stale_reply = self._outgoing_reply
-            self._held_stale_reply = stale_reply
-            self._stale_replies_remaining = 3
-            self._outgoing_reply = None
-            stale_reply = self._consume_stale_reply()
-            assert stale_reply is not None
-            return stale_reply
-        stale_reply = self._consume_stale_reply() if command != FSOECommand.RESET else None
-        if stale_reply is not None:
-            return stale_reply
-        if command == FSOECommand.RESET:
-            self._replies_this_session = 0
-            sequence_number = self._replies_ever
-            connection_id = 0
-        elif command == FSOECommand.SESSION:
-            sequence_number = self._replies_this_session
-            connection_id = 0
-        else:
-            sequence_number = self._replies_this_session
-            connection_id = request.control.connection_id
-
-        reply = FSOEFrame.frame_from_array(request_bytes)
-        reply.control.command = command
-        reply.control.connection_id = connection_id
-        reply.control.sequence_number = sequence_number
-        reply.control.crc0 = int(request.crcs[0])
-        reply.set_safe_data_bytes(data)
-        reply.generate_crcs()
-        reply_bytes = reply.frame_to_array()
-
-        self._outgoing_reply = reply_bytes
-
-        self._replies_ever += 1
-        self._replies_this_session += 1
-        return reply_bytes
-
-
-class FSoENetwork:
-    """The EtherCAT medium connecting a master handler to a slave device,
-    cycling PDO data between them - the only object that needs a reference
-    to both sides.
-
-    The slave survives a master being replaced, e.g. when a different master
-    handler connects to it after a previous one disconnects - matching real
-    hardware, which is never power-cycled between them.
-    """
-
-    def __init__(
-        self,
-        handler: "FSoEMasterHandler",
-        slave: FSoESlave,
-        trace_path: Optional[Path] = None,
-    ) -> None:
-        self.master = handler
-        self.slave = slave
-        self._trace_path = trace_path
-        self._trace_file: Optional[TextIO] = None
-        self._round = 0
-        if self._trace_path is not None:
-            self._trace_file = self._trace_path.open("w", encoding="utf-8")
-            self._trace_file.write("FSoE exchange trace\n")
-            self._trace_file.flush()
-
-    def __enter__(self) -> "FSoENetwork":
-        """Return the network with its trace lifecycle managed by a context."""
-        return self
-
-    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
-        """Close the trace file when leaving the network context."""
-        self.close()
-
-    def trace(self, marker: str, message: str) -> None:
-        """Append a marked event to the exchange trace, if enabled."""
-        if self._trace_file is None:
-            return
-        self._trace_file.write(f"[{marker}] {message}\n")
-        self._trace_file.flush()
-
-    def close(self) -> None:
-        """Close the trace file, if one is open."""
-        if self._trace_file is not None:
-            self._trace_file.close()
-            self._trace_file = None
-
-    def replace_master(self, handler: "FSoEMasterHandler") -> None:
-        """Connect a different master handler to the same slave."""
-        self.master = handler
-
-    def exchange_one_round(self) -> bytes:
-        """Exchange one request/reply round.
-
-        Returns:
-            The reply bytes sent.
-        """
-        self._round += 1
-        self.trace(
-            f"ROUND {self._round:02d}",
-            f"state_before={self.master.state.name}",
-        )
-        try:
-            self.master.get_request()
-            request_bytes = self.master.safety_master_pdu_map.get_item_bytes()
-            self.trace(f"ROUND {self._round:02d}", f"request={request_bytes.hex(' ')}")
-            reply_bytes = self.slave.compute_reply(request_bytes)
-            self.trace(
-                f"ROUND {self._round:02d}",
-                f"reply_source={self.slave.last_reply_source}",
-            )
-            self.trace(f"ROUND {self._round:02d}", f"reply={reply_bytes.hex(' ')}")
-            self.master.safety_slave_pdu_map.set_item_bytes(reply_bytes)
-            self.master.set_reply()
-            self.trace(
-                f"ROUND {self._round:02d}",
-                f"state_after={self.master.state.name}",
-            )
-            return reply_bytes
-        except Exception as error:
-            self.trace(
-                f"ROUND {self._round:02d} EXCEPTION",
-                f"{type(error).__name__}: {error}",
-            )
-            raise
-
-    def exchange_to_data(self, max_rounds: int = 20) -> list[bytes]:
-        """Exchange rounds until the master's startup handshake reaches Data.
-
-        Reusable across a real ``stop()``/``start()`` restart, or a master
-        replacement: the slave's own per-session counter resets whenever it
-        sees a new Reset request, matching the real master's own behavior.
-
-        Returns:
-            The reply bytes sent, in order.
-
-        Raises:
-            RuntimeError: If Data state isn't reached within ``max_rounds``.
-        """
-        replies = []
-        for _ in range(max_rounds):
-            if self.master.state == FSoEState.DATA:
-                return replies
-            replies.append(self.exchange_one_round())
-        raise RuntimeError(f"Did not reach Data state within {max_rounds} rounds")
-
-
 @pytest.mark.fsoe
 def test_mock_slave_drives_real_handshake_to_data_state() -> None:
     errors: list[tuple[str, str]] = []
@@ -544,14 +307,23 @@ def test_mock_slave_drives_real_handshake_to_data_state() -> None:
         handler.delete()
 
 
+@pytest.fixture
+def fsoe_trace_path(test_output_handler: "PytestOutputHandler") -> Path:
+    """Location of the FSoE exchange trace inside the test output directory.
+
+    Returns:
+        Path to the exchange trace log file.
+    """
+    return test_output_handler.tests_output_dir / "fsoe_startup_sequence.log"
+
+
 @pytest.mark.fsoe
-def test_master_ignores_stale_reply_after_master_replacement() -> None:
+def test_master_ignores_stale_reply_after_master_replacement(fsoe_trace_path: Path) -> None:
     # One physical slave, one master instance connecting to it after another -
     # e.g. Motionlab switching between two FSoE master configurations against
     # the same drive - not two independent slaves.
     mock_servo = MockServo(SAMPLE_SAFE_PH1_XDFV3_DICTIONARY)
     mock_network = MockNetwork()
-    trace_path = Path(os.environ.get("FSOE_TRACE_FILE", "fsoe_startup_sequence.log"))
 
     errors_a: list[tuple[str, str]] = []
 
@@ -565,7 +337,7 @@ def test_master_ignores_stale_reply_after_master_replacement() -> None:
         use_sra=True,
         report_error_callback=report_error_a,
     )
-    network = FSoENetwork(handler_a, FSoESlave(), trace_path=trace_path)
+    network = FSoENetwork(handler_a, FSoESlave(), trace_path=fsoe_trace_path)
     network.trace("TEST", "handler_a startup")
     try:
         # handler_a completes a real startup and exchanges one live DATA

--- a/tests/fsoe/test_handler.py
+++ b/tests/fsoe/test_handler.py
@@ -1,7 +1,7 @@
 import logging
 import random
 import time
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Optional
 
 import pytest
 from ingenialink.dictionary import DictionarySafetyModule
@@ -282,6 +282,274 @@ def test_handler_is_stopped_if_error_in_pdo_thread(
     time.sleep(1.0)
     assert handler.running is False
     assert fsoe_states[-1] == FSoEState.RESET
+
+
+if FSOE_MASTER_INSTALLED:
+    from fsoe_master.fsoe_master import FSOECommand, FSOEFrame
+
+
+class FSoESlave:
+    """Represents a physical FSoE slave device, computing genuine replies via
+    the ``fsoe_master`` library for framing/CRC generation - so the replies
+    are real protocol traffic, not fabricated constants.
+
+    Deliberately holds no reference to any ``FSoEMasterHandler``: a real FSoE
+    slave doesn't contain a master, it only exchanges bytes with one over the
+    wire - see ``FSoENetwork`` below, the only object that needs a reference
+    to both sides. Because it outlives any one master connection (it's never
+    power-cycled), it can hold onto a stale reply from a previous session for
+    a test to feed to a later one.
+
+    The reply formula:
+      - The safe data is an exact echo of the request's safe data.
+      - The command matches the request's command.
+      - ``crc0`` is the crc0 of the request being answered.
+      - The frame header's connection_id is 0 during Reset/Session (before a
+        session is established); from Connection state onward, the master's
+        own request already carries the now-established connection_id in its
+        header, so it's read directly off each request rather than tracked
+        separately - no need to peek at the master's internal session object.
+      - ``sequence_number`` is the number of replies already sent *in the
+        current session* (0-indexed, reset every time a new Reset request
+        starts a fresh session): confirmed via gdb that the compiled master
+        checks it against replies accepted since the current session began,
+        not a lifetime total. Reset itself doesn't validate
+        sequence_number/crc0 at all (any command-matching frame is accepted)
+        - but it does reject an exact byte-for-byte repeat of a
+        previously-accepted frame, so a separate, never-resetting counter is
+        used just for Reset's own crc/seq input, purely to keep its output
+        bytes from colliding with an earlier session's Reset reply when the
+        same handler restarts.
+
+    None of ``sequence_number``/``crc0`` is transmitted on the wire - each
+    side tracks them independently - so ``FSOEFrame.generate_crcs()`` only
+    produces a CRC the real master will accept when fed the values above.
+    """
+
+    def __init__(self) -> None:
+        self._replies_ever = 0
+        self._replies_this_session = 0
+        self._session_reply: Optional[bytes] = None
+        self.stale_reply_from_previous_session: Optional[bytes] = None
+
+    def compute_reply(self, request_bytes: bytes) -> bytes:
+        """Compute the reply for one request.
+
+        Args:
+            request_bytes: The master's current request, as raw bytes.
+
+        Returns:
+            The reply bytes.
+        """
+        request = FSOEFrame.frame_from_array(request_bytes)
+        data = request.get_safe_data_bytes()[: request.safe_data_size_bytes]
+        command = request.control.command
+
+        if command == FSOECommand.RESET:
+            # A new session is starting: this device's own Session-state
+            # reply from whatever session just ended is still the last thing
+            # it transmitted - exactly what a PDO thread would briefly
+            # deliver right after a restart, since the device is never
+            # power-cycled between sessions.
+            self.stale_reply_from_previous_session = self._session_reply
+            self._replies_this_session = 0
+            sequence_number = self._replies_ever
+            connection_id = 0
+        elif command == FSOECommand.SESSION:
+            sequence_number = self._replies_this_session
+            connection_id = 0
+        else:
+            sequence_number = self._replies_this_session
+            connection_id = request.control.connection_id
+
+        reply = FSOEFrame.frame_from_array(request_bytes)
+        reply.control.command = command
+        reply.control.connection_id = connection_id
+        reply.control.sequence_number = sequence_number
+        reply.control.crc0 = int(request.crcs[0])
+        reply.set_safe_data_bytes(data)
+        reply.generate_crcs()
+        reply_bytes = reply.frame_to_array()
+
+        if command == FSOECommand.SESSION:
+            self._session_reply = reply_bytes
+
+        self._replies_ever += 1
+        self._replies_this_session += 1
+        return reply_bytes
+
+
+class FSoENetwork:
+    """The EtherCAT medium connecting a master handler to a slave device,
+    cycling PDO data between them - the only object that needs a reference
+    to both sides.
+
+    The slave survives a master being replaced, e.g. when a different master
+    handler connects to it after a previous one disconnects - matching real
+    hardware, which is never power-cycled between them.
+    """
+
+    def __init__(self, handler: "FSoEMasterHandler", slave: FSoESlave) -> None:
+        self.master = handler
+        self.slave = slave
+
+    def replace_master(self, handler: "FSoEMasterHandler") -> None:
+        """Connect a different master handler to the same slave."""
+        self.master = handler
+
+    def deliver(self, reply_bytes: bytes) -> None:
+        """Deliver these exact reply bytes to the master, without computing a
+        fresh one - e.g. to replay a stale reply still sitting on the slave.
+        """
+        self.master.safety_slave_pdu_map.set_item_bytes(reply_bytes)
+        self.master.set_reply()
+
+    def replay_stale_reply_from_previous_session(self) -> bytes:
+        """Feed the slave's own leftover reply from a previous session to the
+        master, exactly as a PDO thread would right after a restart, since
+        the slave is never power-cycled between sessions.
+
+        Returns:
+            The stale reply bytes delivered.
+        """
+        stale_reply = self.slave.stale_reply_from_previous_session
+        self.deliver(stale_reply)
+        return stale_reply
+
+    def exchange_one_round(self) -> bytes:
+        """Exchange one request/reply round.
+
+        Returns:
+            The reply bytes sent.
+        """
+        self.master.get_request()
+        request_bytes = self.master.safety_master_pdu_map.get_item_bytes()
+        reply_bytes = self.slave.compute_reply(request_bytes)
+        self.master.safety_slave_pdu_map.set_item_bytes(reply_bytes)
+        self.master.set_reply()
+        return reply_bytes
+
+    def exchange_to_data(self, max_rounds: int = 20) -> list[bytes]:
+        """Exchange rounds until the master's startup handshake reaches Data.
+
+        Reusable across a real ``stop()``/``start()`` restart, or a master
+        replacement: the slave's own per-session counter resets whenever it
+        sees a new Reset request, matching the real master's own behavior.
+
+        Returns:
+            The reply bytes sent, in order.
+
+        Raises:
+            RuntimeError: If Data state isn't reached within ``max_rounds``.
+        """
+        replies = []
+        for _ in range(max_rounds):
+            if self.master.state == FSoEState.DATA:
+                return replies
+            replies.append(self.exchange_one_round())
+        raise RuntimeError(f"Did not reach Data state within {max_rounds} rounds")
+
+
+@pytest.mark.fsoe
+def test_mock_slave_drives_real_handshake_to_data_state() -> None:
+    errors: list[tuple[str, str]] = []
+    mock_servo = MockServo(SAMPLE_SAFE_PH1_XDFV3_DICTIONARY)
+    handler = FSoEMasterHandler(
+        servo=mock_servo,
+        net=MockNetwork(),
+        use_sra=True,
+        report_error_callback=lambda name, err: errors.append((name, err)),
+    )
+    try:
+        handler.start()
+        FSoENetwork(handler, FSoESlave()).exchange_to_data()
+
+        assert handler.state == FSoEState.DATA
+        assert errors == []
+    finally:
+        handler.delete()
+
+
+@pytest.mark.fsoe
+def test_startup_replay_filter_is_not_shared_between_handler_instances() -> None:
+    # One physical slave, one master instance connecting to it after another -
+    # e.g. Motionlab switching between two FSoE master configurations against
+    # the same drive - not two independent slaves.
+    mock_servo = MockServo(SAMPLE_SAFE_PH1_XDFV3_DICTIONARY)
+    mock_network = MockNetwork()
+
+    errors_a: list[tuple[str, str]] = []
+    handler_a = FSoEMasterHandler(
+        servo=mock_servo,
+        net=mock_network,
+        use_sra=True,
+        report_error_callback=lambda name, err: errors_a.append((name, err)),
+    )
+    network = FSoENetwork(handler_a, FSoESlave())
+    stale_reply: bytes
+    try:
+        # handler_a completes one full, real startup, is stopped, and
+        # restarted - genuinely progressing past its own Reset state for
+        # real, matching production timing where the CURRENT session's real
+        # replies advance the handshake before any leftover PDO bytes from
+        # the PREVIOUS session show up. This is also what turns
+        # __in_initial_reset off, so a real error is no longer suppressed and
+        # becomes visible in report_error_callback - the actual, user-facing
+        # symptom from the original bug report.
+        handler_a.start()
+        network.exchange_to_data()
+        assert handler_a.state == FSoEState.DATA
+        handler_a.stop()
+
+        handler_a.start()
+        network.exchange_one_round()
+        assert handler_a.state == FSoEState.SESSION
+
+        # The slave is never power-cycled: it still has its own Session-state
+        # reply from the session that just ended as its last output, exactly
+        # what a real device would still be transmitting right after a
+        # restart. handler_a recognizes it as its own previously-seen reply
+        # and suppresses it: no user-visible error is reported, and its
+        # state is undisturbed.
+        stale_reply = network.replay_stale_reply_from_previous_session()
+        assert errors_a == []
+        assert handler_a.state == FSoEState.SESSION
+    finally:
+        handler_a.stop()
+        handler_a.delete()
+
+    # handler_a has fully disconnected from the slave. A second, independent
+    # master instance now takes over the SAME slave (never power-cycled),
+    # which still has handler_a's own last reply (captured above, before
+    # handler_b's own session traffic updates the slave's memory) as output.
+    errors_b: list[tuple[str, str]] = []
+    handler_b = FSoEMasterHandler(
+        servo=mock_servo,
+        net=mock_network,
+        use_sra=True,
+        report_error_callback=lambda name, err: errors_b.append((name, err)),
+    )
+    try:
+        network.replace_master(handler_b)
+        handler_b.start()
+        network.exchange_to_data()
+        assert handler_b.state == FSoEState.DATA
+        handler_b.stop()
+
+        handler_b.start()
+        network.exchange_one_round()
+        assert handler_b.state == FSoEState.SESSION
+
+        # handler_b has never seen handler_a's stale reply - it's traffic
+        # from a different handler instance - so its own filter doesn't
+        # catch it: it reaches the real master, which (correctly) rejects it
+        # as invalid for this session, and that rejection IS reported to the
+        # user. This is the actual gap this mechanism doesn't close:
+        # cross-instance replay.
+        network.deliver(stale_reply)
+        assert errors_b == [("SESSION_STAY2", "Invalid slave CRC")]
+    finally:
+        handler_b.delete()
 
 
 @pytest.mark.fsoe

--- a/tests/fsoe/test_handler.py
+++ b/tests/fsoe/test_handler.py
@@ -545,7 +545,7 @@ def test_mock_slave_drives_real_handshake_to_data_state() -> None:
 
 
 @pytest.mark.fsoe
-def test_stale_data_reply_survives_master_replacement() -> None:
+def test_master_ignores_stale_reply_after_master_replacement() -> None:
     # One physical slave, one master instance connecting to it after another -
     # e.g. Motionlab switching between two FSoE master configurations against
     # the same drive - not two independent slaves.

--- a/tests/fsoe/test_handler.py
+++ b/tests/fsoe/test_handler.py
@@ -337,22 +337,27 @@ class FSoESlave:
     def __init__(self) -> None:
         self._replies_ever = 0
         self._replies_this_session = 0
-        self._last_reply: Optional[bytes] = None
-        self._stale_reply: Optional[bytes] = None
+        self._outgoing_reply: Optional[bytes] = None
+        self._held_stale_reply: Optional[bytes] = None
         self._stale_replies_remaining = 0
         self._last_reply_source = "fresh"
 
     def _consume_stale_reply(self) -> Optional[bytes]:
         """Return the preserved reply while its simulated buffer is held."""
-        if self._stale_reply is None or self._stale_replies_remaining == 0:
+        if self._held_stale_reply is None or self._stale_replies_remaining == 0:
             return None
-        stale_reply = self._stale_reply
+        stale_reply = self._held_stale_reply
         self._stale_replies_remaining -= 1
         if self._stale_replies_remaining == 0:
-            self._stale_reply = None
+            self._held_stale_reply = None
         self._last_reply_source = "stale"
         self._replies_ever += 1
         return stale_reply
+
+    @property
+    def last_reply_source(self) -> str:
+        """Return whether the last reply was fresh or stale."""
+        return self._last_reply_source
 
     def compute_reply(self, request_bytes: bytes) -> bytes:
         """Compute the reply for one request.
@@ -372,13 +377,13 @@ class FSoESlave:
         command = request.control.command
         self._last_reply_source = "fresh"
 
-        if command == FSOECommand.RESET and self._last_reply is not None:
+        if command == FSOECommand.RESET and self._outgoing_reply is not None:
             # The first PDO cycle after a restart can deliver the previous
             # output before the slave has processed the new Reset request.
-            stale_reply = self._last_reply
-            self._stale_reply = stale_reply
+            stale_reply = self._outgoing_reply
+            self._held_stale_reply = stale_reply
             self._stale_replies_remaining = 3
-            self._last_reply = None
+            self._outgoing_reply = None
             stale_reply = self._consume_stale_reply()
             assert stale_reply is not None
             return stale_reply
@@ -405,7 +410,7 @@ class FSoESlave:
         reply.generate_crcs()
         reply_bytes = reply.frame_to_array()
 
-        self._last_reply = reply_bytes
+        self._outgoing_reply = reply_bytes
 
         self._replies_ever += 1
         self._replies_this_session += 1
@@ -437,6 +442,14 @@ class FSoENetwork:
             self._trace_file = self._trace_path.open("w", encoding="utf-8")
             self._trace_file.write("FSoE exchange trace\n")
             self._trace_file.flush()
+
+    def __enter__(self) -> "FSoENetwork":
+        """Return the network with its trace lifecycle managed by a context."""
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        """Close the trace file when leaving the network context."""
+        self.close()
 
     def trace(self, marker: str, message: str) -> None:
         """Append a marked event to the exchange trace, if enabled."""
@@ -473,7 +486,7 @@ class FSoENetwork:
             reply_bytes = self.slave.compute_reply(request_bytes)
             self.trace(
                 f"ROUND {self._round:02d}",
-                f"reply_source={self.slave._last_reply_source}",
+                f"reply_source={self.slave.last_reply_source}",
             )
             self.trace(f"ROUND {self._round:02d}", f"reply={reply_bytes.hex(' ')}")
             self.master.safety_slave_pdu_map.set_item_bytes(reply_bytes)
@@ -532,7 +545,7 @@ def test_mock_slave_drives_real_handshake_to_data_state() -> None:
 
 
 @pytest.mark.fsoe
-def test_startup_replay_filter_is_not_shared_between_handler_instances() -> None:
+def test_stale_data_reply_survives_master_replacement() -> None:
     # One physical slave, one master instance connecting to it after another -
     # e.g. Motionlab switching between two FSoE master configurations against
     # the same drive - not two independent slaves.

--- a/tests/fsoe/test_handler.py
+++ b/tests/fsoe/test_handler.py
@@ -620,11 +620,11 @@ def test_stale_data_reply_survives_master_replacement() -> None:
         assert handler_b.state == FSoEState.SESSION
 
         # The stale incoming DATA packet is delivered again while the master
-        # is in SESSION, where it is no longer suppressed and is reported.
+        # is in SESSION. The master still reacts to it internally (it isn't
+        # withheld), but the resulting error is recognized as caused by a
+        # repeated slave reply and is not reported to the user.
         network.exchange_one_round()  # Session -> stale DATA reply
-        assert errors_b == [
-            ("SESSION_FAIL3", "Invalid slave frame command"),
-        ]
+        assert errors_b == []
         assert handler_b.state == FSoEState.RESET
     finally:
         handler_b.delete()

--- a/tests/fsoe/test_handler.py
+++ b/tests/fsoe/test_handler.py
@@ -1,7 +1,9 @@
 import logging
+import os
 import random
 import time
-from typing import TYPE_CHECKING, Callable, Optional
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Optional, TextIO
 
 import pytest
 from ingenialink.dictionary import DictionarySafetyModule
@@ -326,19 +328,31 @@ class FSoESlave:
     side tracks them independently - so ``FSOEFrame.generate_crcs()`` only
     produces a CRC the real master will accept when fed the values above.
 
-    On a Reset request, the slave captures its own last Session-state reply
-    as a stale reply, to be returned automatically on the first non-Reset
-    request of the new session. Once that stale reply has been delivered, the
-    previous session's memory is forgotten so the next fresh startup (e.g.
-    a different master handler connecting to the same physical slave) does
-    not re-deliver it.
+    When a new Reset request arrives, the slave first returns its previous
+    output buffer, if any, before processing the Reset. The preserved output
+    remains available for three exchange iterations, until the simulated PDO
+    buffer is replaced by fresh output.
     """
 
     def __init__(self) -> None:
         self._replies_ever = 0
         self._replies_this_session = 0
-        self._session_reply: Optional[bytes] = None
+        self._last_reply: Optional[bytes] = None
         self._stale_reply: Optional[bytes] = None
+        self._stale_replies_remaining = 0
+        self._last_reply_source = "fresh"
+
+    def _consume_stale_reply(self) -> Optional[bytes]:
+        """Return the preserved reply while its simulated buffer is held."""
+        if self._stale_reply is None or self._stale_replies_remaining == 0:
+            return None
+        stale_reply = self._stale_reply
+        self._stale_replies_remaining -= 1
+        if self._stale_replies_remaining == 0:
+            self._stale_reply = None
+        self._last_reply_source = "stale"
+        self._replies_ever += 1
+        return stale_reply
 
     def compute_reply(self, request_bytes: bytes) -> bytes:
         """Compute the reply for one request.
@@ -356,26 +370,25 @@ class FSoESlave:
         request = FSOEFrame.frame_from_array(request_bytes)
         data = request.get_safe_data_bytes()[: request.safe_data_size_bytes]
         command = request.control.command
+        self._last_reply_source = "fresh"
 
+        if command == FSOECommand.RESET and self._last_reply is not None:
+            # The first PDO cycle after a restart can deliver the previous
+            # output before the slave has processed the new Reset request.
+            stale_reply = self._last_reply
+            self._stale_reply = stale_reply
+            self._stale_replies_remaining = 3
+            self._last_reply = None
+            stale_reply = self._consume_stale_reply()
+            assert stale_reply is not None
+            return stale_reply
+        stale_reply = self._consume_stale_reply() if command != FSOECommand.RESET else None
+        if stale_reply is not None:
+            return stale_reply
         if command == FSOECommand.RESET:
-            # A new session is starting: this device's own Session-state
-            # reply from whatever session just ended is still the last thing
-            # it transmitted - exactly what a PDO thread would briefly
-            # deliver right after a restart, since the device is never
-            # power-cycled between sessions.
-            self._stale_reply = self._session_reply
             self._replies_this_session = 0
             sequence_number = self._replies_ever
             connection_id = 0
-        elif self._stale_reply is not None and command != FSOECommand.RESET:
-            # First non-Reset request after a Reset: deliver the stale reply
-            # from the previous session, then forget that previous session
-            # entirely so the next fresh startup does not re-deliver it.
-            stale_reply = self._stale_reply
-            self._stale_reply = None
-            self._session_reply = None
-            self._replies_ever += 1
-            return stale_reply
         elif command == FSOECommand.SESSION:
             sequence_number = self._replies_this_session
             connection_id = 0
@@ -392,8 +405,7 @@ class FSoESlave:
         reply.generate_crcs()
         reply_bytes = reply.frame_to_array()
 
-        if command == FSOECommand.SESSION:
-            self._session_reply = reply_bytes
+        self._last_reply = reply_bytes
 
         self._replies_ever += 1
         self._replies_this_session += 1
@@ -410,9 +422,34 @@ class FSoENetwork:
     hardware, which is never power-cycled between them.
     """
 
-    def __init__(self, handler: "FSoEMasterHandler", slave: FSoESlave) -> None:
+    def __init__(
+        self,
+        handler: "FSoEMasterHandler",
+        slave: FSoESlave,
+        trace_path: Optional[Path] = None,
+    ) -> None:
         self.master = handler
         self.slave = slave
+        self._trace_path = trace_path
+        self._trace_file: Optional[TextIO] = None
+        self._round = 0
+        if self._trace_path is not None:
+            self._trace_file = self._trace_path.open("w", encoding="utf-8")
+            self._trace_file.write("FSoE exchange trace\n")
+            self._trace_file.flush()
+
+    def trace(self, marker: str, message: str) -> None:
+        """Append a marked event to the exchange trace, if enabled."""
+        if self._trace_file is None:
+            return
+        self._trace_file.write(f"[{marker}] {message}\n")
+        self._trace_file.flush()
+
+    def close(self) -> None:
+        """Close the trace file, if one is open."""
+        if self._trace_file is not None:
+            self._trace_file.close()
+            self._trace_file = None
 
     def replace_master(self, handler: "FSoEMasterHandler") -> None:
         """Connect a different master handler to the same slave."""
@@ -424,12 +461,34 @@ class FSoENetwork:
         Returns:
             The reply bytes sent.
         """
-        self.master.get_request()
-        request_bytes = self.master.safety_master_pdu_map.get_item_bytes()
-        reply_bytes = self.slave.compute_reply(request_bytes)
-        self.master.safety_slave_pdu_map.set_item_bytes(reply_bytes)
-        self.master.set_reply()
-        return reply_bytes
+        self._round += 1
+        self.trace(
+            f"ROUND {self._round:02d}",
+            f"state_before={self.master.state.name}",
+        )
+        try:
+            self.master.get_request()
+            request_bytes = self.master.safety_master_pdu_map.get_item_bytes()
+            self.trace(f"ROUND {self._round:02d}", f"request={request_bytes.hex(' ')}")
+            reply_bytes = self.slave.compute_reply(request_bytes)
+            self.trace(
+                f"ROUND {self._round:02d}",
+                f"reply_source={self.slave._last_reply_source}",
+            )
+            self.trace(f"ROUND {self._round:02d}", f"reply={reply_bytes.hex(' ')}")
+            self.master.safety_slave_pdu_map.set_item_bytes(reply_bytes)
+            self.master.set_reply()
+            self.trace(
+                f"ROUND {self._round:02d}",
+                f"state_after={self.master.state.name}",
+            )
+            return reply_bytes
+        except Exception as error:
+            self.trace(
+                f"ROUND {self._round:02d} EXCEPTION",
+                f"{type(error).__name__}: {error}",
+            )
+            raise
 
     def exchange_to_data(self, max_rounds: int = 20) -> list[bytes]:
         """Exchange rounds until the master's startup handshake reaches Data.
@@ -479,77 +538,84 @@ def test_startup_replay_filter_is_not_shared_between_handler_instances() -> None
     # the same drive - not two independent slaves.
     mock_servo = MockServo(SAMPLE_SAFE_PH1_XDFV3_DICTIONARY)
     mock_network = MockNetwork()
+    trace_path = Path(os.environ.get("FSOE_TRACE_FILE", "fsoe_startup_sequence.log"))
 
     errors_a: list[tuple[str, str]] = []
+
+    def report_error_a(name: str, error: str) -> None:
+        errors_a.append((name, error))
+        network.trace("HANDLER_A_ERROR", f"{name}: {error}")
+
     handler_a = FSoEMasterHandler(
         servo=mock_servo,
         net=mock_network,
         use_sra=True,
-        report_error_callback=lambda name, err: errors_a.append((name, err)),
+        report_error_callback=report_error_a,
     )
-    network = FSoENetwork(handler_a, FSoESlave())
+    network = FSoENetwork(handler_a, FSoESlave(), trace_path=trace_path)
+    network.trace("TEST", "handler_a startup")
     try:
-        # handler_a completes one full, real startup, is stopped, and
-        # restarted - genuinely progressing past its own Reset state for
-        # real, matching production timing where the CURRENT session's real
-        # replies advance the handshake before any leftover PDO bytes from
-        # the PREVIOUS session show up. This is also what turns
-        # __in_initial_reset off, so a real error is no longer suppressed and
-        # becomes visible in report_error_callback - the actual, user-facing
-        # symptom from the original bug report.
+        # handler_a completes a real startup and exchanges one live DATA
+        # packet, leaving that packet in the physical slave's PDO buffer.
         handler_a.start()
         network.exchange_to_data()
         assert handler_a.state == FSoEState.DATA
+        network.exchange_one_round()  # DATA -> last live data reply
+        network.trace(
+            "STOP",
+            f"request_before_stop={handler_a.safety_master_pdu_map.get_item_bytes().hex(' ')}, "
+            f"state={handler_a.state.name}",
+        )
         handler_a.stop()
-
-        handler_a.start()
-        network.exchange_one_round()  # Reset -> fresh Reset reply, state -> SESSION
-        assert handler_a.state == FSoEState.SESSION
-
-        # The slave is never power-cycled: it still has its own Session-state
-        # reply from the session that just ended as its last output, exactly
-        # what a real device would still be transmitting right after a
-        # restart. The slave auto-delivers its previous Session reply on the
-        # next round; handler_a recognizes it as its own previously-seen reply
-        # and suppresses it: no user-visible error is reported, and its state
-        # is undisturbed.
-        network.exchange_one_round()  # Session -> stale reply auto-delivered
+        network.trace(
+            "STOP",
+            f"request_after_stop={handler_a.safety_master_pdu_map.get_item_bytes().hex(' ')}, "
+            f"state={handler_a.state.name}",
+        )
         assert errors_a == []
-        assert handler_a.state == FSoEState.SESSION
-
-        # Complete the new session so the slave has a current Session reply
-        # ready to replay when the next master connects.
-        network.exchange_to_data()
-        assert handler_a.state == FSoEState.DATA
-        handler_a.stop()
     finally:
         handler_a.stop()
         handler_a.delete()
 
     # handler_a has fully disconnected from the slave. A second, independent
     # master instance now takes over the SAME slave (never power-cycled),
-    # which still has handler_a's current Session reply as its last output.
+    # which still has handler_a's last DATA reply as its last output.
     errors_b: list[tuple[str, str]] = []
+
+    def report_error_b(name: str, error: str) -> None:
+        errors_b.append((name, error))
+        network.trace("HANDLER_B_ERROR", f"{name}: {error}")
+
     handler_b = FSoEMasterHandler(
         servo=mock_servo,
         net=mock_network,
         use_sra=True,
-        report_error_callback=lambda name, err: errors_b.append((name, err)),
+        report_error_callback=report_error_b,
     )
     try:
         network.replace_master(handler_b)
+        network.trace("TEST", "handler_b startup on the same slave")
         handler_b.start()
-        network.exchange_one_round()  # Reset -> fresh Reset reply, state -> SESSION
+        # The stale incoming DATA packet is delivered before B processes its
+        # Reset, while the outgoing master request is independently replaced
+        # with a fresh Reset on the next cycle.
+        network.exchange_one_round()  # Reset -> stale DATA reply
+        assert handler_b.state == FSoEState.RESET
+        assert errors_b == []
+
+        network.exchange_one_round()  # Reset -> fresh Reset reply
         assert handler_b.state == FSoEState.SESSION
 
-        # The slave automatically replays handler_a's Session reply. handler_b
-        # has never seen it, so its own filter does not catch it: it reaches
-        # the real master, which correctly rejects it as invalid for this
-        # session, and that rejection is reported to the user.
-        network.exchange_one_round()  # Session -> handler_a's reply replayed
-        assert errors_b == [("SESSION_STAY2", "Invalid slave CRC")]
+        # The stale incoming DATA packet is delivered again while the master
+        # is in SESSION, where it is no longer suppressed and is reported.
+        network.exchange_one_round()  # Session -> stale DATA reply
+        assert errors_b == [
+            ("SESSION_FAIL3", "Invalid slave frame command"),
+        ]
+        assert handler_b.state == FSoEState.RESET
     finally:
         handler_b.delete()
+        network.close()
 
 
 @pytest.mark.fsoe

--- a/tests/fsoe/test_process_image.py
+++ b/tests/fsoe/test_process_image.py
@@ -38,7 +38,6 @@ if FSOE_MASTER_INSTALLED:
 
 if TYPE_CHECKING:
     from ingenialink.ethercat.dictionary import EthercatDictionary
-    from ingenialink.ethercat.servo import EthercatServo
 
     from ingeniamotion.fsoe import FSoEDictionary
 

--- a/tests/fsoe/test_process_image.py
+++ b/tests/fsoe/test_process_image.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Callable
 
 import pytest
 from ingenialink import RegAccess
-from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.pdo import RPDOMap, TPDOMap
 
 from ingeniamotion.enums import FSoEState
@@ -38,6 +37,7 @@ if FSOE_MASTER_INSTALLED:
 
 if TYPE_CHECKING:
     from ingenialink.ethercat.dictionary import EthercatDictionary
+    from ingenialink.ethercat.servo import EthercatServo
 
     from ingeniamotion.fsoe import FSoEDictionary
 

--- a/tests/fsoe/test_safety_pdos.py
+++ b/tests/fsoe/test_safety_pdos.py
@@ -12,7 +12,6 @@ except ImportError:
     pysoem = None
 
 from ingeniamotion.enums import FSoEState
-from ingeniamotion.motion_controller import MotionController
 
 if TYPE_CHECKING:
     from ingenialink.ethercat.network import EthercatNetwork
@@ -20,6 +19,7 @@ if TYPE_CHECKING:
     from ingenialink.pdo import RPDOMap, TPDOMap
 
     from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED
+    from ingeniamotion.motion_controller import MotionController
 
     if FSOE_MASTER_INSTALLED:
         from ingeniamotion.fsoe_master.handler import FSoEMasterHandler

--- a/tests/fsoe/test_safety_pdos.py
+++ b/tests/fsoe/test_safety_pdos.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from ingenialink.pdo import RPDOMap, TPDOMap
 
     from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED
-    from ingeniamotion.motion_controller import MotionController
 
     if FSOE_MASTER_INSTALLED:
         from ingeniamotion.fsoe_master.handler import FSoEMasterHandler

--- a/tests/fsoe/utils/fsoe_emulation.py
+++ b/tests/fsoe/utils/fsoe_emulation.py
@@ -1,0 +1,319 @@
+"""Pure-software emulation of an FSoE slave for exercising a real master handler.
+
+No hardware is involved: :class:`FSoESlave` computes genuine protocol replies with
+the ``fsoe_master`` library, and :class:`FSoENetwork` cycles PDO data between it
+and a real ``FSoEMasterHandler``, mimicking the EtherCAT medium.
+"""
+
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional, TextIO
+
+from ingeniamotion.enums import FSoEState
+from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED
+
+if FSOE_MASTER_INSTALLED:
+    from fsoe_master.fsoe_master import FSOECommand, FSOEFrame
+
+if TYPE_CHECKING:
+    from ingeniamotion.fsoe_master.handler import FSoEMasterHandler
+
+
+class ReplySource(Enum):
+    """Origin of the slave's most recent reply."""
+
+    FRESH = "fresh"
+    STALE = "stale"
+
+
+class StaleReplyBuffer:
+    """Simulates the slave's PDO output buffer surviving a master restart.
+
+    On real hardware the slave's last output stays in the PDO buffer when a
+    master disconnects: the first cycles after a new master connects can
+    re-deliver it before the slave has processed the new Reset request. The
+    held reply stays available for ``HOLD_EXCHANGES`` deliveries, until fresh
+    output replaces the simulated buffer.
+    """
+
+    HOLD_EXCHANGES = 3
+
+    def __init__(self) -> None:
+        self._reply: Optional[bytes] = None
+        self._deliveries_remaining = 0
+
+    def hold(self, reply: bytes) -> None:
+        """Preserve a reply as the buffered output to re-deliver.
+
+        Args:
+            reply: The reply bytes left in the simulated PDO buffer.
+        """
+        self._reply = reply
+        self._deliveries_remaining = self.HOLD_EXCHANGES
+
+    def consume(self) -> Optional[bytes]:
+        """Return the buffered reply, or None once the buffer is exhausted.
+
+        Returns:
+            The held reply bytes, or None if nothing is buffered anymore.
+        """
+        if self._reply is None:
+            return None
+        reply = self._reply
+        self._deliveries_remaining -= 1
+        if self._deliveries_remaining == 0:
+            self._reply = None
+        return reply
+
+
+class FSoESlave:
+    """A software FSoE slave device.
+
+    Computes genuine replies via the ``fsoe_master`` library for framing/CRC
+    generation - the replies are real protocol traffic, not fabricated
+    constants.
+
+    Because it outlives any one master connection (it's never power-cycled),
+    its :class:`StaleReplyBuffer` can re-deliver a reply from a previous
+    session right after a master restart.
+    """
+
+    def __init__(self) -> None:
+        self._replies_ever = 0
+        self._replies_this_session = 0
+        self._outgoing_reply: Optional[bytes] = None
+        self._stale_buffer = StaleReplyBuffer()
+        self._last_reply_source = ReplySource.FRESH
+
+    @property
+    def last_reply_source(self) -> ReplySource:
+        """Origin of the most recent reply."""
+        return self._last_reply_source
+
+    def compute_reply(self, request_bytes: bytes) -> bytes:
+        """Compute the reply for one request.
+
+        A Reset request arriving while a previous output is still buffered
+        makes that output re-deliverable: the buffered stale reply is then
+        returned instead of a fresh one until the buffer is exhausted, exactly
+        what a PDO thread would briefly deliver right after a restart.
+
+        Args:
+            request_bytes: The master's current request, as raw bytes.
+
+        Returns:
+            The reply bytes.
+        """
+        request = FSOEFrame.frame_from_array(request_bytes)
+        stale_reply = self._stale_buffered_reply(request.control.command)
+        if stale_reply is not None:
+            self._last_reply_source = ReplySource.STALE
+            self._replies_ever += 1
+            return stale_reply
+        self._last_reply_source = ReplySource.FRESH
+        return self._fresh_reply(request, request_bytes)
+
+    def _stale_buffered_reply(self, command: "FSOECommand") -> Optional[bytes]:
+        """Return the stale buffered reply to deliver, if any.
+
+        A Reset request finding a leftover output moves it into the stale
+        buffer and delivers it immediately - the first PDO cycle after a
+        restart can deliver the previous output before the slave has processed
+        the new Reset request. Further Reset requests are answered fresh,
+        while any other request keeps draining the buffer.
+
+        Args:
+            command: The command of the request being answered.
+
+        Returns:
+            The stale reply bytes to deliver, or None to answer fresh.
+        """
+        if command == FSOECommand.RESET:
+            if self._outgoing_reply is None:
+                return None
+            self._stale_buffer.hold(self._outgoing_reply)
+            self._outgoing_reply = None
+            return self._stale_buffer.consume()
+        return self._stale_buffer.consume()
+
+    def _fresh_reply(self, request: "FSOEFrame", request_bytes: bytes) -> bytes:
+        """Compute a protocol-correct reply to the given request.
+
+        The reply echoes the request's command and safe data, and answers
+        with the request's own crc0. The connection_id is 0 until a session
+        is established (Reset/Session); afterwards it is read directly off
+        the request, which already carries the established one. The
+        sequence_number counts the replies sent in the current session,
+        restarting with every new Reset request - except for Reset replies
+        themselves, which use the never-resetting ``_replies_ever`` counter
+        only so their bytes never collide with an earlier session's Reset
+        reply (the master rejects exact repeats).
+
+        Neither sequence_number nor crc0 is transmitted on the wire - each
+        side tracks them independently - so ``generate_crcs()`` produces a
+        CRC the real master accepts only when fed the values above.
+
+        Args:
+            request: The parsed view of ``request_bytes``.
+            request_bytes: The master's current request, as raw bytes.
+
+        Returns:
+            The reply bytes.
+        """
+        command = request.control.command
+        data = request.get_safe_data_bytes()[: request.safe_data_size_bytes]
+
+        if command == FSOECommand.RESET:
+            self._replies_this_session = 0
+            sequence_number = self._replies_ever
+            connection_id = 0
+        elif command == FSOECommand.SESSION:
+            sequence_number = self._replies_this_session
+            connection_id = 0
+        else:
+            sequence_number = self._replies_this_session
+            connection_id = request.control.connection_id
+
+        reply = FSOEFrame.frame_from_array(request_bytes)
+        reply.control.command = command
+        reply.control.connection_id = connection_id
+        reply.control.sequence_number = sequence_number
+        reply.control.crc0 = int(request.crcs[0])
+        reply.set_safe_data_bytes(data)
+        reply.generate_crcs()
+        reply_bytes: bytes = reply.frame_to_array()
+
+        self._outgoing_reply = reply_bytes
+        self._replies_ever += 1
+        self._replies_this_session += 1
+        return reply_bytes
+
+
+class ExchangeTrace:
+    """Log of exchange events for debugging failing handshakes.
+
+    Created without a path, it silently discards everything, so callers never
+    need to check whether tracing is enabled.
+    """
+
+    def __init__(self, path: Optional[Path]) -> None:
+        self._file: Optional[TextIO] = None
+        if path is not None:
+            self._file = path.open("w", encoding="utf-8")
+            self._file.write("FSoE exchange trace\n")
+            self._file.flush()
+
+    def write(self, marker: str, message: str) -> None:
+        """Append a marked event to the trace, if enabled.
+
+        Args:
+            marker: Short label identifying the event source.
+            message: The event description.
+        """
+        if self._file is None:
+            return
+        self._file.write(f"[{marker}] {message}\n")
+        self._file.flush()
+
+    def close(self) -> None:
+        """Close the trace file, if one is open."""
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+
+class FSoENetwork:
+    """The EtherCAT medium connecting a master handler to a slave device.
+
+    Cycles PDO data between them - the only object that needs a reference to
+    both sides. The slave survives a master being replaced, e.g. when a
+    different master handler connects to it after a previous one disconnects -
+    matching real hardware, which is never power-cycled between them.
+    """
+
+    def __init__(
+        self,
+        handler: "FSoEMasterHandler",
+        slave: FSoESlave,
+        trace_path: Optional[Path] = None,
+    ) -> None:
+        self.master = handler
+        self.slave = slave
+        self._trace = ExchangeTrace(trace_path)
+        self._round = 0
+
+    def __enter__(self) -> "FSoENetwork":
+        """Return the network with its trace lifecycle managed by a context."""
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        """Close the trace when leaving the network context."""
+        self.close()
+
+    def trace(self, marker: str, message: str) -> None:
+        """Append a marked event to the exchange trace, if enabled.
+
+        Args:
+            marker: Short label identifying the event source.
+            message: The event description.
+        """
+        self._trace.write(marker, message)
+
+    def close(self) -> None:
+        """Close the exchange trace, if one is open."""
+        self._trace.close()
+
+    def replace_master(self, handler: "FSoEMasterHandler") -> None:
+        """Connect a different master handler to the same slave.
+
+        Args:
+            handler: The master handler taking over the slave.
+        """
+        self.master = handler
+
+    def exchange_one_round(self) -> bytes:
+        """Exchange one request/reply round.
+
+        Returns:
+            The reply bytes sent.
+        """
+        self._round += 1
+        marker = f"ROUND {self._round:02d}"
+        self.trace(marker, f"state_before={self.master.state.name}")
+        try:
+            self.master.get_request()
+            request_bytes = self.master.safety_master_pdu_map.get_item_bytes()
+            self.trace(marker, f"request={request_bytes.hex(' ')}")
+            reply_bytes = self.slave.compute_reply(request_bytes)
+            self.trace(marker, f"reply_source={self.slave.last_reply_source.value}")
+            self.trace(marker, f"reply={reply_bytes.hex(' ')}")
+            self.master.safety_slave_pdu_map.set_item_bytes(reply_bytes)
+            self.master.set_reply()
+            self.trace(marker, f"state_after={self.master.state.name}")
+            return reply_bytes
+        except Exception as error:
+            self.trace(f"{marker} EXCEPTION", f"{type(error).__name__}: {error}")
+            raise
+
+    def exchange_to_data(self, max_rounds: int = 20) -> list[bytes]:
+        """Exchange rounds until the master's startup handshake reaches Data.
+
+        Reusable across a real ``stop()``/``start()`` restart, or a master
+        replacement: the slave's own per-session counter resets whenever it
+        sees a new Reset request, matching the real master's own behavior.
+
+        Args:
+            max_rounds: Maximum number of rounds to exchange before giving up.
+
+        Returns:
+            The reply bytes sent, in order.
+
+        Raises:
+            RuntimeError: If Data state isn't reached within ``max_rounds``.
+        """
+        replies = []
+        for _ in range(max_rounds):
+            if self.master.state == FSoEState.DATA:
+                return replies
+            replies.append(self.exchange_one_round())
+        raise RuntimeError(f"Did not reach Data state within {max_rounds} rounds")


### PR DESCRIPTION
When an FSoE master (re)connects to a novanta fsoe slave it will respond with a reply from a previous session — e.g. a frozen safety PDU after a master replacement or a `stop()`/`start()` restart — the master reacts with transient, expected errors (`SESSION_RESET1`, `Invalid slave CRC`) that resolve on their own once the slave catches up. These were forwarded to the user's error callback as if they were real failures.

`FSoEMasterHandler` now keeps the first reply seen since `start()` as a baseline: errors triggered while the slave is repeating that baseline are logged at debug level instead of being reported. Errors raised while the handler is intentionally stopping (teardown noise such as `DATA_WD`) are suppressed the same way.

This was partially solved earlier by withholding replies whose first byte is 0 (not a valid FSoE command, i.e. the slave not ready yet), and later refactored in [#617](https://github.com/ingeniamc/ingeniamotion/pull/617) to suppress errors until the master exits the Reset state. That window is not enough: when the slave is dead or echoing stale frames, the master cycles from Reset to Session continuously, so it repeatedly leaves Reset and the spurious errors are reported again. This PR replaces the state-based window with a baseline-reply comparison that holds for as long as the slave keeps repeating the same stale answer.

Supersedes [#618](https://github.com/ingeniamc/ingeniamotion/pull/618), which also fixed this problem and a potential other one. But the implementation didn't work for the cross-master scenario, and now we cannot reproduce the scenario with real hardware 

### Type of change

- [x] Bug fix: stale-reply and teardown errors are no longer reported to the user callback.
- [x] Test infrastructure: `tests/fsoe/utils/fsoe_emulation.py` adds a software FSoE slave (`FSoESlave`) and medium (`FSoENetwork`) that drive the real master handshake to Data without hardware, including re-delivery of stale replies across a master replacement. Exchange traces are written to the summit-testing-framework output directory.
- [x] Re-enabled `test_start_stop_master` for DEN-S-NET-E (removed the `not_valid_for_product` marker).

### Tests

- [x] Add new unit tests if it applies.

New hardware-less tests in `tests/fsoe/test_handler.py`:

- `test_mock_slave_drives_real_handshake_to_data_state`: the emulated slave brings the real master from Reset to Data with no errors.
- `test_master_ignores_stale_reply_after_master_replacement`: a second master taking over the same slave receives the previous session's DATA reply; the resulting errors are suppressed.
