### PR TITLE
Cit 781 parameter last selection is picking configurations from not last run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@3d56087') _ 
+@Library('cicd-lib@3d56087') _
 
 import python.VirtualEnvironment
 import python.VEnvManager

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@b5d19b8') _
+@Library('cicd-lib@18055fc') _
 
 import python.VirtualEnvironment
 import python.VEnvManager
@@ -140,6 +140,11 @@ pipeline {
         timestamps()
     }
     stages {
+        stage('Inspect pipeline parameters') {
+            steps {
+                echo("${PyTestParams.configSummary(params, env, currentBuild)}")
+            }
+        }
         stage('Prepare test sessions') {
             agent {
                 docker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@3d56087') _
+@Library('cicd-lib@fd87ea7') _
 
 import python.VirtualEnvironment
 import python.VEnvManager

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@173ddb4ffc75557c611d227efe9f47e5cc5250e5') _
+@Library('cicd-lib@b5d19b8') _
 
 import python.VirtualEnvironment
 import python.VEnvManager

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@18055fc') _
+@Library('cicd-lib@3d56087') _
 
 import python.VirtualEnvironment
 import python.VEnvManager

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@3d56087') _
+@Library('cicd-lib@3d56087') _ 
 
 import python.VirtualEnvironment
 import python.VEnvManager

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@fd87ea7') _
+@Library('cicd-lib@0142b4f') _
 
 import python.VirtualEnvironment
 import python.VEnvManager


### PR DESCRIPTION
# PR Description
* Updated CICD commit
* Updated Jenkins pipeline to add an initial parameter inspection stage. This should help to debug if we see that some strange behavior is happening again.
   * CICD has been improved to properly store the value of checkboxes in previous builds, so this should not happen anymore.

# Validation

Boolean values are shown in the order: `WIRESHARK_LOGGING / RUN_POLICY_NIGHTLY / RUN_POLICY_WEEKEND`.

| Test | Build(s) | Setup | Observed result | Status |
|---|---:|---|---|---|
| Manual build with defaults | `#25` | `Set to default` | Raw: `true / empty / empty`<br>Effective: `true / false / false` | Passed |
| Manual parameter overrides | `#26` | `Set to default`, Wireshark disabled, nightly enabled | Raw: `empty / true / empty`<br>Effective: `false / true / false` | Passed |
| Restore previous values | `#27` | `Set to last build` | Restored: `false / true / false` | Passed |
| Override one remembered value | `#28` | `Set to last build`, weekend enabled | Effective: `false / true / true` | Passed |
| First webhook | `#29` | `BranchEventCause` | Raw: `true / true / true`<br>Effective: `false / true / true` | Passed |
| Consecutive webhook | `#30` | Webhook immediately after `#29` | Raw: `true / true / true`<br>Effective: `false / true / true` | Passed |
| Timer/cron integration on `develop` | Not run | Requires the change to be merged into `develop` | Pending post-merge validation | Not run |

## Webhook Verification

The webhook tests confirm that synthetic Active Choices values are ignored for branch-event builds:

```txt
Webhook #29:
  raw WIRESHARK_LOGGING=true
  effective WIRESHARK_LOGGING=false

Webhook #30:
  raw WIRESHARK_LOGGING=true
  effective WIRESHARK_LOGGING=false
```

# Pipeline parameters output 
Check [output here](http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingeniamotion/job/PR-673/30/stages/?selected-node=7) (link may expire):

```txt
=== Pipeline parameter diagnostics ===

Current build:
  number: #30
  id: 30
  causes:
    jenkins.branch.BranchEventCause

Raw submitted parameters:
  CHECK_STATE_SCOPE=session
  PYTEST_LOGGING_LEVEL=INFO
  PYTEST_REPEAT_COUNTS=<empty>
  PYTEST_SELECTION=<empty>
  PYTHON_VERSIONS=MIN
  RUN_POLICY_NIGHTLY=true
  RUN_POLICY_WEEKEND=true
  RUN_WITH_PARAMETERS=Set to last build
  WIRESHARK_LOGGING=true
  test_session_filter=.*

Raw submitted versus effective parameter values:
  ----- RUN_WITH_PARAMETERS (runWithParameters) -----
    raw submitted (provided): Set to last build
    effective value: Set to last build
  ----- PYTHON_VERSIONS (pythonVersions) -----
    raw submitted (provided): MIN
    effective value: MIN
  ----- test_session_filter (testSessionFilter) -----
    raw submitted (provided): .*
    effective value: .*
  ----- WIRESHARK_LOGGING (wiresharkLogging) -----
    raw submitted (provided): true
    effective value: false
  ----- CHECK_STATE_SCOPE (checkStateScope) -----
    raw submitted (provided): session
    effective value: session
  ----- RUN_POLICY_NIGHTLY (runPolicyNightly) -----
    raw submitted (provided): true
    effective value: true
  ----- RUN_POLICY_WEEKEND (runPolicyWeekend) -----
    raw submitted (provided): true
    effective value: true
  ----- PYTEST_SELECTION (pytestSelection) -----
    raw submitted (provided): <empty>
    effective value: <empty>
  ----- PYTEST_REPEAT_COUNTS (pytestRepeatCounts) -----
    raw submitted (provided): <empty>
    effective value: 1
  ----- PYTEST_LOGGING_LEVEL (pytestLoggingLevel) -----
    raw submitted (provided): INFO
    effective value: INFO

Previous-build parameter sources (starts at currentBuild.previousBuild):
  ----- RUN_WITH_PARAMETERS (runWithParameters) -----
    source: build #29 (29)
    raw: Set to last build
    type: java.lang.String
    cause: jenkins.branch.BranchEventCause
  ----- PYTHON_VERSIONS (pythonVersions) -----
    source: build #29 (29)
    raw: MIN
    type: java.lang.String
    cause: jenkins.branch.BranchEventCause
  ----- test_session_filter (testSessionFilter) -----
    source: build #29 (29)
    raw: .*
    type: java.lang.String
    cause: jenkins.branch.BranchEventCause
  ----- WIRESHARK_LOGGING (wiresharkLogging) -----
    source: build #29 (29)
    raw: true
    type: java.lang.String
    cause: jenkins.branch.BranchEventCause
  ----- CHECK_STATE_SCOPE (checkStateScope) -----
    source: build #29 (29)
    raw: session
    type: java.lang.String
    cause: jenkins.branch.BranchEventCause
  ----- RUN_POLICY_NIGHTLY (runPolicyNightly) -----
    source: build #29 (29)
    raw: true
    type: java.lang.String
    cause: jenkins.branch.BranchEventCause
  ----- RUN_POLICY_WEEKEND (runPolicyWeekend) -----
    source: build #29 (29)
    raw: true
    type: java.lang.String
    cause: jenkins.branch.BranchEventCause
  ----- PYTEST_SELECTION (pytestSelection) -----
    source: build #29 (29)
    raw: <empty>
    type: java.lang.String
    cause: jenkins.branch.BranchEventCause
  ----- PYTEST_REPEAT_COUNTS (pytestRepeatCounts) -----
    source: build #29 (29)
    raw: <empty>
    type: java.lang.String
    cause: jenkins.branch.BranchEventCause
  ----- PYTEST_LOGGING_LEVEL (pytestLoggingLevel) -----
    source: build #29 (29)
    raw: INFO
    type: java.lang.String
    cause: jenkins.branch.BranchEventCause
```