### PR TITLE
Cit 761 add configure encoder logic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,6 +102,7 @@ def pipelineParams = PyTestParams.pytestParams(this, currentBuild, [
             'ethercat.*',
             'ethercat_everest.*',
             'ethercat_capitan.*',
+            'ethercat_everest_s.*',
             'ethercat_multislave.*',
             'fsoe.*',
             'fsoe_phase1.*',

--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post511+pr.81.b18"
+version = "0.3.0.post512+pr.81.b19"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post511+pr.81.b18-py3-none-any.whl", hash = "sha256:6f6bebe8fd0c3bf98933e2fa8d6d7bde2420fcbfd146526d0eb5a907ee97c69b"},
+    {file = "summit_testing_framework-0.3.0.post512+pr.81.b19-py3-none-any.whl", hash = "sha256:c52256580d4de9d2d9edf87e5df3fbfc36198272eba883f876a5f3f1b9b0b627"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "56223bfd031830c1e8d2626705f5d52794cf6f05118a35b35cde4dd4a6d96ff2"
+content-hash = "f8e8701c7081bf606424ec745cbec1d626d8b64805a005f3067ff257af4b1a61"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post510+pr.81.b17"
+version = "0.3.0.post511+pr.81.b18"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post510+pr.81.b17-py3-none-any.whl", hash = "sha256:2ac32dc515ee7b8280da966d4c95ba6daa15c3fe451f54d8c649f1c36667f387"},
+    {file = "summit_testing_framework-0.3.0.post511+pr.81.b18-py3-none-any.whl", hash = "sha256:6f6bebe8fd0c3bf98933e2fa8d6d7bde2420fcbfd146526d0eb5a907ee97c69b"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "0a5923933cefeadf82c13b1b1cc092a581ba409c9db042a91347531b7ddbda3d"
+content-hash = "56223bfd031830c1e8d2626705f5d52794cf6f05118a35b35cde4dd4a6d96ff2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post467+pr.76.b4"
+version = "0.3.0.post501+pr.81.b13"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post467+pr.76.b4-py3-none-any.whl", hash = "sha256:66e42bfdb79dad3efc050a4bb28fb600790dbdf28c4bf42cc5a38289a3c23090"},
+    {file = "summit_testing_framework-0.3.0.post501+pr.81.b13-py3-none-any.whl", hash = "sha256:9c8e2f5ceddcf760ef3ab5b6a62a48b59b50a6481f533d93efe5d5280f0ab599"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "cfbb2ef45021ce92de3482aa1452061bc94018941f10ce426f815216c7be1152"
+content-hash = "2fe485c397912b50015383d604ac924a6a8c25d0b0f2332e02335592225ebb4f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post501+pr.81.b13"
+version = "0.3.0.post510+pr.81.b17"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post501+pr.81.b13-py3-none-any.whl", hash = "sha256:9c8e2f5ceddcf760ef3ab5b6a62a48b59b50a6481f533d93efe5d5280f0ab599"},
+    {file = "summit_testing_framework-0.3.0.post510+pr.81.b17-py3-none-any.whl", hash = "sha256:2ac32dc515ee7b8280da966d4c95ba6daa15c3fe451f54d8c649f1c36667f387"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "2fe485c397912b50015383d604ac924a6a8c25d0b0f2332e02335592225ebb4f"
+content-hash = "0a5923933cefeadf82c13b1b1cc092a581ba409c9db042a91347531b7ddbda3d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post467+pr.76.b4"}
+summit-testing-framework = {version = "0.3.0.post501+pr.81.b13"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post510+pr.81.b17"}
+summit-testing-framework = {version = "0.3.0.post511+pr.81.b18"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post501+pr.81.b13"}
+summit-testing-framework = {version = "0.3.0.post510+pr.81.b17"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post511+pr.81.b18"}
+summit-testing-framework = {version = "0.3.0.post512+pr.81.b19"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import logging
 import time
 from collections.abc import Generator, Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
@@ -22,14 +21,11 @@ from summit_testing_framework.pytest_helpers.marker_helper import (
 from summit_testing_framework.setups.specifiers import (
     DictionaryType,
     DictionaryVersion,
-    RackServiceConfigSpecifier,
 )
 
 from tests.dictionaries import SAMPLE_SAFE_PH1_XDFV3_DICTIONARY
 
 if TYPE_CHECKING:
-    from summit_testing_framework.services.rack_service_client import RackServiceClient
-    from summit_testing_framework.setups import SetupDescriptor
     from summit_testing_framework.setups.specifiers import SetupSpecifier
 
     from ingeniamotion.axis import Axis
@@ -39,8 +35,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 __BISS_C_CONFIG_MARKER: str = "biss_c_flaky"
-__ABS1_SLAVE_INDEX = 1
-_VALID_ENCODER_PROTOCOLS = ["SSI1", "BIS3"]
 
 
 pytest_plugins = [
@@ -335,78 +329,3 @@ def sample_safe_ph2_xdfv3_dictionary(
         "EVS-S-NET-E",
         DictionaryVersion("2.9.1", DictionaryType.XDF_V3),
     )
-
-
-@dataclass(frozen=True)
-class EncoderConfiguration:
-    protocol: str
-    resolution: int
-
-    def __post_init__(self) -> None:
-        """Validate the protocol and resolution values.
-
-        Raises:
-            ValueError: If the protocol is not in the valid protocols list or
-                if the resolution is not a positive integer.
-        """
-        if self.protocol not in _VALID_ENCODER_PROTOCOLS:
-            raise ValueError(
-                f"Invalid protocol: {self.protocol}. Must be one of {_VALID_ENCODER_PROTOCOLS}."
-            )
-        if not isinstance(self.resolution, int) or self.resolution <= 0:
-            raise ValueError(f"Resolution must be a positive integer. Got: {self.resolution}.")
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "EncoderConfiguration":
-        """Create an EncoderConfiguration instance from a dictionary.
-
-        Args:
-            data: Dictionary containing 'protocol' and 'resolution' keys.
-
-        Returns:
-            EncoderConfiguration: An instance of EncoderConfiguration.
-
-        Raises:
-            ValueError: If the dictionary does not contain the required keys.
-        """
-        if "protocol" not in data or "resolution" not in data:
-            raise ValueError("Dictionary must contain 'protocol' and 'resolution' keys.")
-        return cls(protocol=data.get("protocol"), resolution=data.get("resolution"))
-
-
-@pytest.fixture(autouse=True, scope="session")
-def configure_abs_encoder(request: "pytest.FixtureRequest") -> None:
-    """Configure ABS1 through the rack service if the encoder is configurable."""
-    try:
-        setup_specifier: SetupSpecifier = request.getfixturevalue("setup_specifier")
-    # There are some tests that do not need any setup to run
-    except Exception:
-        return
-    encoder_dict_config = setup_specifier.extra_data.get("configure_encoder_protocol", None)
-    if not encoder_dict_config:
-        return
-    if not isinstance(setup_specifier, RackServiceConfigSpecifier):
-        return
-    setup_descriptor: SetupDescriptor = request.getfixturevalue("setup_descriptor")
-    rs_client: RackServiceClient = request.getfixturevalue("rs_client")
-
-    encoder_config: EncoderConfiguration = EncoderConfiguration.from_dict(encoder_dict_config)
-    logger.info(
-        f"Configuring ABS1 feedback through rack service with protocol {encoder_config.protocol} "
-        f"and resolution {encoder_config.resolution}..."
-    )
-
-    try:
-        rs_client.client.exposed_set_abs(
-            setup_descriptor.rack_drive_idx,
-            __ABS1_SLAVE_INDEX,
-            encoder_config.resolution,
-            encoder_config.protocol,
-        )
-
-        current_config = rs_client.client.exposed_get_abs(setup_descriptor.rack_drive_idx, 1)
-        assert current_config.protocol.name == encoder_config.protocol
-        assert current_config.resolution.n == encoder_config.resolution
-        logger.info("SIRIUS ABS1 feedback configured successfully.")
-    except Exception as exc:
-        pytest.fail(f"Unable to configure SIRIUS ABS1 feedback: {exc}", pytrace=False)

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -1,9 +1,12 @@
-import platform
-from pathlib import Path
-
 from ingenialink.dictionary import Interface
+from summit_testing_framework.configuration.encoder_configurator import (
+    EncoderConfiguration,
+    EncoderProtocol,
+)
+from summit_testing_framework.configuration.feedback_configuration import FeedbackConfiguration
 from summit_testing_framework.jenkins.pytest_config import PyTestConfig
 from summit_testing_framework.setups.specifier_container import SpecifierContainer
+from summit_testing_framework.setups.specifier_utils import dist_path
 from summit_testing_framework.setups.specifiers import (
     DictionaryType,
     MultiRackServiceConfigSpecifier,
@@ -13,25 +16,6 @@ from summit_testing_framework.setups.specifiers import (
 )
 
 import summit_drives_ci_configs.config_files as config_files
-
-
-def dist_path(p: str) -> Path:
-    """Converts a path string to a Path object, handling platform-specific nuances.
-
-    Args:
-        p: A string representing the path.
-
-    Returns:
-        A Path object corresponding to the given path string.
-    """
-    if platform.system().lower() == "windows":
-        return Path(p)
-    else:
-        # Convert //server/... to /server/...
-        if p.startswith("//"):
-            p = "/" + p.lstrip("/")
-        return Path(p)
-
 
 __EXECUTION_POLICY_KEY: str = "execution_policy"
 __TEST_CONFIGS_KEY: str = "test_configs"
@@ -341,8 +325,12 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
                         stage_name="SIRIUS EVS-NET-E Tests - FW. 2.10.0",
                     )
                 },
-                "configure_encoder_protocol": {"protocol": "SSI1", "resolution": 17},
             },
+            feedback_configuration=FeedbackConfiguration.from_configurable(
+                abs_encoder_1_configuration=EncoderConfiguration(
+                    protocol=EncoderProtocol.SSI1, resolution_bits=17
+                )
+            ),
         ),
         # BiSS-C tests are flaky on 2.10.0 should pass on 2.11.0
         "2.11.0.005": VersionConfig.from_files(
@@ -363,8 +351,12 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
                         stage_name="SIRIUS EVS-NET-E Tests - FW. 2.11.0.005",
                     )
                 },
-                "configure_encoder_protocol": {"protocol": "BIS3", "resolution": 17},
             },
+            feedback_configuration=FeedbackConfiguration.from_configurable(
+                abs_encoder_1_configuration=EncoderConfiguration(
+                    protocol=EncoderProtocol.BIS3, resolution_bits=17
+                )
+            ),
         ),
     },
 )

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -321,7 +321,7 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
                 __TEST_CONFIGS_KEY: {
                     "SIRIUS_TEST_SESSIONS": PyTestConfig(
                         markers="soem and biss_c_flaky",  # https://novantamotion.atlassian.net/browse/INGM-798
-                        run_test_stage_uid="sirius_evs_net_e_2.10.0",
+                        run_test_stage_uid="ethercat_everest_s_2.10.0",
                         stage_name="SIRIUS EVS-NET-E Tests - FW. 2.10.0",
                     )
                 },
@@ -347,7 +347,7 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
                 __TEST_CONFIGS_KEY: {
                     "SIRIUS_TEST_SESSIONS": PyTestConfig(
                         markers="soem and biss_c_flaky",
-                        run_test_stage_uid="sirius_evs_net_e_2.11.0.005",
+                        run_test_stage_uid="ethercat_everest_s_2.11.0.005",
                         stage_name="SIRIUS EVS-NET-E Tests - FW. 2.11.0.005",
                     )
                 },


### PR DESCRIPTION
This pull request refactors how encoder protocol configuration is handled in the test suite, moving from an ad-hoc dictionary-based approach to using structured configuration objects. It also removes now-unneeded code and updates dependencies accordingly.

**Refactoring encoder configuration handling:**

* Replaces the use of the `configure_encoder_protocol` dictionary in test configurations with a structured `feedback_configuration` object using `FeedbackConfiguration` and `EncoderConfiguration` in `tests/setups/rack_specifiers.py`. This makes encoder configuration more robust and type-safe. [[1]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L344-R333) [[2]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L366-R359)
* Imports and uses `EncoderConfiguration`, `EncoderProtocol`, and `FeedbackConfiguration` from the main framework instead of defining them locally.

**Code cleanup and removal:**

* Removes the local `EncoderConfiguration` dataclass, related validation logic, and the `configure_abs_encoder` pytest fixture from `tests/conftest.py`, as configuration is now handled via the main framework.
* Removes unused imports and variables in `tests/conftest.py` and deletes the local `dist_path` function from `tests/setups/rack_specifiers.py`, now using the version imported from the framework. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L5) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L25-L32) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L42-L43) [[4]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L17-L35)

**Dependency updates:**

* Updates `summit-testing-framework` to a newer version in `pyproject.toml` to support the new configuration approach.