### PR TITLE
Ingm 780 fix test get actual position

### DIFF
--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -312,26 +312,6 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
     part_number=PartNumber.EVS_NET_E,
     interface=Interface.ECAT,
     version_configs={
-        "2.10.0": VersionConfig.from_version(
-            version="2.10.0",
-            config_file=config_files.SIRIUS_EVS_NET_E_2_10_0_CONFIG,
-            dictionary_type=DictionaryType.XDF_V3,
-            extra_data={
-                __EXECUTION_POLICY_KEY: "always",
-                __TEST_CONFIGS_KEY: {
-                    "SIRIUS_TEST_SESSIONS": PyTestConfig(
-                        markers="soem and biss_c_flaky",  # https://novantamotion.atlassian.net/browse/INGM-798
-                        run_test_stage_uid="ethercat_everest_s_2.10.0",
-                        stage_name="SIRIUS EVS-NET-E Tests - FW. 2.10.0",
-                    )
-                },
-            },
-            feedback_configuration=FeedbackConfiguration.from_configurable(
-                abs_encoder_1_configuration=EncoderConfiguration(
-                    protocol=EncoderProtocol.SSI1, resolution_bits=17
-                )
-            ),
-        ),
         # BiSS-C tests are flaky on 2.10.0 should pass on 2.11.0
         "2.11.0.005": VersionConfig.from_files(
             version="2.11.0.005",
@@ -355,6 +335,26 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
             feedback_configuration=FeedbackConfiguration.from_configurable(
                 abs_encoder_1_configuration=EncoderConfiguration(
                     protocol=EncoderProtocol.BIS3, resolution_bits=17
+                )
+            ),
+        ),
+        "2.10.0": VersionConfig.from_version(
+            version="2.10.0",
+            config_file=config_files.SIRIUS_EVS_NET_E_2_10_0_CONFIG,
+            dictionary_type=DictionaryType.XDF_V3,
+            extra_data={
+                __EXECUTION_POLICY_KEY: "always",
+                __TEST_CONFIGS_KEY: {
+                    "SIRIUS_TEST_SESSIONS": PyTestConfig(
+                        markers="soem and biss_c_flaky",  # https://novantamotion.atlassian.net/browse/INGM-798
+                        run_test_stage_uid="ethercat_everest_s_2.10.0",
+                        stage_name="SIRIUS EVS-NET-E Tests - FW. 2.10.0",
+                    )
+                },
+            },
+            feedback_configuration=FeedbackConfiguration.from_configurable(
+                abs_encoder_1_configuration=EncoderConfiguration(
+                    protocol=EncoderProtocol.SSI1, resolution_bits=17
                 )
             ),
         ),

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -312,6 +312,26 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
     part_number=PartNumber.EVS_NET_E,
     interface=Interface.ECAT,
     version_configs={
+        "2.10.0": VersionConfig.from_version(
+            version="2.10.0",
+            config_file=config_files.SIRIUS_EVS_NET_E_2_10_0_CONFIG,
+            dictionary_type=DictionaryType.XDF_V3,
+            extra_data={
+                __EXECUTION_POLICY_KEY: "always",
+                __TEST_CONFIGS_KEY: {
+                    "SIRIUS_TEST_SESSIONS": PyTestConfig(
+                        markers="soem and biss_c_flaky",  # https://novantamotion.atlassian.net/browse/INGM-798
+                        run_test_stage_uid="ethercat_everest_s_2.10.0",
+                        stage_name="SIRIUS EVS-NET-E Tests - FW. 2.10.0",
+                    )
+                },
+            },
+            feedback_configuration=FeedbackConfiguration.from_configurable(
+                abs_encoder_1_configuration=EncoderConfiguration(
+                    protocol=EncoderProtocol.SSI1, resolution_bits=17
+                )
+            ),
+        ),
         # BiSS-C tests are flaky on 2.10.0 should pass on 2.11.0
         "2.11.0.005": VersionConfig.from_files(
             version="2.11.0.005",
@@ -335,26 +355,6 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
             feedback_configuration=FeedbackConfiguration.from_configurable(
                 abs_encoder_1_configuration=EncoderConfiguration(
                     protocol=EncoderProtocol.BIS3, resolution_bits=17
-                )
-            ),
-        ),
-        "2.10.0": VersionConfig.from_version(
-            version="2.10.0",
-            config_file=config_files.SIRIUS_EVS_NET_E_2_10_0_CONFIG,
-            dictionary_type=DictionaryType.XDF_V3,
-            extra_data={
-                __EXECUTION_POLICY_KEY: "always",
-                __TEST_CONFIGS_KEY: {
-                    "SIRIUS_TEST_SESSIONS": PyTestConfig(
-                        markers="soem and biss_c_flaky",  # https://novantamotion.atlassian.net/browse/INGM-798
-                        run_test_stage_uid="ethercat_everest_s_2.10.0",
-                        stage_name="SIRIUS EVS-NET-E Tests - FW. 2.10.0",
-                    )
-                },
-            },
-            feedback_configuration=FeedbackConfiguration.from_configurable(
-                abs_encoder_1_configuration=EncoderConfiguration(
-                    protocol=EncoderProtocol.SSI1, resolution_bits=17
                 )
             ),
         ),

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -382,6 +382,7 @@ def test_ramp_generator(mocker, init_v, final_v, total_t, t, result):
 @pytest.mark.biss_c_flaky(
     "Sporadically fails on ABS BiSS-C config, will be skipped for certain firmware versions"
 )
+@pytest.mark.repeat(100)
 def test_get_actual_position(mc, alias, position_value):
     mc.motion.set_operation_mode(OperationMode.PROFILE_POSITION, servo=alias)
     mc.motion.motor_enable(servo=alias)

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -379,8 +379,10 @@ def test_ramp_generator(mocker, init_v, final_v, total_t, t, result):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("position_value", [-4000, -1000, 1000, 4000])
-# https://novantamotion.atlassian.net/browse/INGM-780
-@pytest.mark.not_valid_for_product(part_number="CAP-XCR-E")
+@pytest.mark.biss_c_flaky(
+    "Sporadically fails on ABS BiSS-C config, will be skipped for certain firmware versions"
+)
+@pytest.mark.repeat(100)
 @pytest.mark.not_valid_for_product(part_number="EVE-*")
 def test_get_actual_position(mc, alias, position_value):
     mc.motion.set_operation_mode(OperationMode.PROFILE_POSITION, servo=alias)

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -382,14 +382,14 @@ def test_ramp_generator(mocker, init_v, final_v, total_t, t, result):
 @pytest.mark.biss_c_flaky(
     "Sporadically fails on ABS BiSS-C config, will be skipped for certain firmware versions"
 )
-@pytest.mark.repeat(100)
+@pytest.mark.repeat(20)
 def test_get_actual_position(mc, alias, position_value):
     mc.motion.set_operation_mode(OperationMode.PROFILE_POSITION, servo=alias)
     mc.motion.motor_enable(servo=alias)
     mc.motion.move_to_position(position_value, servo=alias, blocking=True, timeout=10)
 
     # Wait for the position to stabilize
-    stability_timeout = 10
+    stability_timeout = 3
     stability_interval = 0.1
     stable_samples_required = 5
     stable_positions = []

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -383,7 +383,8 @@ def test_ramp_generator(mocker, init_v, final_v, total_t, t, result):
     "Sporadically fails on ABS BiSS-C config, will be skipped for certain firmware versions"
 )
 @pytest.mark.not_valid_for_product(part_number="EVE-*")
-def test_get_actual_position(mc, alias, position_value):
+def test_get_actual_position(mc: "MotionController", alias: str, position_value: int) -> None:
+    position_resolution = mc.configuration.get_position_feedback_resolution(servo=alias)
     mc.motion.set_operation_mode(OperationMode.PROFILE_POSITION, servo=alias)
     mc.motion.motor_enable(servo=alias)
     mc.motion.move_to_position(position_value, servo=alias, blocking=True, timeout=10)
@@ -391,7 +392,7 @@ def test_get_actual_position(mc, alias, position_value):
     # Wait for the position to stabilize
     stability_timeout = 3
     stability_interval = 0.1
-    stability_tolerance = 20
+    stability_tolerance = position_resolution * POSITION_PERCENTAGE_ERROR_ALLOWED / 100
     stable_samples_required = 5
     stable_positions = []
     stability_start_time = time.monotonic()

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -383,7 +383,13 @@ def test_ramp_generator(mocker, init_v, final_v, total_t, t, result):
     "Sporadically fails on ABS BiSS-C config, will be skipped for certain firmware versions"
 )
 @pytest.mark.repeat(100)
