### PR TITLE
Ingm 782 fix test digital halls test

### DIFF
--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -102,9 +102,6 @@ def assert_returns_to_initial_value(
 @pytest.mark.soem
 @pytest.mark.canopen
 @pytest.mark.usefixtures("feedback_test_setup")
-# https://novantamotion.atlassian.net/browse/INGM-782
-# @pytest.mark.not_valid_for_product(part_number="CAP-XCR-E")
-@pytest.mark.repeat(200)
 def test_digital_halls_test(
     servo: Servo, mc, alias, feedback_list, registers_baseline: DriveRegistersValue
 ):

--- a/tests/test_all_drive_tests.py
+++ b/tests/test_all_drive_tests.py
@@ -103,7 +103,8 @@ def assert_returns_to_initial_value(
 @pytest.mark.canopen
 @pytest.mark.usefixtures("feedback_test_setup")
 # https://novantamotion.atlassian.net/browse/INGM-782
-@pytest.mark.not_valid_for_product(part_number="CAP-XCR-E")
+# @pytest.mark.not_valid_for_product(part_number="CAP-XCR-E")
+@pytest.mark.repeat(200)
 def test_digital_halls_test(
     servo: Servo, mc, alias, feedback_list, registers_baseline: DriveRegistersValue
 ):


### PR DESCRIPTION
The failure could not be reproduced for EtherCAT products, check [successful pipeline](http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingeniamotion/view/change-requests/job/PR-651/1/stages/?selected-node=865) (link may expire) with 200 repetitions. Removing the marker for now, if we see the failure again we'll analyze it.

Changes:
* Removed not_valid_for_product marker for CAP products since it could not be reproduced.