### PR TITLE
Cit 765 move configuration register check from ingm to framework

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post512+pr.81.b19"
+version = "0.3.0.post517+pr.85.b6"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post512+pr.81.b19-py3-none-any.whl", hash = "sha256:c52256580d4de9d2d9edf87e5df3fbfc36198272eba883f876a5f3f1b9b0b627"},
+    {file = "summit_testing_framework-0.3.0.post517+pr.85.b6-py3-none-any.whl", hash = "sha256:a64701ad1c1f7daafa522cf4a8c273a832aa8631da15eccb9cc445f0dbf00dc5"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "f8e8701c7081bf606424ec745cbec1d626d8b64805a005f3067ff257af4b1a61"
+content-hash = "d401127f2703fc6ebef67775effff8c4919b010ccadd23d6d31cd8b77e3e2b89"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post501+pr.81.b13"
+version = "0.3.0.post502+pr.85.b1"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post501+pr.81.b13-py3-none-any.whl", hash = "sha256:9c8e2f5ceddcf760ef3ab5b6a62a48b59b50a6481f533d93efe5d5280f0ab599"},
+    {file = "summit_testing_framework-0.3.0.post502+pr.85.b1-py3-none-any.whl", hash = "sha256:309f262e2e47312d72aaf2f26297dd9eb2c01caf638a95eb259d6b85da8e6ea4"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "2fe485c397912b50015383d604ac924a6a8c25d0b0f2332e02335592225ebb4f"
+content-hash = "05237445c060b058c43a5cae4f09d39d42e424e11b25af7f9da48321e7854437"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post513+pr.85.b3"
+version = "0.3.0.post515+pr.85.b4"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post513+pr.85.b3-py3-none-any.whl", hash = "sha256:eb59fcae53232e24ad1a9c8d1b7c6435890ba2284bc903ce1948c5b81370150f"},
+    {file = "summit_testing_framework-0.3.0.post515+pr.85.b4-py3-none-any.whl", hash = "sha256:ab1822e011d2d22124382535b5ffb8fedc5a6529726d23f39619f6e688cf1ca8"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "8ccad7bfdbe04c128f8dfd8ec2ae5b90939898d39228b2e4ac26f38e578e5166"
+content-hash = "0240e3e7e61145b181255df9e0f9da483de78e1bfa7d85d7486fda0761ff072a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post515+pr.85.b4"}
+summit-testing-framework = {version = "0.3.0.post517+pr.85.b6"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post513+pr.85.b3"}
+summit-testing-framework = {version = "0.3.0.post515+pr.85.b4"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post501+pr.81.b13"}
+summit-testing-framework = {version = "0.3.0.post502+pr.85.b1"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,20 +8,16 @@ from typing import TYPE_CHECKING, Callable, Optional, Union
 import numpy as np
 import pytest
 from ingenialink import Servo
-from ingenialink.configuration_file import ConfigurationFile
 from ingenialink.dictionary import Interface
 from ingenialink.exceptions import ILRegisterNotFoundError
-from ingenialink.utils._utils import convert_bytes_to_dtype
 from summit_testing_framework import dynamic_loader
+from summit_testing_framework.configuration.config_checker import ConfigChecker
 from summit_testing_framework.profilers.stoppable_gaps import StoppableProfilerConfig
 from summit_testing_framework.pytest_helpers.marker_helper import (
     MarkerHelper,
     apply_firmware_version_markers_to_items,
 )
-from summit_testing_framework.setups.specifiers import (
-    DictionaryType,
-    DictionaryVersion,
-)
+from summit_testing_framework.setups.specifiers import DictionaryType, DictionaryVersion
 
 from tests.dictionaries import SAMPLE_SAFE_PH1_XDFV3_DICTIONARY
 
@@ -89,39 +85,22 @@ def __config_uses_biss_c(config_file: Path) -> bool:
     Returns:
         bool: True if the configuration file uses BISS-C protocol, False otherwise.
     """
+    config_checker: ConfigChecker = ConfigChecker(config_file=config_file)
 
-    # Check if absolute encoder is present in feedback sensor
+    # Check if Primary Absolute Slave 1 (=1) or Secondary Absolute Slave 1 (=7)
+    # are selected in some of the possible feedback sensors registers:
     # CL_VEL_FBK_SENSOR, CL_POS_FBK_SENSOR, COMMU_ANGLE_SENSOR
-    position_feedback_registers = ["CL_VEL_FBK_SENSOR", "CL_POS_FBK_SENSOR", "COMMU_ANGLE_SENSOR"]
-    encoder_protocol_registers = ["FBK_BISS1_SSI1_PROTOCOL", "FBK_SSI2_PROTOCOL"]
-    # Primary Absolute Slave 1: 1, Secondary Absolute Slave 1: 2
-    search_registers = dict.fromkeys(position_feedback_registers + encoder_protocol_registers, None)
-
-    xcf_instance = ConfigurationFile.load_from_xcf(config_file)
-    for config_register in xcf_instance.registers:
-        if config_register.uid in search_registers:
-            search_registers[config_register.uid] = (
-                convert_bytes_to_dtype(config_register.data, config_register.dtype)
-                if config_register.data is not None
-                else config_register.storage
-            )
-
-        if all(value is not None for value in search_registers.values()):
-            break
-
-    for register in position_feedback_registers:
-        if search_registers[register] is None:
-            continue
-
-        # Primary Absolute Slave 1 selected
-        if search_registers[register] == 1:
-            if search_registers[encoder_protocol_registers[0]] == 0:
-                return True
-        # Secondary Absolute Slave 1 selected
-        elif (
-            search_registers[register] == 7 and search_registers[encoder_protocol_registers[1]] == 0
-        ):
+    # If they are, then check if the corresponding encoder protocol is BISS-C (=0)
+    for register in ["CL_VEL_FBK_SENSOR", "CL_POS_FBK_SENSOR", "COMMU_ANGLE_SENSOR"]:
+        if config_checker.register_has_expected_value(
+            register, 1
+        ) and config_checker.register_has_expected_value("FBK_BISS1_SSI1_PROTOCOL", 0):
             return True
+        if config_checker.register_has_expected_value(
+            register, 7
+        ) and config_checker.register_has_expected_value("FBK_SSI2_PROTOCOL", 0):
+            return True
+
     return False
 
 


### PR DESCRIPTION
This pull request updates the dependency on `summit-testing-framework` and refactors the `__config_uses_biss_c` function in `tests/conftest.py` to use the new `ConfigChecker` utility, simplifying the logic for checking configuration files. The main changes are grouped as follows:

Dependency updates:

* Updated the `summit-testing-framework` dependency in `pyproject.toml` from version `0.3.0.post501+pr.81.b13` to `0.3.0.post502+pr.85.b1`, ensuring the latest features and fixes are available.

Test configuration refactor:

* Refactored the `__config_uses_biss_c` function in `tests/conftest.py` to use the new `ConfigChecker` class, significantly simplifying the logic for determining if a configuration file uses the BISS-C protocol. The new implementation replaces manual parsing and register checks with calls to `ConfigChecker.register_has_expected_value`.
* Removed unused imports (`ConfigurationFile`, `convert_bytes_to_dtype`) from `tests/conftest.py` and added the import for `ConfigChecker`, reflecting the updated logic.