### PR TITLE
Ingm 781 fix test get actual velocity

### DIFF
--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -312,26 +312,6 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
     part_number=PartNumber.EVS_NET_E,
     interface=Interface.ECAT,
     version_configs={
-        "2.10.0": VersionConfig.from_version(
-            version="2.10.0",
-            config_file=config_files.SIRIUS_EVS_NET_E_2_10_0_CONFIG,
-            dictionary_type=DictionaryType.XDF_V3,
-            extra_data={
-                __EXECUTION_POLICY_KEY: "always",
-                __TEST_CONFIGS_KEY: {
-                    "SIRIUS_TEST_SESSIONS": PyTestConfig(
-                        markers="soem and biss_c_flaky",  # https://novantamotion.atlassian.net/browse/INGM-798
-                        run_test_stage_uid="ethercat_everest_s_2.10.0",
-                        stage_name="SIRIUS EVS-NET-E Tests - FW. 2.10.0",
-                    )
-                },
-            },
-            feedback_configuration=FeedbackConfiguration.from_configurable(
-                abs_encoder_1_configuration=EncoderConfiguration(
-                    protocol=EncoderProtocol.SSI1, resolution_bits=17
-                )
-            ),
-        ),
         # BiSS-C tests are flaky on 2.10.0 should pass on 2.11.0
         "2.11.0.005": VersionConfig.from_files(
             version="2.11.0.005",
@@ -355,6 +335,26 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
             feedback_configuration=FeedbackConfiguration.from_configurable(
                 abs_encoder_1_configuration=EncoderConfiguration(
                     protocol=EncoderProtocol.BIS3, resolution_bits=17
+                )
+            ),
+        ),
+        "2.10.0": VersionConfig.from_version(
+            version="2.10.0",
+            config_file=config_files.SIRIUS_EVS_NET_E_2_10_0_CONFIG,
+            dictionary_type=DictionaryType.XDF_V3,
+            extra_data={
+                __EXECUTION_POLICY_KEY: "always",
+                __TEST_CONFIGS_KEY: {
+                    "SIRIUS_TEST_SESSIONS": PyTestConfig(
+                        markers="soem and biss_c_flaky",  # https://novantamotion.atlassian.net/browse/INGM-798
+                        run_test_stage_uid="ethercat_everest_s_2.10.0",
+                        stage_name="SIRIUS EVS-NET-E Tests - FW. 2.10.0",
+                    )
+                },
+            },
+            feedback_configuration=FeedbackConfiguration.from_configurable(
+                abs_encoder_1_configuration=EncoderConfiguration(
+                    protocol=EncoderProtocol.SSI1, resolution_bits=17
                 )
             ),
         ),

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -400,7 +400,8 @@ def test_get_actual_position(mc, alias, position_value):
 @pytest.mark.canopen
 @pytest.mark.parametrize("velocity_value", [1, 0, -1])
 # https://novantamotion.atlassian.net/browse/INGM-781
-@pytest.mark.not_valid_for_product(part_number="CAP-XCR-E")
+# @pytest.mark.not_valid_for_product(part_number="CAP-XCR-E")
+@pytest.mark.repeat(50)
 def test_get_actual_velocity(servo, mc, alias, velocity_value):
     with refresh_registers_for_test_rollback(
         servo,

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -399,6 +399,8 @@ def test_get_actual_position(mc, alias, position_value):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("velocity_value", [1, 0, -1])
+# https://novantamotion.atlassian.net/browse/INGM-802
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-C")
 def test_get_actual_velocity(servo, mc, alias, velocity_value):
     with refresh_registers_for_test_rollback(
         servo,

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -399,9 +399,6 @@ def test_get_actual_position(mc, alias, position_value):
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.parametrize("velocity_value", [1, 0, -1])
-# https://novantamotion.atlassian.net/browse/INGM-781
-# @pytest.mark.not_valid_for_product(part_number="CAP-XCR-E")
-@pytest.mark.repeat(50)
 def test_get_actual_velocity(servo, mc, alias, velocity_value):
     with refresh_registers_for_test_rollback(
         servo,


### PR DESCRIPTION
The failure could not be reproduced for EtherCAT products, check [successful pipeline](http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingeniamotion/view/change-requests/job/PR-649/1/) (link may expire) with 150 runs.
I also tried to reproduce it locally with more than 1000 runs and I couldn't. Removing the marker for now, if we see the failure again we'll analyze it.

Note that it sometimes happen in [CAN](http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingeniamotion/job/PR-644/18/testReport/) (link may expire), but there is no marker that is currently skipping that:
```
servo = <ingenialink.canopen.servo.CanopenServo object at 0x000001B1107726A0>
mc = <ingeniamotion.motion_controller.MotionController object at 0x000001B10F94F580>
alias = 'default', velocity_value = 1

    @pytest.mark.ethernet
    @pytest.mark.soem
    @pytest.mark.canopen
    @pytest.mark.parametrize("velocity_value", [1, 0, -1])
    # https://novantamotion.atlassian.net/browse/INGM-781
    @pytest.mark.not_valid_for_product(part_number="CAP-XCR-E")
    def test_get_actual_velocity(servo, mc, alias, velocity_value):
        with refresh_registers_for_test_rollback(
            servo,
            [
                "COMMU_ANGLE_OFFSET",
            ],
        ):
            mc.motion.set_operation_mode(OperationMode.PROFILE_VELOCITY, servo=alias)
            mc.motion.motor_enable(servo=alias)
>           mc.motion.set_velocity(velocity_value, servo=alias, blocking=True, timeout=10)

tests\test_motion.py:436: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ingeniamotion\motion.py:313: in set_velocity
    self.wait_for_velocity(velocity, servo, axis, error, timeout, interval)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ingeniamotion.motion.Motion object at 0x000001B1101B4F10>, velocity = 1
servo = 'default', axis = 1, error = 0.1, timeout = 10, interval = None

    def wait_for_velocity(
        self,
        velocity: float,
        servo: str = DEFAULT_SERVO,
        axis: int = DEFAULT_AXIS,
        error: float = 0.1,
        timeout: Optional[float] = None,
        interval: Optional[float] = None,
    ) -> None:
        """Wait until actual velocity is equal to a target velocity, with an error.
    
        Args:
            velocity : target velocity, in rev/s.
            servo : servo alias to reference it. ``default`` by default.
            axis : servo axis. ``1`` by default.
            error : allowed error between actual velocity and target
                velocity, in rev/s.
            timeout : how many seconds to wait for the servo to reach the
                target velocity, if ``None`` it will wait forever.
                ``None`` by default.
            interval : interval of time between actual velocity reads,
                in seconds. ``None`` by default.
    
        Raises:
            IMTimeoutError: If the target velocity is not reached in time.
    
        """
        target_reached = False
        init_time = time.time()
        self.logger.debug(
            "Wait for velocity %s", velocity, axis=axis, drive=self.mc.servo_name(servo)
        )
        while not target_reached:
            if interval:
                time.sleep(interval)
            curr_velocity = self.get_actual_velocity(servo=servo, axis=axis)
            target_reached = abs(velocity - curr_velocity) < abs(error)
            if timeout and (init_time + timeout) < time.time():
                target_reached = True
                self.logger.warning(
                    "Timeout: velocity %s was not reached",
                    velocity,
                    axis=axis,
                    drive=self.mc.servo_name(servo),
                )
>               raise IMTimeoutError("Velocity was not reached in time")
E               ingeniamotion.exceptions.IMTimeoutError: Velocity was not reached in time

ingeniamotion\motion.py:720: IMTimeoutError
```

Changes:
* Removed `not_valid_for_product` marker for CAP products since it could not be reproduced.
* Added `not_valid_for_product` marker for EVE product and added linked issue.
* Changed SIRIUS SSI and BiSS-C runs, execute first release candidate with BiSS-C.