### PR TITLE
INGM-791 Replace ClassVars for Final

### DIFF
--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar, Optional, Union
+from typing import TYPE_CHECKING, Final, Optional, Union
 
 import numpy as np
 from ingenialink.dictionary import SubnodeType
@@ -45,12 +45,12 @@ class Capture:
     MONITORING_STATUS_ENABLED_BIT = 0x1
     DISTURBANCE_STATUS_ENABLED_BIT = 0x1
 
-    MONITORING_STATUS_PROCESS_STAGE_BITS: ClassVar[dict[MonitoringVersion, int]] = {
+    MONITORING_STATUS_PROCESS_STAGE_BITS: Final[dict[MonitoringVersion, int]] = {
         MonitoringVersion.MONITORING_V1: 0x6,
         MonitoringVersion.MONITORING_V2: 0x6,
         MonitoringVersion.MONITORING_V3: 0xE,
     }
-    MONITORING_AVAILABLE_FRAME_BIT: ClassVar[dict[MonitoringVersion, int]] = {
+    MONITORING_AVAILABLE_FRAME_BIT: Final[dict[MonitoringVersion, int]] = {
         MonitoringVersion.MONITORING_V1: 0x800,
         MonitoringVersion.MONITORING_V2: 0x800,
         MonitoringVersion.MONITORING_V3: 0x10,

--- a/ingeniamotion/configuration.py
+++ b/ingeniamotion/configuration.py
@@ -2,7 +2,7 @@ import re
 import warnings
 from enum import IntEnum
 from os import path
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union
+from typing import TYPE_CHECKING, Any, Final, Optional, Union
 
 import ingenialogger
 from ingenialink import CanBaudrate
@@ -95,7 +95,7 @@ class Configuration(Homing, Feedbacks):
     PROFILE_MAX_VELOCITY_REGISTER = "PROF_MAX_VEL"
     MAX_VELOCITY_REGISTER = "CL_VEL_REF_MAX"
     POWER_STAGE_FREQUENCY_SELECTION_REGISTER = "DRV_PS_FREQ_SELECTION"
-    POWER_STAGE_FREQUENCY_REGISTERS: ClassVar[list[str]] = [
+    POWER_STAGE_FREQUENCY_REGISTERS: Final[list[str]] = [
         "DRV_PS_FREQ_1",
         "DRV_PS_FREQ_2",
         "DRV_PS_FREQ_3",
@@ -135,23 +135,23 @@ class Configuration(Homing, Feedbacks):
     STO_ACTIVE_STATE = 4
     STO_INACTIVE_STATE = 23
 
-    PRODUCT_ID_REGISTERS: ClassVar[dict[SubnodeType, str]] = {
+    PRODUCT_ID_REGISTERS: Final[dict[SubnodeType, str]] = {
         SubnodeType.COMMUNICATION: "DRV_ID_PRODUCT_CODE_COCO",
         SubnodeType.MOTION: "DRV_ID_PRODUCT_CODE",
     }
-    REVISION_NUMBER_REGISTERS: ClassVar[dict[SubnodeType, str]] = {
+    REVISION_NUMBER_REGISTERS: Final[dict[SubnodeType, str]] = {
         SubnodeType.COMMUNICATION: "DRV_ID_REVISION_NUMBER_COCO",
         SubnodeType.MOTION: "DRV_ID_REVISION_NUMBER",
     }
-    SERIAL_NUMBER_REGISTERS: ClassVar[dict[SubnodeType, str]] = {
+    SERIAL_NUMBER_REGISTERS: Final[dict[SubnodeType, str]] = {
         SubnodeType.COMMUNICATION: "DRV_ID_SERIAL_NUMBER_COCO",
         SubnodeType.MOTION: "DRV_ID_SERIAL_NUMBER",
     }
-    SOFTWARE_VERSION_REGISTERS: ClassVar[dict[SubnodeType, str]] = {
+    SOFTWARE_VERSION_REGISTERS: Final[dict[SubnodeType, str]] = {
         SubnodeType.COMMUNICATION: "DRV_APP_COCO_VERSION",
         SubnodeType.MOTION: "DRV_ID_SOFTWARE_VERSION",
     }
-    VENDOR_ID_REGISTERS: ClassVar[dict[SubnodeType, str]] = {
+    VENDOR_ID_REGISTERS: Final[dict[SubnodeType, str]] = {
         SubnodeType.COMMUNICATION: "DRV_ID_VENDOR_ID_COCO",
         SubnodeType.MOTION: "DRV_ID_VENDOR_ID",
     }

--- a/ingeniamotion/disturbance.py
+++ b/ingeniamotion/disturbance.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, ClassVar, Optional, Union
+from typing import TYPE_CHECKING, Callable, Final, Optional, Union
 
 import ingenialogger
 import numpy as np
@@ -62,7 +62,7 @@ class Disturbance:
     MONITORING_STATUS_ENABLED_BIT = 0x1
     REGISTER_MAP_OFFSET = 0x800
 
-    __data_type_size: ClassVar[dict[RegDtype, int]] = {
+    __data_type_size: Final[dict[RegDtype, int]] = {
         RegDtype.U8: 1,
         RegDtype.S8: 1,
         RegDtype.U16: 2,

--- a/ingeniamotion/drive_tests.py
+++ b/ingeniamotion/drive_tests.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar, Optional, Union
+from typing import TYPE_CHECKING, Final, Optional, Union
 
 import ingenialogger
 
@@ -38,7 +38,7 @@ from ingeniamotion.wizard_tests.sto import STOTest
 class DriveTests:
     """Class that contain the tests that can be performed on a drive."""
 
-    __sensors: ClassVar[dict[SensorType, type[Feedbacks]]] = {
+    __sensors: Final[dict[SensorType, type[Feedbacks]]] = {
         SensorType.ABS1: AbsoluteEncoder1Test,
         SensorType.QEI: DigitalIncremental1Test,
         SensorType.HALLS: DigitalHallTest,

--- a/ingeniamotion/feedbacks.py
+++ b/ingeniamotion/feedbacks.py
@@ -1,5 +1,5 @@
 import typing
-from typing import TYPE_CHECKING, ClassVar, Optional, Union
+from typing import TYPE_CHECKING, Final, Optional, Union
 
 import ingenialogger
 
@@ -13,7 +13,7 @@ from ingeniamotion.metaclass import DEFAULT_AXIS, DEFAULT_SERVO, MCMetaClass
 class Feedbacks:
     """Feedbacks Wizard Class description."""
 
-    __feedback_type_dict: ClassVar[dict[SensorType, SensorCategory]] = {
+    __feedback_type_dict: Final[dict[SensorType, SensorCategory]] = {
         SensorType.ABS1: SensorCategory.ABSOLUTE,
         SensorType.QEI: SensorCategory.INCREMENTAL,
         SensorType.HALLS: SensorCategory.ABSOLUTE,
@@ -24,7 +24,7 @@ class Feedbacks:
         SensorType.SINCOS: SensorCategory.INCREMENTAL,
     }
 
-    __feedback_polarity_register_dict: ClassVar[dict[SensorType, str]] = {
+    __feedback_polarity_register_dict: Final[dict[SensorType, str]] = {
         SensorType.ABS1: "FBK_BISS1_SSI1_POS_POLARITY",
         SensorType.QEI: "FBK_DIGENC1_POLARITY",
         SensorType.HALLS: "FBK_DIGHALL_POLARITY",

--- a/ingeniamotion/monitoring/base_monitoring.py
+++ b/ingeniamotion/monitoring/base_monitoring.py
@@ -2,7 +2,7 @@ import struct
 import time
 from abc import ABC, abstractmethod
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, ClassVar, Optional, Union
+from typing import TYPE_CHECKING, Callable, Final, Optional, Union
 
 import ingenialogger
 import numpy as np
@@ -54,7 +54,7 @@ class Monitoring(ABC):
     REGISTER_MAP_OFFSET = 0x800
     ESTIMATED_MAX_TIME_FOR_SAMPLE = 0.003
 
-    _data_type_size: ClassVar[dict[RegDtype, int]] = {
+    _data_type_size: Final[dict[RegDtype, int]] = {
         RegDtype.U8: 1,
         RegDtype.S8: 1,
         RegDtype.U16: 2,

--- a/ingeniamotion/monitoring/monitoring_v1.py
+++ b/ingeniamotion/monitoring/monitoring_v1.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar, Optional, Union
+from typing import TYPE_CHECKING, Final, Optional, Union
 
 import ingenialogger
 from ingenialink.enums.register import RegDtype
@@ -25,7 +25,7 @@ class MonitoringV1(Monitoring):
     MONITORING_NUMBER_TRIGGER_REPETITIONS_REGISTER = "MON_CFG_TRIGGER_REPETITIONS"
     MONITOR_END_CONDITION_TYPE_REGISTER = "MON_CFG_EOC_TYPE"
 
-    EDGE_CONDITION_REGISTER: ClassVar[dict[MonitoringSoCConfig, str]] = {
+    EDGE_CONDITION_REGISTER: Final[dict[MonitoringSoCConfig, str]] = {
         MonitoringSoCConfig.TRIGGER_CONFIG_RISING: "MON_CFG_RISING_CONDITION",
         MonitoringSoCConfig.TRIGGER_CONFIG_FALLING: "MON_CFG_FALLING_CONDITION",
     }

--- a/ingeniamotion/wizard_tests/base_test.py
+++ b/ingeniamotion/wizard_tests/base_test.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Final, Generic, Optional, TypeVar, Union
 
 import ingenialogger
 from ingenialink.drive_context_manager import DriveContextManager, DriveRegistersValue
@@ -45,7 +45,7 @@ T = TypeVar("T", bound=Union[LegacyDictReportType, ReportBase])
 class BaseTest(ABC, Stoppable, Generic[T]):
     """Abstract base Test class."""
 
-    ACCEPTED_CHANGED_REGISTERS: ClassVar[tuple[str, ...]] = ()
+    ACCEPTED_CHANGED_REGISTERS: Final[tuple[str, ...]] = ()
     """Registers that the test is expected to leave changed after it runs."""
 
     def __init__(self) -> None:

--- a/ingeniamotion/wizard_tests/base_test.py
+++ b/ingeniamotion/wizard_tests/base_test.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Final, Generic, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, TypeVar, Union
 
 import ingenialogger
 from ingenialink.drive_context_manager import DriveContextManager, DriveRegistersValue
@@ -45,7 +45,7 @@ T = TypeVar("T", bound=Union[LegacyDictReportType, ReportBase])
 class BaseTest(ABC, Stoppable, Generic[T]):
     """Abstract base Test class."""
 
-    ACCEPTED_CHANGED_REGISTERS: Final[tuple[str, ...]] = ()
+    ACCEPTED_CHANGED_REGISTERS: ClassVar[tuple[str, ...]] = ()
     """Registers that the test is expected to leave changed after it runs."""
 
     def __init__(self) -> None:

--- a/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_polarity_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_polarity_test.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Final, Optional
 
 import ingenialogger
 from typing_extensions import override
@@ -29,7 +29,7 @@ class DCFeedbacksPolarityTest(BaseTest[LegacyDictReportType]):
 
         SUCCESS = 0
 
-    result_description: ClassVar[dict[ResultType, str]] = {
+    result_description: Final[dict[ResultType, str]] = {
         ResultType.SUCCESS: "Feedback polarity test pass successfully",
     }
 

--- a/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_resolution_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/dc_feedback_resolution_test.py
@@ -1,6 +1,6 @@
 import math
 from enum import IntEnum
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Final, Optional
 
 import ingenialogger
 from typing_extensions import override
@@ -23,7 +23,7 @@ class DCFeedbacksResolutionTest(BaseTest[LegacyDictReportType]):
 
     MOVEMENT_ERROR_FACTOR = 0.05
     DEFAULT_PROFILE_MAX_VEL = 0.3
-    DEFAULT_VELOCITY_PID: ClassVar[dict[str, float]] = {"kp": 0.1, "ki": 10, "kd": 0}
+    DEFAULT_VELOCITY_PID: Final[dict[str, float]] = {"kp": 0.1, "ki": 10, "kd": 0}
     POSITION_TUNE_BW = 1
     MOVEMENT_EXTRA_TIME_FACTOR = 1.5
     MOVEMENT_TIMEOUT = MOVEMENT_EXTRA_TIME_FACTOR / DEFAULT_PROFILE_MAX_VEL
@@ -36,7 +36,7 @@ class DCFeedbacksResolutionTest(BaseTest[LegacyDictReportType]):
 
         SUCCESS = 0
 
-    result_description: ClassVar[dict[ResultType, str]] = {
+    result_description: Final[dict[ResultType, str]] = {
         ResultType.SUCCESS: "Feedback resolution test has been executed",
     }
 

--- a/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
+++ b/ingeniamotion/wizard_tests/feedbacks_tests/feedback_test.py
@@ -1,7 +1,7 @@
 import math
 import time
 from enum import IntEnum
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Final, Optional
 
 import ingenialogger
 from ingenialink.exceptions import ILIOError, ILStateError, ILTimeoutError
@@ -42,7 +42,7 @@ class Feedbacks(BaseTest[LegacyDictReportType]):
         NORMAL = 0
         REVERSED = 1
 
-    result_description: ClassVar[dict[ResultType, str]] = {
+    result_description: Final[dict[ResultType, str]] = {
         ResultType.SUCCESS: "Feedback test pass successfully",
         ResultType.RESOLUTION_ERROR: "Feedback has a resolution error."
         " Detected resolution does not match the one specified on the configuration.",

--- a/ingeniamotion/wizard_tests/phase_calibration.py
+++ b/ingeniamotion/wizard_tests/phase_calibration.py
@@ -1,6 +1,6 @@
 import time
 from enum import IntEnum
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Final, Optional
 
 import ingenialogger
 from typing_extensions import override
@@ -42,7 +42,7 @@ class Phasing(BaseTest[LegacyDictReportType]):
 
     # Left changed on purpose: drive-computed calibration results (angle offsets) and the
     # phasing config the test applies. They are not rolled back, so restore checks accept them.
-    ACCEPTED_CHANGED_REGISTERS: ClassVar[tuple[str, ...]] = (
+    ACCEPTED_CHANGED_REGISTERS: Final[tuple[str, ...]] = (
         COMMUTATION_ANGLE_OFFSET_REGISTER,
         COMMUTATION_ANGLE_REF_OFFSET_REGISTER,
         MAX_CURRENT_ON_PHASING_SEQUENCE_REGISTER,
@@ -55,7 +55,7 @@ class Phasing(BaseTest[LegacyDictReportType]):
         SUCCESS = 0
         FAIL = -1
 
-    result_description: ClassVar[dict[ResultType, str]] = {
+    result_description: Final[dict[ResultType, str]] = {
         ResultType.SUCCESS: "Phasing process finished successfully",
         ResultType.FAIL: "Phasing process has failed.  Review your motor configuration.",
     }

--- a/ingeniamotion/wizard_tests/phase_calibration.py
+++ b/ingeniamotion/wizard_tests/phase_calibration.py
@@ -1,6 +1,6 @@
 import time
 from enum import IntEnum
-from typing import TYPE_CHECKING, Final, Optional
+from typing import TYPE_CHECKING, ClassVar, Final, Optional
 
 import ingenialogger
 from typing_extensions import override
@@ -42,7 +42,7 @@ class Phasing(BaseTest[LegacyDictReportType]):
 
     # Left changed on purpose: drive-computed calibration results (angle offsets) and the
     # phasing config the test applies. They are not rolled back, so restore checks accept them.
-    ACCEPTED_CHANGED_REGISTERS: Final[tuple[str, ...]] = (
+    ACCEPTED_CHANGED_REGISTERS: ClassVar[tuple[str, ...]] = (
         COMMUTATION_ANGLE_OFFSET_REGISTER,
         COMMUTATION_ANGLE_REF_OFFSET_REGISTER,
         MAX_CURRENT_ON_PHASING_SEQUENCE_REGISTER,

--- a/ingeniamotion/wizard_tests/phasing_check.py
+++ b/ingeniamotion/wizard_tests/phasing_check.py
@@ -1,6 +1,6 @@
 import time
 from enum import IntEnum
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Final, Optional
 
 import ingenialogger
 from typing_extensions import override
@@ -31,7 +31,7 @@ class PhasingCheck(BaseTest[LegacyDictReportType]):
         SUCCESS = 0
         WRONG_PHASING = -1
 
-    result_description: ClassVar[dict[ResultType, str]] = {
+    result_description: Final[dict[ResultType, str]] = {
         ResultType.SUCCESS: "Motor is well phased.",
         ResultType.WRONG_PHASING: "Phasing check failed. Wrong motor phasing.",
     }

--- a/ingeniamotion/wizard_tests/sto.py
+++ b/ingeniamotion/wizard_tests/sto.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Final, Optional
 
 import ingenialogger
 from typing_extensions import override
@@ -30,7 +30,7 @@ class STOTest(BaseTest[LegacyDictReportType]):
         NORMAL = 0
         REVERSED = 1
 
-    result_description: ClassVar[dict[ResultType, str]] = {
+    result_description: Final[dict[ResultType, str]] = {
         ResultType.STO_INACTIVE: "STO Inactive",
         ResultType.STO_ACTIVE: "STO Active",
         ResultType.STO_ABNORMAL_LATCHED: "Abnormal STO Latched",

--- a/ingeniamotion/wizard_tests/stoppable.py
+++ b/ingeniamotion/wizard_tests/stoppable.py
@@ -5,7 +5,7 @@ import typing
 from dataclasses import dataclass
 from functools import wraps
 from queue import Empty, Full, Queue
-from typing import Callable, ClassVar, Optional
+from typing import Callable, Final, Optional
 
 
 class StopExceptionError(Exception):
@@ -49,7 +49,7 @@ class Stoppable:
     """
 
     stop_queue: Queue[StopExceptionError] = Queue(1)
-    _stop_opportunity_subscriptions: ClassVar[list[StopOpportunitySubscription]] = []
+    _stop_opportunity_subscriptions: Final[list[StopOpportunitySubscription]] = []
 
     @classmethod
     def subscribe_to_stop_opportunities(


### PR DESCRIPTION
This pull request refactors type annotations in both the main code and tests to use `Final` instead of `ClassVar` for certain constant class attributes. This change clarifies that these attributes are intended to be immutable constants rather than just class-level variables.