### PR TITLE
Ingm 775 fix test homing on switch limit

### DIFF
--- a/tests/test_homing.py
+++ b/tests/test_homing.py
@@ -107,14 +107,7 @@ def test_homing_on_current_position(servo, mc, alias, homing_offset):
 @pytest.mark.canopen
 @pytest.mark.usefixtures("initial_position")
 @pytest.mark.parametrize("direction", [1, 0])
-@pytest.mark.not_valid_for_specifier(
-    specifier="tests.setups.rack_specifiers.ECAT_SETUP",
-    skip_reason="https://novantamotion.atlassian.net/browse/INGM-775",
-)
-@pytest.mark.not_valid_for_specifier(
-    specifier="tests.setups.rack_specifiers.CAN_SETUP@EVE-XCR-C",
-    skip_reason="https://novantamotion.atlassian.net/browse/INGM-775",
-)
+@pytest.mark.repeat(100)
 def test_homing_on_switch_limit(servo, mc, alias, direction):
     with refresh_registers_for_test_rollback(
         servo,

--- a/tests/test_homing.py
+++ b/tests/test_homing.py
@@ -107,7 +107,6 @@ def test_homing_on_current_position(servo, mc, alias, homing_offset):
 @pytest.mark.canopen
 @pytest.mark.usefixtures("initial_position")
 @pytest.mark.parametrize("direction", [1, 0])
-@pytest.mark.repeat(100)
 def test_homing_on_switch_limit(servo, mc, alias, direction):
     with refresh_registers_for_test_rollback(
         servo,


### PR DESCRIPTION
# Description
Couldn't reproduce the issue after 100 runs. Enabling the test until we see the failure again.

There is no record of the original failure, but it may have been mitigated by the changes introduced by:
* https://github.com/ingeniamc/ingeniamotion/pull/683
* https://github.com/ingeniamc/ingeniamotion/pull/687

# Tests
* Tested with 100 runs in commit [15b9117](https://github.com/ingeniamc/ingeniamotion/pull/694/commits/15b9117a0ce77e3e8fc004d07362fde277cad8c8) with [pipeline](http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingeniamotion/job/PR-694/1/stages/?selected-node=968) (link may expire).