### PR TITLE
Ingm 789 fix test emcy callback

### DIFF
--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -809,9 +809,8 @@ def test_subscribe_register_updates(mc: "MotionController", alias: str) -> None:
 
 @pytest.mark.canopen
 @pytest.mark.soem
-@pytest.mark.not_valid_for_product(
-    part_number="EVE-XCR-E", xfail="https://novantamotion.atlassian.net/browse/DRIVSUS-392"
-)
+# https://novantamotion.atlassian.net/browse/DRIVSUS-392
+@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E")
 def test_emcy_callback(mc: "MotionController", alias: str) -> None:
     emcy_test = EmcyTest()
     prev_val = mc.communication.get_register("DRV_PROT_USER_OVER_VOLT", axis=1, servo=alias)

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -776,7 +776,7 @@ def test_get_available_canopen_devices(mocker):
 
 
 @pytest.mark.virtual
-def test_subscribe_register_updates(mc, alias):
+def test_subscribe_register_updates(mc: "MotionController", alias: str) -> None:
     user_over_voltage_uid = "DRV_PROT_USER_OVER_VOLT"
     register_update_callback = RegisterUpdateTest()
 
@@ -809,9 +809,8 @@ def test_subscribe_register_updates(mc, alias):
 
 @pytest.mark.canopen
 @pytest.mark.soem
-# https://novantamotion.atlassian.net/browse/INGM-789
-@pytest.mark.not_valid_for_product(part_number="EVE-XCR-E")
-def test_emcy_callback(mc, alias):
+@pytest.mark.repeat(100)
+def test_emcy_callback(mc: "MotionController", alias: str) -> None:
     emcy_test = EmcyTest()
     mc.communication.subscribe_emergency_message(emcy_test.emcy_callback, servo=alias)
     prev_val = mc.communication.get_register("DRV_PROT_USER_OVER_VOLT", axis=1, servo=alias)

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -812,23 +812,29 @@ def test_subscribe_register_updates(mc: "MotionController", alias: str) -> None:
 @pytest.mark.repeat(100)
 def test_emcy_callback(mc: "MotionController", alias: str) -> None:
     emcy_test = EmcyTest()
-    mc.communication.subscribe_emergency_message(emcy_test.emcy_callback, servo=alias)
     prev_val = mc.communication.get_register("DRV_PROT_USER_OVER_VOLT", axis=1, servo=alias)
-    mc.communication.set_register("DRV_PROT_USER_OVER_VOLT", value=10.0, axis=1, servo=alias)
-    with pytest.raises(ILError):
-        mc.motion.motor_enable(servo=alias)
-    mc.motion.fault_reset(servo=alias)
-    assert len(emcy_test.messages) == 2
-    servo_alias, first_emcy = emcy_test.messages[0]
-    assert servo_alias == alias
-    assert first_emcy.error_code == 0x3231
-    assert first_emcy.get_desc() == "User Over-voltage detected"
-    servo_alias, second_emcy = emcy_test.messages[1]
-    assert servo_alias == alias
-    assert second_emcy.error_code == 0x0000
-    assert second_emcy.get_desc() == "No error"
-    mc.communication.set_register("DRV_PROT_USER_OVER_VOLT", value=prev_val, axis=1, servo=alias)
-    mc.communication.unsubscribe_emergency_message(emcy_test.emcy_callback, servo=alias)
+    mc.communication.subscribe_emergency_message(emcy_test.emcy_callback, servo=alias)
+    try:
+        mc.communication.set_register("DRV_PROT_USER_OVER_VOLT", value=10.0, axis=1, servo=alias)
+        with pytest.raises(ILError):
+            mc.motion.motor_enable(servo=alias)
+        mc.motion.fault_reset(servo=alias)
+        assert len(emcy_test.messages) == 2
+        servo_alias, first_emcy = emcy_test.messages[0]
+        assert servo_alias == alias
+        assert first_emcy.error_code == 0x3231
+        assert first_emcy.get_desc() == "User Over-voltage detected"
+        servo_alias, second_emcy = emcy_test.messages[1]
+        assert servo_alias == alias
+        assert second_emcy.error_code == 0x0000
+        assert second_emcy.get_desc() == "No error"
+    finally:
+        try:
+            mc.communication.set_register(
+                "DRV_PROT_USER_OVER_VOLT", value=prev_val, axis=1, servo=alias
+            )
+        finally:
+            mc.communication.unsubscribe_emergency_message(emcy_test.emcy_callback, servo=alias)
 
 
 def test_scan_sdcp_nodes(mocker):

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -809,7 +809,9 @@ def test_subscribe_register_updates(mc: "MotionController", alias: str) -> None:
 
 @pytest.mark.canopen
 @pytest.mark.soem
-@pytest.mark.repeat(100)
+@pytest.mark.not_valid_for_product(
+    part_number="EVE-XCR-E", xfail="https://novantamotion.atlassian.net/browse/DRIVSUS-392"
+)
 def test_emcy_callback(mc: "MotionController", alias: str) -> None:
     emcy_test = EmcyTest()
     prev_val = mc.communication.get_register("DRV_PROT_USER_OVER_VOLT", axis=1, servo=alias)
@@ -822,12 +824,20 @@ def test_emcy_callback(mc: "MotionController", alias: str) -> None:
         assert len(emcy_test.messages) == 2
         servo_alias, first_emcy = emcy_test.messages[0]
         assert servo_alias == alias
-        assert first_emcy.error_code == 0x3231
-        assert first_emcy.get_desc() == "User Over-voltage detected"
+        assert first_emcy.error_code == 0x3231, (
+            f"Expected error code 0x3231, got {first_emcy.error_code:#06x}"
+        )
+        assert first_emcy.get_desc() == "User Over-voltage detected", (
+            f"Expected description 'User Over-voltage detected', got '{first_emcy.get_desc()}'"
+        )
         servo_alias, second_emcy = emcy_test.messages[1]
         assert servo_alias == alias
-        assert second_emcy.error_code == 0x0000
-        assert second_emcy.get_desc() == "No error"
+        assert second_emcy.error_code == 0x0000, (
+            f"Expected error code 0x0000, got {second_emcy.error_code:#06x}"
+        )
+        assert second_emcy.get_desc() == "No error", (
+            f"Expected description 'No error', got '{second_emcy.get_desc()}'"
+        )
     finally:
         try:
             mc.communication.set_register(


### PR DESCRIPTION
After running 100 iterations both on EVE-XCR-E 2.6.0 and 2.8.1, Wireshark captures conclude that it is not a software bug.

Out of 100 iterations, sometimes 5 or 7 fail, so there is still a chance that it will pass.

See [related issue](https://novantamotion.atlassian.net/browse/DRIVSUS-392) for the full issue investigation and results.