-def test_get_actual_position(mc, alias, position_value):
+def test_get_actual_position(mc, alias, position_value, environment):
+    try:
+        mc.motor_enable(servo=alias)
+    except Exception:
+        environment.power_cycle_and_load_configuration(
+            wait_for_drives=False, reconnect_drives=True, reconnect_timeout=20
+        )
     mc.motion.set_operation_mode(OperationMode.PROFILE_POSITION, servo=alias)
     mc.motion.motor_enable(servo=alias)
     mc.motion.move_to_position(position_value, servo=alias, blocking=True, timeout=10)

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -382,14 +382,7 @@ def test_ramp_generator(mocker, init_v, final_v, total_t, t, result):
 @pytest.mark.biss_c_flaky(
     "Sporadically fails on ABS BiSS-C config, will be skipped for certain firmware versions"
 )
-@pytest.mark.repeat(100)
-def test_get_actual_position(mc, alias, position_value, environment):
-    try:
-        mc.motor_enable(servo=alias)
-    except Exception:
-        environment.power_cycle_and_load_configuration(
-            wait_for_drives=False, reconnect_drives=True, reconnect_timeout=20
-        )
+def test_get_actual_position(mc, alias, position_value):
     mc.motion.set_operation_mode(OperationMode.PROFILE_POSITION, servo=alias)
     mc.motion.motor_enable(servo=alias)
     mc.motion.move_to_position(position_value, servo=alias, blocking=True, timeout=10)

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -391,6 +391,7 @@ def test_get_actual_position(mc, alias, position_value):
     # Wait for the position to stabilize
     stability_timeout = 3
     stability_interval = 0.1
