### PR TITLE
Simplify markers to use * syntax

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,27 +24,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def not_valid_for_eve_can_ecat_products(func: Callable) -> Callable:
-    """Decorator that applies not_valid_for_product markers for CAN and ECAT EVE products.
-
-    Returns:
-        The decorated function with the markers applied.
-    """
-    func = pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])(
-        func
-    )
-    func = pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])(
-        func
-    )
-    func = pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])(
-        func
-    )
-    func = pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])(
-        func
-    )
-    return func
-
-
 def not_valid_for_all_eve_products(func: Callable) -> Callable:
     """Decorator that applies not_valid_for_product markers for all EVE products.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Callable, Optional, Union
 import numpy as np
 import pytest
 from ingenialink import Servo
-from ingenialink.dictionary import Interface
 from ingenialink.exceptions import ILRegisterNotFoundError
 from summit_testing_framework import dynamic_loader
 from summit_testing_framework.profilers.stoppable_gaps import StoppableProfilerConfig
@@ -22,33 +21,6 @@ if TYPE_CHECKING:
     from ingeniamotion.motion_node import MotionNode
 
 logger = logging.getLogger(__name__)
-
-
-def not_valid_for_all_eve_products(func: Callable) -> Callable:
-    """Decorator that applies not_valid_for_product markers for all EVE products.
-
-    Returns:
-        The decorated function with the markers applied.
-    """
-    func = pytest.mark.not_valid_for_product(part_number="EVE-XCR-E", interfaces=[Interface.ECAT])(
-        func
-    )
-    func = pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.CAN])(
-        func
-    )
-    func = pytest.mark.not_valid_for_product(part_number="EVE-XCR-C", interfaces=[Interface.ETH])(
-        func
-    )
-    func = pytest.mark.not_valid_for_product(part_number="EVE-NET-E", interfaces=[Interface.ECAT])(
-        func
-    )
-    func = pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.CAN])(
-        func
-    )
-    func = pytest.mark.not_valid_for_product(part_number="EVE-NET-C", interfaces=[Interface.ETH])(
-        func
-    )
-    return func
 
 
 pytest_plugins = [

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -31,7 +31,7 @@ from ingeniamotion.wizard_tests.feedbacks_tests.digital_incremental2_test import
 from ingeniamotion.wizard_tests.feedbacks_tests.secondary_ssi_test import SecondarySSITest
 from ingeniamotion.wizard_tests.phase_calibration import Phasing
 from ingeniamotion.wizard_tests.phasing_check import PhasingCheck
-from tests.conftest import not_valid_for_all_eve_products, refresh_registers_for_test_rollback
+from tests.conftest import refresh_registers_for_test_rollback
 
 # Record stop opportunities for every wizard-test integration case in this module.
 pytestmark = pytest.mark.usefixtures("stoppable_trace_recorder")
@@ -506,7 +506,7 @@ def test_current_ramp_up(
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.ethernet
-@not_valid_for_all_eve_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*")
 def test_dynamic_forced_phasing(mc, alias, registers_baseline: DriveRegistersValue, servo: Servo):
     """Run the test on a real drive and check it succeeds, leaving the drive in NO_PHASING.
 

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -2,6 +2,7 @@ import time
 
 import numpy as np
 import pytest
