### PR TITLE
Cit 758 power cycle load configuration method in environment

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post525+pr.86.b7"
+version = "0.3.0.post528+pr.86.b11"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post525+pr.86.b7-py3-none-any.whl", hash = "sha256:16f711e27673af8bf3881a1b3f3d9f8da1ea4fffab1ed4c24b20b4eb275db97b"},
+    {file = "summit_testing_framework-0.3.0.post528+pr.86.b11-py3-none-any.whl", hash = "sha256:96bcf52b8bec5582dd8ce89bd10564e830b8d72263dee6e8e1416fa645601072"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "55af221594da0f5914f355067b3303d0d9222958c918d2b6e727e954d6638296"
+content-hash = "e5ff4fa9be8345316b8696cd9804507394ff77048054afaca384239ee625cea6"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post502+pr.85.b1"
+version = "0.3.0.post504+pr.86.b1"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post502+pr.85.b1-py3-none-any.whl", hash = "sha256:309f262e2e47312d72aaf2f26297dd9eb2c01caf638a95eb259d6b85da8e6ea4"},
+    {file = "summit_testing_framework-0.3.0.post504+pr.86.b1-py3-none-any.whl", hash = "sha256:18f5f280417d7f19c5de3740ea4c88dbcba8d334c62e0353c005901da1b530d1"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "05237445c060b058c43a5cae4f09d39d42e424e11b25af7f9da48321e7854437"
+content-hash = "aa052f07ee143ee178bfeda4279bbcc71e2e01e018ed9e3d1b44302f6f911bd9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post524+pr.86.b6"
+version = "0.3.0.post525+pr.86.b7"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post524+pr.86.b6-py3-none-any.whl", hash = "sha256:50b73f8c7a4c53404b42c27a3ea94910bd8589f62ff33039de0ef5cde0389618"},
+    {file = "summit_testing_framework-0.3.0.post525+pr.86.b7-py3-none-any.whl", hash = "sha256:16f711e27673af8bf3881a1b3f3d9f8da1ea4fffab1ed4c24b20b4eb275db97b"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "7b885162b71cb0eaa9266ce08cbc715eaaafff78ba9347de12aaec079e27aa0c"
+content-hash = "55af221594da0f5914f355067b3303d0d9222958c918d2b6e727e954d6638296"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post521+pr.86.b4"
+version = "0.3.0.post524+pr.86.b6"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post521+pr.86.b4-py3-none-any.whl", hash = "sha256:ae13f28c380f2824f36147f6e3fdacd719c2e1b27b7c5ed661a8abdfcd93550f"},
+    {file = "summit_testing_framework-0.3.0.post524+pr.86.b6-py3-none-any.whl", hash = "sha256:50b73f8c7a4c53404b42c27a3ea94910bd8589f62ff33039de0ef5cde0389618"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "d2e7c95da129aa7dccd96d771c151563edc2b813a13a897b430d0f7f34ad012e"
+content-hash = "7b885162b71cb0eaa9266ce08cbc715eaaafff78ba9347de12aaec079e27aa0c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,13 +4213,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.3.0.post504+pr.86.b1"
+version = "0.3.0.post521+pr.86.b4"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.3.0.post504+pr.86.b1-py3-none-any.whl", hash = "sha256:18f5f280417d7f19c5de3740ea4c88dbcba8d334c62e0353c005901da1b530d1"},
+    {file = "summit_testing_framework-0.3.0.post521+pr.86.b4-py3-none-any.whl", hash = "sha256:ae13f28c380f2824f36147f6e3fdacd719c2e1b27b7c5ed661a8abdfcd93550f"},
 ]
 
 [package.dependencies]
@@ -4785,4 +4785,4 @@ fsoe = ["fsoe_master"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "aa052f07ee143ee178bfeda4279bbcc71e2e01e018ed9e3d1b44302f6f911bd9"
+content-hash = "d2e7c95da129aa7dccd96d771c151563edc2b813a13a897b430d0f7f34ad012e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post502+pr.85.b1"}
+summit-testing-framework = {version = "0.3.0.post504+pr.86.b1"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post525+pr.86.b7"}
+summit-testing-framework = {version = "0.3.0.post528+pr.86.b11"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post521+pr.86.b4"}
+summit-testing-framework = {version = "0.3.0.post524+pr.86.b6"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post524+pr.86.b6"}
+summit-testing-framework = {version = "0.3.0.post525+pr.86.b7"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ pytest-repeat = "==0.9.4"
 pytest-rerunfailures = "==15.1"
 pytest-console-scripts = "==1.4.1"
 matplotlib = "==3.8.2"
-summit-testing-framework = {version = "0.3.0.post504+pr.86.b1"}
+summit-testing-framework = {version = "0.3.0.post521+pr.86.b4"}
 ingenialink = {version = "7.6.1.post216+develop.5e466f4"}
 
 # -----------------------------------------------------------------------

--- a/tests/fsoe/test_safety_errors.py
+++ b/tests/fsoe/test_safety_errors.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable
 import pytest
 from ingenialink.dictionary import Interface
 from ingenialink.servo import DictionaryFactory
+from summit_testing_framework.connection.reconnect_utils import power_cycle_and_restore
 from summit_testing_framework.setups.specifiers import PartNumber
 
 from ingeniamotion.fsoe import FSOE_MASTER_INSTALLED, FSoEState
@@ -16,6 +17,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from ingenialink.ethercat.servo import EthercatServo
+    from summit_testing_framework.connection.reconnect_utils import ConnectionWrapper
     from summit_testing_framework.setups.descriptors import DriveHwSetup
     from summit_testing_framework.setups.environment_control import (
         ManualUserEnvironmentController,
@@ -70,11 +72,16 @@ def test_get_error_with_id_not_in_dict(sample_safe_ph2_xdfv3_dictionary: str) ->
 def test_no_errors(
     mcu_error_queue_a: "ServoErrorQueue",
     environment: "ManualUserEnvironmentController",
+    connection_wrapper: "ConnectionWrapper",
 ) -> None:
     """Test methods when there are no errors"""
     # Clear any existing errors by power cycling
-    environment.power_cycle_and_load_configuration(
-        wait_for_drives=False, reconnect_drives=True, reconnect_timeout=30
+    power_cycle_and_restore(
+        environment=environment,
+        connection_wrapper=connection_wrapper,
+        wait_for_drives=False,
+        reconnect_drives=True,
+        reconnect_timeout=30,
     )
 
     assert mcu_error_queue_a.get_number_total_errors() == 0
@@ -91,11 +98,16 @@ def test_get_last_error_overtemp_error(
     servo: "EthercatServo",
     mcu_error_queue_a: "ServoErrorQueue",
     environment: "ManualUserEnvironmentController",
+    connection_wrapper: "ConnectionWrapper",
 ) -> None:
     """Test getting the last error when there is an overtemperature error."""
     # Clear any existing errors by power cycling
-    environment.power_cycle_and_load_configuration(
-        wait_for_drives=False, reconnect_drives=True, reconnect_timeout=30
+    power_cycle_and_restore(
+        environment=environment,
+        connection_wrapper=connection_wrapper,
+        wait_for_drives=False,
+        reconnect_drives=True,
+        reconnect_timeout=30,
     )
 
     servo.write("FSOE_USER_OVER_TEMPERATURE", 0, subnode=1)
@@ -122,11 +134,16 @@ def test_get_last_error_invalid_map(
     mcu_error_queue_a: "ServoErrorQueue",
     mc_with_fsoe_with_sra_no_fail_on_errors: tuple["MotionController", "FSoEMasterHandler"],
     environment: "ManualUserEnvironmentController",
+    connection_wrapper: "ConnectionWrapper",
     timeout_for_data_sra: float,
 ) -> None:
     """Test getting the last error when there is an invalid map error."""
-    environment.power_cycle_and_load_configuration(
-        wait_for_drives=False, reconnect_drives=True, reconnect_timeout=30
+    power_cycle_and_restore(
+        environment=environment,
+        connection_wrapper=connection_wrapper,
+        wait_for_drives=False,
+        reconnect_drives=True,
+        reconnect_timeout=30,
     )
 
     mc, handler = mc_with_fsoe_with_sra_no_fail_on_errors

--- a/tests/fsoe/test_safety_errors.py
+++ b/tests/fsoe/test_safety_errors.py
@@ -17,7 +17,9 @@ except ImportError:
 if TYPE_CHECKING:
     from ingenialink.ethercat.servo import EthercatServo
     from summit_testing_framework.setups.descriptors import DriveHwSetup
-    from summit_testing_framework.setups.environment_control import DriveEnvironmentController
+    from summit_testing_framework.setups.environment_control import (
+        ManualUserEnvironmentController,
+    )
 
     from ingeniamotion.motion_controller import MotionController
 
@@ -67,11 +69,13 @@ def test_get_error_with_id_not_in_dict(sample_safe_ph2_xdfv3_dictionary: str) ->
 @pytest.mark.fsoe_phase2
 def test_no_errors(
     mcu_error_queue_a: "ServoErrorQueue",
-    environment: "DriveEnvironmentController",
+    environment: "ManualUserEnvironmentController",
 ) -> None:
     """Test methods when there are no errors"""
     # Clear any existing errors by power cycling
-    environment.power_cycle(wait_for_drives=False, reconnect_drives=True, reconnect_timeout=30)
+    environment.power_cycle_and_load_configuration(
+        wait_for_drives=False, reconnect_drives=True, reconnect_timeout=30
+    )
 
     assert mcu_error_queue_a.get_number_total_errors() == 0
 
@@ -86,11 +90,13 @@ def test_no_errors(
 def test_get_last_error_overtemp_error(
     servo: "EthercatServo",
     mcu_error_queue_a: "ServoErrorQueue",
-    environment: "DriveEnvironmentController",
+    environment: "ManualUserEnvironmentController",
 ) -> None:
     """Test getting the last error when there is an overtemperature error."""
     # Clear any existing errors by power cycling
-    environment.power_cycle(wait_for_drives=False, reconnect_drives=True, reconnect_timeout=30)
+    environment.power_cycle_and_load_configuration(
+        wait_for_drives=False, reconnect_drives=True, reconnect_timeout=30
+    )
 
     servo.write("FSOE_USER_OVER_TEMPERATURE", 0, subnode=1)
 
@@ -115,11 +121,13 @@ def mc_with_fsoe_with_sra_no_fail_on_errors(
 def test_get_last_error_invalid_map(
     mcu_error_queue_a: "ServoErrorQueue",
     mc_with_fsoe_with_sra_no_fail_on_errors: tuple["MotionController", "FSoEMasterHandler"],
-    environment: "DriveEnvironmentController",
+    environment: "ManualUserEnvironmentController",
     timeout_for_data_sra: float,
 ) -> None:
     """Test getting the last error when there is an invalid map error."""
-    environment.power_cycle(wait_for_drives=False, reconnect_drives=True, reconnect_timeout=30)
+    environment.power_cycle_and_load_configuration(
+        wait_for_drives=False, reconnect_drives=True, reconnect_timeout=30
+    )
 
     mc, handler = mc_with_fsoe_with_sra_no_fail_on_errors
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from ingenialink.exceptions import ILError
+from summit_testing_framework.connection.reconnect_utils import power_cycle_and_restore
 
 from ingeniamotion.errors import (
     COCO_ERROR_QUEUE,
@@ -21,6 +22,7 @@ from ingeniamotion.exceptions import IMErrorQueueNotExistsError
 
 if TYPE_CHECKING:
     from ingenialink.servo import Servo
+    from summit_testing_framework.connection.reconnect_utils import ConnectionWrapper
     from summit_testing_framework.setups.environment_control import (
         ManualUserEnvironmentController,
     )
@@ -311,10 +313,15 @@ class TestErrors:
         servo: "Servo",
         alias: str,
         environment: "ManualUserEnvironmentController",
+        connection_wrapper: "ConnectionWrapper",
     ) -> None:
         """Test ServoErrorQueue with no errors present."""
-        environment.power_cycle_and_load_configuration(
-            wait_for_drives=False, reconnect_drives=True, reconnect_timeout=20
+        power_cycle_and_restore(
+            environment=environment,
+            connection_wrapper=connection_wrapper,
+            wait_for_drives=False,
+            reconnect_drives=True,
+            reconnect_timeout=20,
         )
 
         mc.motion.fault_reset(servo=alias)
@@ -351,10 +358,15 @@ class TestErrors:
         servo: "Servo",
         alias: str,
         environment: "ManualUserEnvironmentController",
+        connection_wrapper: "ConnectionWrapper",
     ) -> None:
         """Test that ServoErrorQueue only reports new errors after first call."""
-        environment.power_cycle_and_load_configuration(
-            wait_for_drives=False, reconnect_drives=True, reconnect_timeout=20
+        power_cycle_and_restore(
+            environment=environment,
+            connection_wrapper=connection_wrapper,
+            wait_for_drives=False,
+            reconnect_drives=True,
+            reconnect_timeout=20,
         )
 
         error_queue = ServoErrorQueue(MOCO_ERROR_QUEUE, servo)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -21,7 +21,9 @@ from ingeniamotion.exceptions import IMErrorQueueNotExistsError
 
 if TYPE_CHECKING:
     from ingenialink.servo import Servo
-    from summit_testing_framework.setups.environment_control import DriveEnvironmentController
+    from summit_testing_framework.setups.environment_control import (
+        ManualUserEnvironmentController,
+    )
 
     from ingeniamotion.axis import Axis
     from ingeniamotion.motion_controller import MotionController
@@ -308,10 +310,12 @@ class TestErrors:
         mc: "MotionController",
         servo: "Servo",
         alias: str,
-        environment: "DriveEnvironmentController",
+        environment: "ManualUserEnvironmentController",
     ) -> None:
         """Test ServoErrorQueue with no errors present."""
-        environment.power_cycle(wait_for_drives=False, reconnect_drives=True, reconnect_timeout=20)
+        environment.power_cycle_and_load_configuration(
+            wait_for_drives=False, reconnect_drives=True, reconnect_timeout=20
+        )
 
         mc.motion.fault_reset(servo=alias)
         error_queue = ServoErrorQueue(MOCO_ERROR_QUEUE, servo)
@@ -346,10 +350,12 @@ class TestErrors:
         mc: "MotionController",
         servo: "Servo",
         alias: str,
-        environment: "DriveEnvironmentController",
+        environment: "ManualUserEnvironmentController",
     ) -> None:
         """Test that ServoErrorQueue only reports new errors after first call."""
-        environment.power_cycle(wait_for_drives=False, reconnect_drives=True, reconnect_timeout=20)
+        environment.power_cycle_and_load_configuration(
+            wait_for_drives=False, reconnect_drives=True, reconnect_timeout=20
+        )
 
         error_queue = ServoErrorQueue(MOCO_ERROR_QUEUE, servo)
 


### PR DESCRIPTION
This pull request updates the test suite to use the ManualUserEnvironmentController instead of DriveEnvironmentController and replaces calls to power_cycle with power_cycle_and_load_configuration. It also updates the summit-testing-framework dependency version.

Dependency update:

Updated summit-testing-framework to version 0.3.0.post504+pr.86.b1 in pyproject.toml to ensure compatibility with the new environment controller and test behaviors.
Test environment changes:

Replaced references to DriveEnvironmentController with ManualUserEnvironmentController in type hints and imports in both tests/fsoe/test_safety_errors.py and tests/test_errors.py. [[1]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-a26fe5e8f9f12613b2e4b8e472523420e411efd741d9c131226577394803c940L20-R22) [[2]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-6e5030d96839d3fe377cf209b6cab5b0d50ae900b458248d8c24b61774117170L24-R26) [[3]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-a26fe5e8f9f12613b2e4b8e472523420e411efd741d9c131226577394803c940L70-R78) [[4]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-a26fe5e8f9f12613b2e4b8e472523420e411efd741d9c131226577394803c940L89-R99) [[5]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-a26fe5e8f9f12613b2e4b8e472523420e411efd741d9c131226577394803c940L118-R130) [[6]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-6e5030d96839d3fe377cf209b6cab5b0d50ae900b458248d8c24b61774117170L311-R318) [[7]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-6e5030d96839d3fe377cf209b6cab5b0d50ae900b458248d8c24b61774117170L349-R358)
Updated test setup calls from environment.power_cycle to environment.power_cycle_and_load_configuration to better reflect the new environment control interface and ensure proper configuration loading after power cycling. [[1]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-a26fe5e8f9f12613b2e4b8e472523420e411efd741d9c131226577394803c940L70-R78) [[2]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-a26fe5e8f9f12613b2e4b8e472523420e411efd741d9c131226577394803c940L89-R99) [[3]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-a26fe5e8f9f12613b2e4b8e472523420e411efd741d9c131226577394803c940L118-R130) [[4]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-6e5030d96839d3fe377cf209b6cab5b0d50ae900b458248d8c24b61774117170L311-R318) [[5]](https://github.com/ingeniamc/ingeniamotion/pull/642/files#diff-6e5030d96839d3fe377cf209b6cab5b0d50ae900b458248d8c24b61774117170L349-R358)