+    stability_tolerance = 20
     stable_samples_required = 5
     stable_positions = []
     stability_start_time = time.monotonic()
@@ -398,7 +399,7 @@ def test_get_actual_position(mc, alias, position_value):
         stable_positions.append(mc.motion.get_actual_position(servo=alias))
         if (
             len(stable_positions) >= stable_samples_required
-            and np.ptp(stable_positions[-stable_samples_required:]) <= 1
+            and np.ptp(stable_positions[-stable_samples_required:]) <= stability_tolerance
         ):
             break
         time.sleep(stability_interval)

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -387,6 +387,27 @@ def test_get_actual_position(mc, alias, position_value):
     mc.motion.set_operation_mode(OperationMode.PROFILE_POSITION, servo=alias)
     mc.motion.motor_enable(servo=alias)
     mc.motion.move_to_position(position_value, servo=alias, blocking=True, timeout=10)
+
+    # Wait for the position to stabilize
+    stability_timeout = 10
+    stability_interval = 0.1
+    stable_samples_required = 5
+    stable_positions = []
+    stability_start_time = time.monotonic()
+    while time.monotonic() - stability_start_time < stability_timeout:
+        stable_positions.append(mc.motion.get_actual_position(servo=alias))
+        if (
+            len(stable_positions) >= stable_samples_required
+            and np.ptp(stable_positions[-stable_samples_required:]) <= 1
+        ):
+            break
+        time.sleep(stability_interval)
+    else:
+        raise AssertionError(
+            f"Position did not stabilize within {stability_timeout} seconds: "
+            f"last positions={stable_positions[-stable_samples_required:]}"
+        )
+
     n_samples = 200
     test_position = np.zeros(n_samples)
     reg_value = np.zeros(n_samples)

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -382,7 +382,7 @@ def test_ramp_generator(mocker, init_v, final_v, total_t, t, result):
 @pytest.mark.biss_c_flaky(
     "Sporadically fails on ABS BiSS-C config, will be skipped for certain firmware versions"
 )
-@pytest.mark.repeat(20)
+@pytest.mark.not_valid_for_product(part_number="EVE-*")
 def test_get_actual_position(mc, alias, position_value):
     mc.motion.set_operation_mode(OperationMode.PROFILE_POSITION, servo=alias)
     mc.motion.motor_enable(servo=alias)

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -383,7 +383,6 @@ def test_ramp_generator(mocker, init_v, final_v, total_t, t, result):
     "Sporadically fails on ABS BiSS-C config, will be skipped for certain firmware versions"
 )
 @pytest.mark.repeat(100)
-@pytest.mark.not_valid_for_product(part_number="EVE-*")
 def test_get_actual_position(mc, alias, position_value):
     mc.motion.set_operation_mode(OperationMode.PROFILE_POSITION, servo=alias)
     mc.motion.motor_enable(servo=alias)


### PR DESCRIPTION
The failure for ECAT product was the same than in https://github.com/ingeniamc/ingeniamotion/pull/613, invalid CRC message from the absolute encoder with BiSS-C protocol.

This is a known issue that is supposed to be fixed in the upcoming 2.11.0 release, so it has been marked as `biss_c_flaky`, and will be skipped for fw <= 2.10.0. This test now runs in SIRIUS setup.

With 100 repeated runs, it still failed sometimes, but with an assertion error due to the strict comparison:
<img width="1414" height="726" alt="image" src="https://github.com/user-attachments/assets/7f2d443d-e23f-4201-b0d9-4242aabb2c3c" />
The captured arrays show the position is still changing slightly while those samples are collected. Because of that, a new waiting time has been introduced to wait for the drive to stabilize in the desired position. After that, the samples are taken and compared against the 0.5 threshold.

Changes tested on commit https://github.com/ingeniamc/ingeniamotion/pull/644/changes/74b245fc4bc2b64b1cbf84f3847227c3621e9068 with [this pipeline](http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingeniamotion/job/PR-644/14/stages/?selected-node=401) (link may expire):
* 80 tests pass with SSI protocol (expected - no CRC check)
* 80 tests pass with rc and BiSS-C protocol: upcoming release does fix the issue