### PR TITLE
INGK-1299 Update the WIN docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ def CAN_NODE_LOCK = "test_execution_lock_can"
 def SIRIUS_NODE = "RA-RD-CT-SIRIUS"
 
 def LIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/docker-python:1.7"
-def WIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:1.7"
+def WIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:1.9"
 def PUBLISHER_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/publisher:1.8"
 
 def WIN_DOCKER_TMP_PATH = "C:\\Users\\ContainerAdministrator\\ingeniamotion"


### PR DESCRIPTION
Updates the Docker image to the latest version, which uses Python 3.12.10, to fix the known canopen issue affecting Python 3.12.0.