### PR TITLE
Fix conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ from summit_testing_framework.pytest_helpers.marker_helper import (
 from summit_testing_framework.setups.specifiers import DictionaryType, DictionaryVersion
 
 from tests.dictionaries import SAMPLE_SAFE_PH1_XDFV3_DICTIONARY
-from tests.setups.rack_specifiers import __RANDOM_COMBINATIONS_SLICE_KEY
 
 if TYPE_CHECKING:
     from summit_testing_framework.setups.specifiers import SetupSpecifier
@@ -32,6 +31,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 __BISS_C_CONFIG_MARKER: str = "biss_c_flaky"
+
+# Fraction of exhaustive test configurations to run in shorter daytime test sessions.
+RANDOM_COMBINATIONS_SLICE_KEY: str = "random_combinations_slice"
 
 
 pytest_plugins = [
@@ -273,7 +275,7 @@ def slice_configurations(
         fraction with at least one configuration.
     """
     assert configurations, "At least one test configuration is required"
-    configuration_slice = setup_specifier.extra_data.get(__RANDOM_COMBINATIONS_SLICE_KEY, None)
+    configuration_slice = setup_specifier.extra_data.get(RANDOM_COMBINATIONS_SLICE_KEY, None)
     if configuration_slice is None:
         return configurations
     return configurations[: max(1, int(len(configurations) * configuration_slice))]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__BISS_C_CONFIG_MARKER: str = "biss_c_flaky"
+# Tests that are known to be flaky for BISS-C configuration should be marked with this marker.
+BISS_C_CONFIG_MARKER: str = "biss_c_flaky"
 
 # Fraction of exhaustive test configurations to run in shorter daytime test sessions.
 RANDOM_COMBINATIONS_SLICE_KEY: str = "random_combinations_slice"
@@ -128,7 +129,7 @@ def apply_configuration_marker_to_items(
         return
 
     for item in items:
-        if not item.get_closest_marker(__BISS_C_CONFIG_MARKER):
+        if not item.get_closest_marker(BISS_C_CONFIG_MARKER):
             continue
 
         for skip_product in ["CAP-*", "EVE-*", "EVS-*"]:

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -16,12 +16,11 @@ from summit_testing_framework.setups.specifiers import (
 )
 
 import summit_drives_ci_configs.config_files as config_files
+from tests.conftest import RANDOM_COMBINATIONS_SLICE_KEY
 
 __EXECUTION_POLICY_KEY: str = "execution_policy"
 __TEST_CONFIGS_KEY: str = "test_configs"
 
-# Fraction of exhaustive test configurations to run in shorter daytime test sessions.
-__RANDOM_COMBINATIONS_SLICE_KEY: str = "random_combinations_slice"
 
 ETH_SETUP = SpecifierContainer({
     PartNumber.EVE_XCR_C: RackServiceConfigSpecifier.from_version_configs(
@@ -164,7 +163,7 @@ ECAT_SETUP = SpecifierContainer({
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
                     __EXECUTION_POLICY_KEY: "always",
-                    __RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
+                    RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="soem",
@@ -203,7 +202,7 @@ ECAT_DEN_S_NET_E_SETUP = RackServiceConfigSpecifier.from_version_configs(
             dictionary_type=DictionaryType.XDF_V3,
             extra_data={
                 __EXECUTION_POLICY_KEY: "always",
-                __RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
+                RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
                 __TEST_CONFIGS_KEY: {
                     "ECAT_TEST_SESSIONS": PyTestConfig(
                         markers="fsoe or fsoe_phase2",
@@ -243,7 +242,7 @@ CAN_SETUP = SpecifierContainer({
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
                     __EXECUTION_POLICY_KEY: "always",
-                    __RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
+                    RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",
@@ -265,7 +264,7 @@ CAN_SETUP = SpecifierContainer({
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
                     __EXECUTION_POLICY_KEY: "always",
-                    __RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
+                    RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",
@@ -307,7 +306,7 @@ ECAT_MULTISLAVE_SETUP = MultiRackServiceConfigSpecifier.create(
     ],
     extra_data={
         __EXECUTION_POLICY_KEY: "always",
-        __RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
+        RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
         __TEST_CONFIGS_KEY: {
             "ECAT_TEST_SESSIONS": PyTestConfig(
                 markers="soem_multislave",
@@ -354,7 +353,7 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
             dictionary_type=DictionaryType.XDF_V3,
             extra_data={
                 __EXECUTION_POLICY_KEY: "always",
-                __RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
+                RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
                 __TEST_CONFIGS_KEY: {
                     "SIRIUS_TEST_SESSIONS": PyTestConfig(
                         markers="soem and biss_c_flaky",  # https://novantamotion.atlassian.net/browse/INGM-798

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -16,7 +16,7 @@ from summit_testing_framework.setups.specifiers import (
 )
 
 import summit_drives_ci_configs.config_files as config_files
-from tests.conftest import RANDOM_COMBINATIONS_SLICE_KEY
+from tests.conftest import BISS_C_CONFIG_MARKER, RANDOM_COMBINATIONS_SLICE_KEY
 
 __EXECUTION_POLICY_KEY: str = "execution_policy"
 __TEST_CONFIGS_KEY: str = "test_configs"
@@ -335,7 +335,7 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
                 __EXECUTION_POLICY_KEY: "nightly",
                 __TEST_CONFIGS_KEY: {
                     "SIRIUS_TEST_SESSIONS": PyTestConfig(
-                        markers="soem and biss_c_flaky",
+                        markers=f"soem and {BISS_C_CONFIG_MARKER}",
                         run_test_stage_uid="ethercat_everest_s_2.11.0.005",
                         stage_name="SIRIUS EVS-NET-E Tests - FW. 2.11.0.005",
                     )
@@ -356,7 +356,7 @@ SIRIUS_SETUP = RackServiceConfigSpecifier.from_version_configs(
                 RANDOM_COMBINATIONS_SLICE_KEY: 0.1,
                 __TEST_CONFIGS_KEY: {
                     "SIRIUS_TEST_SESSIONS": PyTestConfig(
-                        markers="soem and biss_c_flaky",  # https://novantamotion.atlassian.net/browse/INGM-798
+                        markers=f"soem and {BISS_C_CONFIG_MARKER}",  # https://novantamotion.atlassian.net/browse/INGM-798
                         run_test_stage_uid="ethercat_everest_s_2.10.0",
                         stage_name="SIRIUS EVS-NET-E Tests - FW. 2.10.0",
                     )


### PR DESCRIPTION
`conftest.py` was importing a private variable from `rack_specifiers.py`.
This broke `summit_drives_ci_configs` [pipeline](http://jenkins.ingenia/job/CeleraMotion%20Github/job/summit_drives_ci_configs/view/change-requests/job/PR-56/12/stages/?selected-node=473) (link may expire):
<img width="1326" height="376" alt="image" src="https://github.com/user-attachments/assets/5cec8c2a-2618-43aa-a53f-fc8c11efed31" />

This happened because `summit_drives_ci_configs` replaces the configurations used, and `rack_specifiers.py` does not exist anymore in that pipeline.

In order to avoid more breaking changes, it is safer to define the needed variables in `conftest.py` and import them elsewhere.