+from ingenialink.dictionary import Interface
 
 from ingeniamotion.enums import (
     MonitoringProcessStage,
@@ -11,7 +12,6 @@ from ingeniamotion.enums import (
     OperationMode,
 )
 from ingeniamotion.exceptions import IMMonitoringError, IMStatusWordError
-from tests.conftest import not_valid_for_eve_can_ecat_products
 
 
 def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
@@ -53,9 +53,10 @@ def test_create_poller(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_create_monitoring_no_trigger(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
+
     mc.motion.set_operation_mode(OperationMode.VELOCITY, alias)
     max_frequency = mc.configuration.get_position_and_velocity_loop_rate(alias)
     divider = 40
@@ -86,7 +87,7 @@ def test_create_monitoring_no_trigger(mc, alias):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 @pytest.mark.parametrize(
     "trigger_mode, trigger_config, values_list",
@@ -154,7 +155,7 @@ def test_create_monitoring_edge_trigger(
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("trigger_delay_rate", [-1 / 4, 1 / 4])
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_create_monitoring_trigger_delay(
     mc,
     alias,
@@ -213,7 +214,7 @@ def test_create_monitoring_trigger_delay(
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 def test_create_disturbance(mc, alias):
     target_register = "CL_POS_SET_POINT_VALUE"
@@ -262,7 +263,7 @@ def test_mcb_synchronization_fail(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_disturbance_max_sample_size(mc, alias):
     target_register = mc.capture.DISTURBANCE_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -273,7 +274,7 @@ def test_disturbance_max_sample_size(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -287,7 +288,7 @@ def test_monitoring_max_sample_size(mc, alias):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_get_frequency(mc, alias):
     registers = [{"name": "CL_POS_REF_VALUE", "axis": 1}]
     max_frequency = mc.configuration.get_position_and_velocity_loop_rate(alias)

--- a/tests/test_disturbance.py
+++ b/tests/test_disturbance.py
@@ -1,8 +1,8 @@
 import pytest
+from ingenialink.dictionary import Interface
 
 from ingeniamotion.disturbance import Disturbance
 from ingeniamotion.exceptions import IMDisturbanceError
-from tests.conftest import not_valid_for_eve_can_ecat_products
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def disturbance(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_disturbance_max_sample_size(mc, alias, disturbance):
     max_sample_size = disturbance.max_sample_number
     value = mc.communication.get_register(
@@ -29,7 +29,7 @@ def test_disturbance_max_sample_size(mc, alias, disturbance):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_set_frequency_divider(mc, alias, disturbance, prescaler):
     disturbance.set_frequency_divider(prescaler)
     value = mc.communication.get_register(
@@ -41,7 +41,7 @@ def test_set_frequency_divider(mc, alias, disturbance, prescaler):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_set_frequency_divider_exception(disturbance):
     prescaler = -1
     with pytest.raises(ValueError):
@@ -51,7 +51,7 @@ def test_set_frequency_divider_exception(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 @pytest.mark.parametrize(
     "axis, name, expected_value",
     [
@@ -72,7 +72,7 @@ def test_disturbance_map_registers(mc, alias, disturbance, axis, name, expected_
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 @pytest.mark.parametrize("number_registers", list(range(1, 17)))
 def test_disturbance_number_map_registers(mc, alias, disturbance, number_registers):
     reg_dict = {"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}
@@ -85,7 +85,7 @@ def test_disturbance_number_map_registers(mc, alias, disturbance, number_registe
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_disturbance_map_registers_sample_number(disturbance):
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]
     value = disturbance.map_registers(registers)
@@ -93,7 +93,7 @@ def test_disturbance_map_registers_sample_number(disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_disturbance_map_registers_exception(disturbance):
     registers = [{"axis": 0, "name": "DRV_AXIS_NUMBER"}]
     with pytest.raises(IMDisturbanceError):
@@ -101,7 +101,7 @@ def test_disturbance_map_registers_exception(disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_disturbance_map_registers_empty(disturbance):
     registers = []
     with pytest.raises(IMDisturbanceError):
@@ -111,7 +111,7 @@ def test_disturbance_map_registers_empty(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 @pytest.mark.usefixtures("disturbance_map_registers")
 def test_write_disturbance_data_buffer_exception(disturbance):
     with pytest.raises(IMDisturbanceError):
@@ -119,7 +119,7 @@ def test_write_disturbance_data_buffer_exception(disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_write_disturbance_data_not_configured(disturbance):
     with pytest.raises(IMDisturbanceError):
         disturbance.write_disturbance_data([0] * 100)
@@ -128,7 +128,7 @@ def test_write_disturbance_data_not_configured(disturbance):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
 def test_write_disturbance_data_enabled(mc, alias, disturbance):
     mc.capture.enable_disturbance(alias)
@@ -137,7 +137,7 @@ def test_write_disturbance_data_enabled(mc, alias, disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_disturbance_map_registers_invalid_subnode(mocker, mc, disturbance):
     registers = [{"axis": "1", "name": "DRV_AXIS_NUMBER"}]
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
@@ -146,7 +146,7 @@ def test_disturbance_map_registers_invalid_subnode(mocker, mc, disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_disturbance_map_registers_invalid_register(mocker, mc, disturbance):
     registers = [{"axis": 1, "name": 1}]
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
@@ -155,7 +155,7 @@ def test_disturbance_map_registers_invalid_register(mocker, mc, disturbance):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_write_disturbance_data_wrong_data_type(mocker, mc, disturbance):
     mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
     registers = [{"axis": 1, "name": "CL_POS_SET_POINT_VALUE"}]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -18,7 +18,6 @@ from ingeniamotion.errors import (
     SystemQueueError,
 )
 from ingeniamotion.exceptions import IMErrorQueueNotExistsError
-from tests.conftest import not_valid_for_all_eve_products
 
 if TYPE_CHECKING:
     from ingenialink.servo import Servo
@@ -449,7 +448,7 @@ class TestErrors:
     @pytest.mark.ethernet
     @pytest.mark.soem
     @pytest.mark.canopen
-    @not_valid_for_all_eve_products
+    @pytest.mark.not_valid_for_product(part_number="EVE-*")
     def test_error_queue_get_error_by_index_system_warning(
         self, servo: "Servo", generate_drive_warning: int
     ) -> None:

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -4,12 +4,12 @@ from functools import partial
 from threading import Thread
 
 import pytest
+from ingenialink.dictionary import Interface
 from ingenialink.enums.register import RegDtype
 
 from ingeniamotion.enums import MonitoringSoCConfig, MonitoringSoCType
 from ingeniamotion.exceptions import IMMonitoringError
 from ingeniamotion.monitoring.base_monitoring import Monitoring
-from tests.conftest import not_valid_for_eve_can_ecat_products
 
 MONITOR_START_CONDITION_TYPE_REGISTER = "MON_CFG_SOC_TYPE"
 
@@ -52,7 +52,7 @@ def mon_map_registers(monitoring):
         4,  # Invalid value
     ],
 )
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_get_trigger_type(mc, alias, monitoring, trigger_type):
     mc.communication.set_register(
         MONITOR_START_CONDITION_TYPE_REGISTER, trigger_type, servo=alias, axis=0
@@ -76,7 +76,7 @@ def test_get_trigger_type(mc, alias, monitoring, trigger_type):
         (True, 0.1, 0.8, 0, False),
     ],
 )
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_raise_forced_trigger(
     mc,
     alias,
@@ -102,7 +102,7 @@ def test_raise_forced_trigger(
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_raise_forced_trigger_fail(mc, alias, monitoring):
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_AUTO)
     monitoring.configure_sample_time(0.8, 0)
@@ -124,7 +124,7 @@ def test_raise_forced_trigger_fail(mc, alias, monitoring):
         (0.1, 0.8, False),
     ],
 )
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_read_monitoring_data_forced_trigger(mc, alias, monitoring, timeout, sample_t, result):
     monitoring.set_trigger(MonitoringSoCType.TRIGGER_EVENT_FORCED)
     monitoring.configure_sample_time(sample_t, 0)
@@ -140,7 +140,7 @@ def test_read_monitoring_data_forced_trigger(mc, alias, monitoring, timeout, sam
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("prescaler", list(range(2, 11, 2)))
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_set_monitoring_frequency(mc, alias, monitoring, prescaler):
     monitoring.set_frequency(prescaler)
     value = mc.communication.get_register(
@@ -152,7 +152,7 @@ def test_set_monitoring_frequency(mc, alias, monitoring, prescaler):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_set_monitoring_frequency_exception(monitoring):
     prescaler = 0.5
     with pytest.raises(ValueError):
@@ -160,7 +160,7 @@ def test_set_monitoring_frequency_exception(monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_monitoring_map_registers_size_exception(monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     monitoring.samples_number = monitoring.max_sample_number
@@ -169,7 +169,7 @@ def test_monitoring_map_registers_size_exception(monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_monitoring_map_registers_fail(monitoring):
     registers = []
     with pytest.raises(IMMonitoringError):
@@ -177,7 +177,7 @@ def test_monitoring_map_registers_fail(monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_monitoring_map_registers_wrong_cyclic(monitoring):
     registers = [{"axis": 1, "name": "DRV_STATE_CONTROL"}]
     with pytest.raises(IMMonitoringError):
@@ -201,7 +201,7 @@ def test_monitoring_map_registers_wrong_cyclic(monitoring):
         ),
     ],
 )
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_monitoring_set_trigger(
     mc,
     alias,
@@ -240,7 +240,7 @@ def test_monitoring_set_trigger(
         ),
     ],
 )
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_monitoring_set_trigger_exceptions(
     monitoring, trigger_type, edge_condition, trigger_signal, trigger_value
 ):
@@ -251,7 +251,7 @@ def test_monitoring_set_trigger_exceptions(
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_configure_number_samples(mc, alias, monitoring):
     total_num_samples = 500
     trigger_delay_samples = 100
@@ -270,7 +270,7 @@ def test_configure_number_samples(mc, alias, monitoring):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("total_num_samples, trigger_delay_samples", [(500, 510), (510, -500)])
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_configure_number_samples_exceptions(monitoring, total_num_samples, trigger_delay_samples):
     with pytest.raises(ValueError):
         monitoring.configure_number_samples(total_num_samples, trigger_delay_samples)
@@ -279,7 +279,7 @@ def test_configure_number_samples_exceptions(monitoring, total_num_samples, trig
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_configure_sample_time(mc, alias, monitoring):
     total_time = 5
     sampling_freq = 1e4
@@ -302,7 +302,7 @@ def test_configure_sample_time(mc, alias, monitoring):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("total_time, sign", [(5, 1), (5, -1)])
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_configure_sample_time_exception(monitoring, total_time, sign):
     trigger_delay = sign * ((total_time // 2) + 1)
     with pytest.raises(ValueError):
@@ -312,7 +312,7 @@ def test_configure_sample_time_exception(monitoring, total_time, sign):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_enable_monitoring_no_mapped_registers(mc, alias):
     mc.capture.clean_monitoring(alias)
     with pytest.raises(IMMonitoringError) as exc:
@@ -325,7 +325,7 @@ def test_enable_monitoring_no_mapped_registers(mc, alias):
 @pytest.mark.canopen
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_read_monitoring_data_disabled(monitoring):
     monitoring.configure_sample_time(0.8, 0)
     with pytest.raises(IMMonitoringError) as exc:
@@ -339,7 +339,7 @@ def test_read_monitoring_data_disabled(monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_read_monitoring_data_timeout(mc, alias, monitoring):
     timeout = 2
     sample_t = 0.8
@@ -356,7 +356,7 @@ def test_read_monitoring_data_timeout(mc, alias, monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_read_monitoring_data_no_rearm(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 2
@@ -382,7 +382,7 @@ def test_read_monitoring_data_no_rearm(mc, alias, monitoring):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_rearm_monitoring(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 2
@@ -422,7 +422,7 @@ def run_read_monitoring_data_and_stop(monitoring, timeout):
 @pytest.mark.usefixtures("mon_set_freq")
 @pytest.mark.usefixtures("mon_map_registers")
 @pytest.mark.usefixtures("disable_monitoring_disturbance")
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_stop_reading_data(mc, alias, monitoring):
     sample_t = 0.8
     timeout = 10
@@ -436,7 +436,7 @@ def test_stop_reading_data(mc, alias, monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_monitoring_max_sample_size(mc, alias):
     target_register = mc.capture.MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER
     axis = 0
@@ -447,7 +447,7 @@ def test_monitoring_max_sample_size(mc, alias):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_monitoring_map_registers_invalid_subnode(mocker, mc, monitoring):
     registers = [{"axis": "1", "name": "DRV_AXIS_NUMBER"}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -456,7 +456,7 @@ def test_monitoring_map_registers_invalid_subnode(mocker, mc, monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_monitoring_map_registers_invalid_register(mocker, mc, monitoring):
     registers = [{"axis": 1, "name": 1}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -465,7 +465,7 @@ def test_monitoring_map_registers_invalid_register(mocker, mc, monitoring):
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_monitoring_map_registers_invalid_number_mapped_registers(mocker, mc, monitoring):
     registers = [{"axis": 1, "name": "CL_POS_FBK_VALUE"}]
     mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
@@ -482,7 +482,7 @@ def test_monitoring_map_registers_invalid_number_mapped_registers(mocker, mc, mo
     ],
 )
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_configure_sample_time_exceptions(
     mocker, mc, monitoring, trigger_delay, expected_exception
 ):
@@ -493,7 +493,7 @@ def test_configure_sample_time_exceptions(
 
 
 @pytest.mark.virtual
-@not_valid_for_eve_can_ecat_products
+@pytest.mark.not_valid_for_product(part_number="EVE-*", interfaces=[Interface.ECAT, Interface.CAN])
 def test_get_trigger_type_exception(mocker, mc, monitoring):
     mocker.patch.object(mc.communication, "get_register", return_value="invalid_value")
     with pytest.raises(TypeError):


### PR DESCRIPTION
Simplify test markers. They were written before we supported * for describing products.