### PR TITLE
MOT3-5669 Create object oriended monitoring module with check_version cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Add SDCP servo support.
 - Add `Axis.feedbacks` (`AxisFeedbacks`), a typed API for configuring and accessing an axis's feedback slots.
+- Add `MotionNode.capture` (`MotionNodeCapture`), a typed API for the monitoring and disturbance operations of a motion node, which caches the detected monitoring version.
 
 ### Changed
 - Refactor feedback management around `Axis.feedbacks`; the legacy `Feedbacks` API remains available for backward compatibility.

--- a/ingeniamotion/_utils.py
+++ b/ingeniamotion/_utils.py
@@ -87,3 +87,29 @@ def weak_lru(
         return cast("Callable[..., _T]", wrapper)
 
     return decorator
+
+
+@contextlib.contextmanager
+def map_exceptions(mapping: dict[type[Exception], type[Exception]]) -> Generator[None, None, None]:
+    """Context manager that raises a mapped exception instead of the caught one.
+
+    Args:
+        mapping: exception type to raise for each caught exception type.
+
+    Yields:
+        None, while the wrapped code runs.
+
+    Raises:
+        Exception: the mapped exception, when a mapped exception type is raised.
+
+    Example:
+        with map_exceptions({ILRegisterNotFoundError: IMRegisterNotExistError}):
+            servo.read("MON_DIST_STATUS", subnode=0)
+    """
+    try:
+        yield
+    except tuple(mapping) as exc:
+        exception_type = next(
+            mapped for caught, mapped in mapping.items() if isinstance(exc, caught)
+        )
+        raise exception_type(str(exc)) from exc

--- a/ingeniamotion/_utils.py
+++ b/ingeniamotion/_utils.py
@@ -1,8 +1,8 @@
 import contextlib
 import functools
 import weakref
-from collections.abc import Generator, Sequence
-from typing import Any, Callable, Optional, TypeVar, cast
+from collections.abc import Callable, Generator, Mapping, Sequence
+from typing import Any, Optional, TypeVar, cast
 
 from exceptiongroup import ExceptionGroup
 
@@ -90,11 +90,13 @@ def weak_lru(
 
 
 @contextlib.contextmanager
-def map_exceptions(mapping: dict[type[Exception], type[Exception]]) -> Generator[None, None, None]:
+def map_exceptions(
+    mapping: Mapping[type[Exception], Callable[[], Exception]]
+) -> Generator[None, None, None]:
     """Context manager that raises a mapped exception instead of the caught one.
 
     Args:
-        mapping: exception type to raise for each caught exception type.
+        mapping: exception type to a zero-argument exception factory.
 
     Yields:
         None, while the wrapped code runs.
@@ -109,7 +111,7 @@ def map_exceptions(mapping: dict[type[Exception], type[Exception]]) -> Generator
     try:
         yield
     except tuple(mapping) as exc:
-        exception_type = next(
+        exception_factory = next(
             mapped for caught, mapped in mapping.items() if isinstance(exc, caught)
         )
-        raise exception_type(str(exc)) from exc
+        raise exception_factory() from exc

--- a/ingeniamotion/_utils.py
+++ b/ingeniamotion/_utils.py
@@ -91,7 +91,7 @@ def weak_lru(
 
 @contextlib.contextmanager
 def map_exceptions(
-    mapping: Mapping[type[Exception], Callable[[], Exception]]
+    mapping: Mapping[type[Exception], Callable[[], Exception]],
 ) -> Generator[None, None, None]:
     """Context manager that raises a mapped exception instead of the caught one.
 

--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -26,6 +26,7 @@ from ingeniamotion.pdo import PDONetworkManager
 
 if TYPE_CHECKING:
     from ingeniamotion.motion_controller import MotionController
+    from ingeniamotion.motion_node import MotionNode
 
 
 class Capture:
@@ -285,6 +286,24 @@ class Capture:
             self.enable_disturbance(servo=servo)
         return disturbance
 
+    def _capture(
+        self, servo: str, version: Optional[MonitoringVersion] = None
+    ) -> "MotionNodeCapture":
+        """Return capture operations for a motion node and optional version."""
+        motion_node = self.mc._get_motion_node(servo)
+        if version is None:
+            return motion_node.capture
+
+        return MotionNodeCapture._with_version(motion_node, version)
+
+    def _resolve_version(
+        self, servo: str, version: Optional[MonitoringVersion]
+    ) -> MonitoringVersion:
+        """Return an explicit version or the bound capture's cached version."""
+        if version is not None:
+            return version
+        return self._capture(servo).version
+
     def _check_version(self, servo: str) -> MonitoringVersion:
         """Checks the version of the monitoring based on a given servo.
 
@@ -299,30 +318,7 @@ class Capture:
             and disturbance.
 
         """
-        try:
-            self.mc.communication.get_register(
-                self.MONITORING_VERSION_REGISTER, servo=servo, axis=0
-            )
-            return MonitoringVersion.MONITORING_V3
-        except (IMRegisterNotExistError, ILError):
-            # The Monitoring V3 is NOT available
-            pass
-        try:
-            self.mc.communication.get_register(
-                self.MONITORING_CURRENT_NUMBER_BYTES_REGISTER, servo=servo, axis=0
-            )
-            return MonitoringVersion.MONITORING_V2
-        except (IMRegisterNotExistError, ILError):
-            # The Monitoring V2 is NOT available
-            pass
-        try:
-            self.mc.communication.get_register(self.MONITORING_STATUS_REGISTER, servo=servo, axis=0)
-            return MonitoringVersion.MONITORING_V1
-        except (IMRegisterNotExistError, ILError):
-            # Monitoring/disturbance are not available
-            raise NotImplementedError(
-                "The monitoring and disturbance features are not available for this drive"
-            )
+        return self._capture(servo).version
 
     def enable_monitoring_disturbance(self, servo: str = DEFAULT_SERVO) -> None:
         """Enable monitoring and disturbance.
@@ -347,13 +343,7 @@ class Capture:
             IMMonitoringError: If monitoring can't be enabled.
 
         """
-        drive = self.mc._get_drive(servo)
-        if drive.monitoring_get_num_mapped_registers() == 0:
-            raise IMMonitoringError("There are no registers mapped for monitoring.")
-        drive.monitoring_enable()
-        # Check monitoring status
-        if not self.is_monitoring_enabled(servo=servo):
-            raise IMMonitoringError("Error enabling monitoring.")
+        self._capture(servo).enable_monitoring()
 
     def enable_disturbance(
         self, servo: str = DEFAULT_SERVO, version: Optional[MonitoringVersion] = None
@@ -369,19 +359,7 @@ class Capture:
             IMMonitoringError: If disturbance can't be enabled.
 
         """
-        drive = self.mc._get_drive(servo)
-        if version is None:
-            version = self._check_version(servo)
-        if version < MonitoringVersion.MONITORING_V3:
-            # V1: monitoring and disturbance share the same enable
-            # mechanism. Bypass enable_monitoring() mapped-register check
-            # because disturbance-only mapped registers are sufficient.
-            drive.monitoring_enable()
-        else:
-            drive.disturbance_enable()
-        # Check disturbance status
-        if not self.is_disturbance_enabled(servo=servo):
-            raise IMMonitoringError("Error enabling disturbance.")
+        self._capture(servo, version).enable_disturbance()
 
     def disable_monitoring_disturbance(self, servo: str = DEFAULT_SERVO) -> None:
         """Disable monitoring and disturbance.
@@ -404,14 +382,7 @@ class Capture:
                 if ``None`` reads from drive. ``None`` by default.
 
         """
-        drive = self.mc._get_drive(servo)
-        if version is None:
-            version = self._check_version(servo)
-        if not self.is_monitoring_enabled(servo=servo):
-            return
-        drive.monitoring_disable()
-        if version >= MonitoringVersion.MONITORING_V3:
-            drive.monitoring_remove_data()
+        self._capture(servo, version).disable_monitoring()
 
     def disable_disturbance(
         self, servo: str = DEFAULT_SERVO, version: Optional[MonitoringVersion] = None
@@ -424,15 +395,7 @@ class Capture:
                 if ``None`` reads from drive. ``None`` by default.
 
         """
-        drive = self.mc._get_drive(servo)
-        if version is None:
-            version = self._check_version(servo)
-        if not self.is_disturbance_enabled(servo, version):
-            return
-        if version < MonitoringVersion.MONITORING_V3:
-            return self.disable_monitoring(servo=servo, version=version)
-        drive.disturbance_disable()
-        drive.disturbance_remove_data()
+        self._capture(servo, version).disable_disturbance()
 
     def get_monitoring_disturbance_status(self, servo: str = DEFAULT_SERVO) -> int:
         """Get Monitoring Status.
@@ -494,19 +457,7 @@ class Capture:
             TypeError: If some read value has a wrong type.
 
         """
-        if version is None:
-            version = self._check_version(servo)
-        if version < MonitoringVersion.MONITORING_V3:
-            disturbance_status = self.mc.communication.get_register(
-                self.MONITORING_STATUS_REGISTER, servo=servo, axis=0
-            )
-        else:
-            disturbance_status = self.mc.communication.get_register(
-                self.DISTURBANCE_STATUS_REGISTER, servo=servo, axis=0
-            )
-        if not isinstance(disturbance_status, int):
-            raise TypeError("Disturbance status value has to be an integer")
-        return disturbance_status
+        return self._capture(servo, version).get_disturbance_status()
 
     def is_monitoring_enabled(self, servo: str = DEFAULT_SERVO) -> bool:
         """Check if monitoring is enabled.
@@ -541,6 +492,7 @@ class Capture:
             IMRegisterNotExistError: If the register doesn't exist.
 
         """
+        version = self._resolve_version(servo, version)
         monitor_status = self.get_disturbance_status(servo, version=version)
         return (monitor_status & self.DISTURBANCE_STATUS_ENABLED_BIT) == 1
 
@@ -561,8 +513,7 @@ class Capture:
             IMRegisterNotExistError: If the register doesn't exist.
 
         """
-        if version is None:
-            version = self._check_version(servo=servo)
+        version = self._resolve_version(servo, version)
         monitor_status = self.mc.capture.get_monitoring_status(servo=servo)
         mask = self.MONITORING_STATUS_PROCESS_STAGE_BITS[version]
         masked_value = monitor_status & mask
@@ -585,8 +536,7 @@ class Capture:
             IMRegisterNotExistError: If the register doesn't exist.
 
         """
-        if version is None:
-            version = self._check_version(servo=servo)
+        version = self._resolve_version(servo, version)
         monitor_status = self.mc.capture.get_monitoring_status(servo=servo)
         mask = self.MONITORING_AVAILABLE_FRAME_BIT[version]
         return (monitor_status & mask) != 0
@@ -727,3 +677,157 @@ class Capture:
             raise TypeError("Monitoring loop frequency divider has to be an integer")
         sampling_freq = round(position_velocity_loop_rate / prescaler, 2)
         return sampling_freq
+
+
+class MotionNodeCapture:
+    """Capture operations bound to a motion node."""
+
+    def __init__(self, motion_node: "MotionNode") -> None:
+        """Initialize capture operations for a motion node.
+
+        Args:
+            motion_node: Motion node associated with the capture operations.
+        """
+        self.__servo = motion_node.servo
+        self.__version: Optional[MonitoringVersion] = None
+        self.__unsupported = False
+
+    @classmethod
+    def _with_version(
+        cls, motion_node: "MotionNode", version: MonitoringVersion
+    ) -> "MotionNodeCapture":
+        """Create a capture instance with a specified monitoring version.
+
+        Args:
+            motion_node: Motion node associated with the capture operations.
+            version: Monitoring version to use.
+
+        Returns:
+            MotionNodeCapture instance with the specified version.
+        """
+        capture = cls(motion_node)
+        capture.__version = version
+        return capture
+
+    @property
+    def version(self) -> MonitoringVersion:
+        """The monitoring version supported by the motion node.
+
+        Raises:
+            NotImplementedError: If the drive does not support monitoring and disturbance.
+            RuntimeError: If version detection does not produce a version.
+        """
+        if self.__unsupported:
+            raise NotImplementedError(
+                "The monitoring and disturbance features are not available for this drive"
+            )
+        if self.__version is not None:
+            return self.__version
+
+        try:
+            self.__servo.read(Capture.MONITORING_VERSION_REGISTER, subnode=0)
+            self.__version = MonitoringVersion.MONITORING_V3
+        except (IMRegisterNotExistError, ILError):
+            try:
+                self.__servo.read(Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER, subnode=0)
+                self.__version = MonitoringVersion.MONITORING_V2
+            except (IMRegisterNotExistError, ILError):
+                try:
+                    self.__servo.read(Capture.MONITORING_STATUS_REGISTER, subnode=0)
+                    self.__version = MonitoringVersion.MONITORING_V1
+                except (IMRegisterNotExistError, ILError):
+                    self.__unsupported = True
+                    raise NotImplementedError(
+                        "The monitoring and disturbance features are not available for this drive"
+                    )
+        if self.__version is None:
+            raise RuntimeError("Monitoring version detection did not produce a version")
+        return self.__version
+
+    def __read_status(self, register: str, message: str) -> int:
+        value = self.__servo.read(register, subnode=0)
+        if not isinstance(value, int):
+            raise TypeError(message)
+        return value
+
+    def __is_monitoring_enabled(self) -> bool:
+        status = self.__read_status(
+            Capture.MONITORING_STATUS_REGISTER,
+            "Monitoring status value has to be an integer",
+        )
+        return (status & Capture.MONITORING_STATUS_ENABLED_BIT) == 1
+
+    def __is_disturbance_enabled(self, version: MonitoringVersion) -> bool:
+        status = self.__get_disturbance_status(version)
+        return (status & Capture.DISTURBANCE_STATUS_ENABLED_BIT) == 1
+
+    def __get_disturbance_status(self, version: MonitoringVersion) -> int:
+        register = (
+            Capture.MONITORING_STATUS_REGISTER
+            if version < MonitoringVersion.MONITORING_V3
+            else Capture.DISTURBANCE_STATUS_REGISTER
+        )
+        return self.__read_status(
+            register,
+            "Disturbance status value has to be an integer",
+        )
+
+    def get_disturbance_status(self) -> int:
+        """Return the disturbance status for the motion node."""
+        return self.__get_disturbance_status(self.version)
+
+    def enable_monitoring(self) -> None:
+        """Enable monitoring for the motion node.
+
+        Raises:
+            IMMonitoringError: If monitoring cannot be enabled.
+        """
+        if self.__servo.monitoring_get_num_mapped_registers() == 0:
+            raise IMMonitoringError("There are no registers mapped for monitoring.")
+        self.__servo.monitoring_enable()
+        if not self.__is_monitoring_enabled():
+            raise IMMonitoringError("Error enabling monitoring.")
+
+    def disable_monitoring(self) -> None:
+        """Disable monitoring for the motion node.
+
+        Raises:
+            IMMonitoringError: If monitoring status cannot be read.
+        """
+        version = self.version
+        if not self.__is_monitoring_enabled():
+            return
+        self.__servo.monitoring_disable()
+        if version >= MonitoringVersion.MONITORING_V3:
+            self.__servo.monitoring_remove_data()
+
+    def enable_disturbance(self) -> None:
+        """Enable disturbance for the motion node.
+
+        Raises:
+            IMMonitoringError: If disturbance cannot be enabled.
+            NotImplementedError: If the drive does not support monitoring and disturbance.
+        """
+        version = self.version
+        if version < MonitoringVersion.MONITORING_V3:
+            self.__servo.monitoring_enable()
+        else:
+            self.__servo.disturbance_enable()
+        if not self.__is_disturbance_enabled(version):
+            raise IMMonitoringError("Error enabling disturbance.")
+
+    def disable_disturbance(self) -> None:
+        """Disable disturbance for the motion node.
+
+        Raises:
+            IMMonitoringError: If disturbance status cannot be read.
+            NotImplementedError: If the drive does not support monitoring and disturbance.
+        """
+        version = self.version
+        if not self.__is_disturbance_enabled(version):
+            return
+        if version < MonitoringVersion.MONITORING_V3:
+            self.disable_monitoring()
+            return
+        self.__servo.disturbance_disable()
+        self.__servo.disturbance_remove_data()

--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -1,11 +1,13 @@
 from typing import TYPE_CHECKING, Final, Optional, Union
 
 import numpy as np
+from ingenialink import Servo
 from ingenialink.dictionary import SubnodeType
-from ingenialink.exceptions import ILError
+from ingenialink.exceptions import ILError, ILRegisterNotFoundError
 from ingenialink.poller import Poller
 from numpy.typing import NDArray
 
+from ingeniamotion._utils import map_exceptions
 from ingeniamotion.disturbance import Disturbance
 from ingeniamotion.enums import (
     MonitoringProcessStage,
@@ -29,22 +31,241 @@ if TYPE_CHECKING:
     from ingeniamotion.motion_node import MotionNode
 
 
+_REGISTER_ERRORS: Final[dict[type[Exception], type[Exception]]] = {
+    ILRegisterNotFoundError: IMRegisterNotExistError
+}
+
+
+class MotionNodeCapture:
+    """Capture operations bound to a motion node."""
+
+    DISTURBANCE_STATUS_REGISTER = "DIST_STATUS"
+    MONITORING_STATUS_REGISTER = "MON_DIST_STATUS"
+    MONITORING_CURRENT_NUMBER_BYTES_REGISTER = "MON_CFG_BYTES_VALUE"
+    MONITORING_VERSION_REGISTER = "MON_DIST_VERSION"
+
+    MONITORING_STATUS_ENABLED_BIT = 0x1
+    DISTURBANCE_STATUS_ENABLED_BIT = 0x1
+
+    __UNSUPPORTED_MESSAGE = (
+        "The monitoring and disturbance features are not available for this drive"
+    )
+
+    def __init__(
+        self, motion_node: "MotionNode", version: Optional[MonitoringVersion] = None
+    ) -> None:
+        """Initialize capture operations for a motion node.
+
+        Args:
+            motion_node: Motion node associated with the capture operations.
+            version: Monitoring version, if ``None`` it is read from the drive.
+        """
+        self.__motion_node = motion_node
+        self.__version = version
+        self.__unsupported = False
+
+    @property
+    def version(self) -> MonitoringVersion:
+        """The monitoring version supported by the motion node.
+
+        The detected version is cached, unless a communication error made the
+        detection unreliable.
+
+        Raises:
+            NotImplementedError: If the drive does not support monitoring and disturbance.
+        """
+        if self.__version is not None:
+            return self.__version
+        if self.__unsupported:
+            raise NotImplementedError(self.__UNSUPPORTED_MESSAGE)
+
+        version, communication_failed = self.__detect_version()
+        if version is None:
+            if not communication_failed:
+                self.__unsupported = True
+            raise NotImplementedError(self.__UNSUPPORTED_MESSAGE)
+        if not communication_failed:
+            self.__version = version
+        return version
+
+    def get_monitoring_status(self) -> int:
+        """Return the monitoring status of the motion node.
+
+        Returns:
+            Monitoring status.
+
+        Raises:
+            ILRegisterNotFoundError: If the register doesn't exist.
+            TypeError: If the read value has a wrong type.
+        """
+        return self.__read_status(
+            self.MONITORING_STATUS_REGISTER, "Monitoring status value has to be an integer"
+        )
+
+    def is_monitoring_enabled(self) -> bool:
+        """Check if monitoring is enabled.
+
+        Returns:
+            True if monitoring is enabled, else False.
+
+        Raises:
+            ILRegisterNotFoundError: If the register doesn't exist.
+        """
+        return (self.get_monitoring_status() & self.MONITORING_STATUS_ENABLED_BIT) == 1
+
+    def get_disturbance_status(self) -> int:
+        """Return the disturbance status of the motion node.
+
+        Returns:
+            Disturbance status.
+
+        Raises:
+            ILRegisterNotFoundError: If the register doesn't exist.
+            NotImplementedError: If the drive does not support monitoring and disturbance.
+            TypeError: If the read value has a wrong type.
+        """
+        register = (
+            self.MONITORING_STATUS_REGISTER
+            if self.version < MonitoringVersion.MONITORING_V3
+            else self.DISTURBANCE_STATUS_REGISTER
+        )
+        return self.__read_status(register, "Disturbance status value has to be an integer")
+
+    def is_disturbance_enabled(self) -> bool:
+        """Check if disturbance is enabled.
+
+        Returns:
+            True if disturbance is enabled, else False.
+
+        Raises:
+            ILRegisterNotFoundError: If the register doesn't exist.
+            NotImplementedError: If the drive does not support monitoring and disturbance.
+        """
+        return (self.get_disturbance_status() & self.DISTURBANCE_STATUS_ENABLED_BIT) == 1
+
+    def enable_monitoring(self) -> None:
+        """Enable monitoring for the motion node.
+
+        Raises:
+            IMMonitoringError: If monitoring cannot be enabled.
+        """
+        if self.__servo.monitoring_get_num_mapped_registers() == 0:
+            raise IMMonitoringError("There are no registers mapped for monitoring.")
+        self.__servo.monitoring_enable()
+        if not self.is_monitoring_enabled():
+            raise IMMonitoringError("Error enabling monitoring.")
+
+    def disable_monitoring(self) -> None:
+        """Disable monitoring for the motion node.
+
+        Raises:
+            NotImplementedError: If the drive does not support monitoring and disturbance.
+        """
+        version = self.version
+        if not self.is_monitoring_enabled():
+            return
+        self.__servo.monitoring_disable()
+        if version >= MonitoringVersion.MONITORING_V3:
+            self.__servo.monitoring_remove_data()
+
+    def enable_disturbance(self) -> None:
+        """Enable disturbance for the motion node.
+
+        Raises:
+            IMMonitoringError: If disturbance cannot be enabled.
+            NotImplementedError: If the drive does not support monitoring and disturbance.
+        """
+        if self.version < MonitoringVersion.MONITORING_V3:
+            # V1 and V2: monitoring and disturbance share the same enable
+            # mechanism. Bypass enable_monitoring() mapped-register check
+            # because disturbance-only mapped registers are sufficient.
+            self.__servo.monitoring_enable()
+        else:
+            self.__servo.disturbance_enable()
+        if not self.is_disturbance_enabled():
+            raise IMMonitoringError("Error enabling disturbance.")
+
+    def disable_disturbance(self) -> None:
+        """Disable disturbance for the motion node.
+
+        Raises:
+            NotImplementedError: If the drive does not support monitoring and disturbance.
+        """
+        if not self.is_disturbance_enabled():
+            return
+        if self.version < MonitoringVersion.MONITORING_V3:
+            self.disable_monitoring()
+            return
+        self.__servo.disturbance_disable()
+        self.__servo.disturbance_remove_data()
+
+    @property
+    def __servo(self) -> Servo:
+        """The servo of the motion node."""
+        return self.__motion_node.servo
+
+    def __detect_version(self) -> tuple[Optional[MonitoringVersion], bool]:
+        """Probe the drive to find out the supported monitoring version.
+
+        Returns:
+            The supported version, ``None`` if there is not any, and whether a
+            communication error made the detection unreliable.
+        """
+        communication_failed = False
+        candidates = (
+            (self.MONITORING_VERSION_REGISTER, MonitoringVersion.MONITORING_V3),
+            (self.MONITORING_CURRENT_NUMBER_BYTES_REGISTER, MonitoringVersion.MONITORING_V2),
+            (self.MONITORING_STATUS_REGISTER, MonitoringVersion.MONITORING_V1),
+        )
+        for register, version in candidates:
+            try:
+                self.__motion_node.read(register)
+            except ILRegisterNotFoundError:
+                continue
+            except ILError:
+                communication_failed = True
+                continue
+            return version, communication_failed
+        return None, communication_failed
+
+    def __read_status(self, register: str, type_error_message: str) -> int:
+        """Read a status register of the motion node.
+
+        Args:
+            register: register UID.
+            type_error_message: message of the error raised on a non integer value.
+
+        Returns:
+            Current register value.
+
+        Raises:
+            ILRegisterNotFoundError: If the register doesn't exist.
+            TypeError: If the read value has a wrong type.
+        """
+        value = self.__motion_node.read(register)
+        if not isinstance(value, int):
+            raise TypeError(type_error_message)
+        return value
+
+
 class Capture:
     """Capture."""
 
-    DISTURBANCE_STATUS_REGISTER = "DIST_STATUS"
+    DISTURBANCE_STATUS_REGISTER = MotionNodeCapture.DISTURBANCE_STATUS_REGISTER
     DISTURBANCE_MAXIMUM_SAMPLE_SIZE_REGISTER = "DIST_MAX_SIZE"
-    MONITORING_STATUS_REGISTER = "MON_DIST_STATUS"
-    MONITORING_CURRENT_NUMBER_BYTES_REGISTER = "MON_CFG_BYTES_VALUE"
+    MONITORING_STATUS_REGISTER = MotionNodeCapture.MONITORING_STATUS_REGISTER
+    MONITORING_CURRENT_NUMBER_BYTES_REGISTER = (
+        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER
+    )
     MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER = "MON_MAX_SIZE"
     MONITORING_FREQUENCY_DIVIDER_REGISTER = "MON_DIST_FREQ_DIV"
 
     MINIMUM_BUFFER_SIZE = 8192
 
-    MONITORING_VERSION_REGISTER = "MON_DIST_VERSION"
+    MONITORING_VERSION_REGISTER = MotionNodeCapture.MONITORING_VERSION_REGISTER
 
-    MONITORING_STATUS_ENABLED_BIT = 0x1
-    DISTURBANCE_STATUS_ENABLED_BIT = 0x1
+    MONITORING_STATUS_ENABLED_BIT = MotionNodeCapture.MONITORING_STATUS_ENABLED_BIT
+    DISTURBANCE_STATUS_ENABLED_BIT = MotionNodeCapture.DISTURBANCE_STATUS_ENABLED_BIT
 
     MONITORING_STATUS_PROCESS_STAGE_BITS: Final[dict[MonitoringVersion, int]] = {
         MonitoringVersion.MONITORING_V1: 0x6,
@@ -288,21 +509,12 @@ class Capture:
 
     def _capture(
         self, servo: str, version: Optional[MonitoringVersion] = None
-    ) -> "MotionNodeCapture":
+    ) -> MotionNodeCapture:
         """Return capture operations for a motion node and optional version."""
         motion_node = self.mc._get_motion_node(servo)
         if version is None:
             return motion_node.capture
-
-        return MotionNodeCapture._with_version(motion_node, version)
-
-    def _resolve_version(
-        self, servo: str, version: Optional[MonitoringVersion]
-    ) -> MonitoringVersion:
-        """Return an explicit version or the bound capture's cached version."""
-        if version is not None:
-            return version
-        return self._capture(servo).version
+        return MotionNodeCapture(motion_node, version)
 
     def _check_version(self, servo: str) -> MonitoringVersion:
         """Checks the version of the monitoring based on a given servo.
@@ -343,7 +555,8 @@ class Capture:
             IMMonitoringError: If monitoring can't be enabled.
 
         """
-        self._capture(servo).enable_monitoring()
+        with map_exceptions(_REGISTER_ERRORS):
+            self._capture(servo).enable_monitoring()
 
     def enable_disturbance(
         self, servo: str = DEFAULT_SERVO, version: Optional[MonitoringVersion] = None
@@ -359,7 +572,8 @@ class Capture:
             IMMonitoringError: If disturbance can't be enabled.
 
         """
-        self._capture(servo, version).enable_disturbance()
+        with map_exceptions(_REGISTER_ERRORS):
+            self._capture(servo, version).enable_disturbance()
 
     def disable_monitoring_disturbance(self, servo: str = DEFAULT_SERVO) -> None:
         """Disable monitoring and disturbance.
@@ -382,7 +596,8 @@ class Capture:
                 if ``None`` reads from drive. ``None`` by default.
 
         """
-        self._capture(servo, version).disable_monitoring()
+        with map_exceptions(_REGISTER_ERRORS):
+            self._capture(servo, version).disable_monitoring()
 
     def disable_disturbance(
         self, servo: str = DEFAULT_SERVO, version: Optional[MonitoringVersion] = None
@@ -395,7 +610,8 @@ class Capture:
                 if ``None`` reads from drive. ``None`` by default.
 
         """
-        self._capture(servo, version).disable_disturbance()
+        with map_exceptions(_REGISTER_ERRORS):
+            self._capture(servo, version).disable_disturbance()
 
     def get_monitoring_disturbance_status(self, servo: str = DEFAULT_SERVO) -> int:
         """Get Monitoring Status.
@@ -411,12 +627,8 @@ class Capture:
             TypeError: If some read value has a wrong type.
 
         """
-        monitoring_disturbance_status = self.mc.communication.get_register(
-            self.MONITORING_STATUS_REGISTER, servo=servo, axis=0
-        )
-        if not isinstance(monitoring_disturbance_status, int):
-            raise TypeError("Monitoring and disturbance status value has to be an integer")
-        return monitoring_disturbance_status
+        with map_exceptions(_REGISTER_ERRORS):
+            return self._capture(servo).get_monitoring_status()
 
     def get_monitoring_status(self, servo: str = DEFAULT_SERVO) -> int:
         """Get Monitoring Status.
@@ -432,12 +644,8 @@ class Capture:
             TypeError: If some read value has a wrong type.
 
         """
-        monitoring_status = self.mc.communication.get_register(
-            self.MONITORING_STATUS_REGISTER, servo=servo, axis=0
-        )
-        if not isinstance(monitoring_status, int):
-            raise TypeError("Monitoring status value has to be an integer")
-        return monitoring_status
+        with map_exceptions(_REGISTER_ERRORS):
+            return self._capture(servo).get_monitoring_status()
 
     def get_disturbance_status(
         self, servo: str = DEFAULT_SERVO, version: Optional[MonitoringVersion] = None
@@ -457,7 +665,8 @@ class Capture:
             TypeError: If some read value has a wrong type.
 
         """
-        return self._capture(servo, version).get_disturbance_status()
+        with map_exceptions(_REGISTER_ERRORS):
+            return self._capture(servo, version).get_disturbance_status()
 
     def is_monitoring_enabled(self, servo: str = DEFAULT_SERVO) -> bool:
         """Check if monitoring is enabled.
@@ -472,8 +681,8 @@ class Capture:
             IMRegisterNotExistError: If the register doesn't exist.
 
         """
-        monitor_status = self.get_monitoring_status(servo)
-        return (monitor_status & self.MONITORING_STATUS_ENABLED_BIT) == 1
+        with map_exceptions(_REGISTER_ERRORS):
+            return self._capture(servo).is_monitoring_enabled()
 
     def is_disturbance_enabled(
         self, servo: str = DEFAULT_SERVO, version: Optional[MonitoringVersion] = None
@@ -492,9 +701,8 @@ class Capture:
             IMRegisterNotExistError: If the register doesn't exist.
 
         """
-        version = self._resolve_version(servo, version)
-        monitor_status = self.get_disturbance_status(servo, version=version)
-        return (monitor_status & self.DISTURBANCE_STATUS_ENABLED_BIT) == 1
+        with map_exceptions(_REGISTER_ERRORS):
+            return self._capture(servo, version).is_disturbance_enabled()
 
     def get_monitoring_process_stage(
         self, servo: str = DEFAULT_SERVO, version: Optional[MonitoringVersion] = None
@@ -513,7 +721,8 @@ class Capture:
             IMRegisterNotExistError: If the register doesn't exist.
 
         """
-        version = self._resolve_version(servo, version)
+        if version is None:
+            version = self._check_version(servo)
         monitor_status = self.mc.capture.get_monitoring_status(servo=servo)
         mask = self.MONITORING_STATUS_PROCESS_STAGE_BITS[version]
         masked_value = monitor_status & mask
@@ -536,7 +745,8 @@ class Capture:
             IMRegisterNotExistError: If the register doesn't exist.
 
         """
-        version = self._resolve_version(servo, version)
+        if version is None:
+            version = self._check_version(servo)
         monitor_status = self.mc.capture.get_monitoring_status(servo=servo)
         mask = self.MONITORING_AVAILABLE_FRAME_BIT[version]
         return (monitor_status & mask) != 0
@@ -677,157 +887,3 @@ class Capture:
             raise TypeError("Monitoring loop frequency divider has to be an integer")
         sampling_freq = round(position_velocity_loop_rate / prescaler, 2)
         return sampling_freq
-
-
-class MotionNodeCapture:
-    """Capture operations bound to a motion node."""
-
-    def __init__(self, motion_node: "MotionNode") -> None:
-        """Initialize capture operations for a motion node.
-
-        Args:
-            motion_node: Motion node associated with the capture operations.
-        """
-        self.__servo = motion_node.servo
-        self.__version: Optional[MonitoringVersion] = None
-        self.__unsupported = False
-
-    @classmethod
-    def _with_version(
-        cls, motion_node: "MotionNode", version: MonitoringVersion
-    ) -> "MotionNodeCapture":
-        """Create a capture instance with a specified monitoring version.
-
-        Args:
-            motion_node: Motion node associated with the capture operations.
-            version: Monitoring version to use.
-
-        Returns:
-            MotionNodeCapture instance with the specified version.
-        """
-        capture = cls(motion_node)
-        capture.__version = version
-        return capture
-
-    @property
-    def version(self) -> MonitoringVersion:
-        """The monitoring version supported by the motion node.
-
-        Raises:
-            NotImplementedError: If the drive does not support monitoring and disturbance.
-            RuntimeError: If version detection does not produce a version.
-        """
-        if self.__unsupported:
-            raise NotImplementedError(
-                "The monitoring and disturbance features are not available for this drive"
-            )
-        if self.__version is not None:
-            return self.__version
-
-        try:
-            self.__servo.read(Capture.MONITORING_VERSION_REGISTER, subnode=0)
-            self.__version = MonitoringVersion.MONITORING_V3
-        except (IMRegisterNotExistError, ILError):
-            try:
-                self.__servo.read(Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER, subnode=0)
-                self.__version = MonitoringVersion.MONITORING_V2
-            except (IMRegisterNotExistError, ILError):
-                try:
-                    self.__servo.read(Capture.MONITORING_STATUS_REGISTER, subnode=0)
-                    self.__version = MonitoringVersion.MONITORING_V1
-                except (IMRegisterNotExistError, ILError):
-                    self.__unsupported = True
-                    raise NotImplementedError(
-                        "The monitoring and disturbance features are not available for this drive"
-                    )
-        if self.__version is None:
-            raise RuntimeError("Monitoring version detection did not produce a version")
-        return self.__version
-
-    def __read_status(self, register: str, message: str) -> int:
-        value = self.__servo.read(register, subnode=0)
-        if not isinstance(value, int):
-            raise TypeError(message)
-        return value
-
-    def __is_monitoring_enabled(self) -> bool:
-        status = self.__read_status(
-            Capture.MONITORING_STATUS_REGISTER,
-            "Monitoring status value has to be an integer",
-        )
-        return (status & Capture.MONITORING_STATUS_ENABLED_BIT) == 1
-
-    def __is_disturbance_enabled(self, version: MonitoringVersion) -> bool:
-        status = self.__get_disturbance_status(version)
-        return (status & Capture.DISTURBANCE_STATUS_ENABLED_BIT) == 1
-
-    def __get_disturbance_status(self, version: MonitoringVersion) -> int:
-        register = (
-            Capture.MONITORING_STATUS_REGISTER
-            if version < MonitoringVersion.MONITORING_V3
-            else Capture.DISTURBANCE_STATUS_REGISTER
-        )
-        return self.__read_status(
-            register,
-            "Disturbance status value has to be an integer",
-        )
-
-    def get_disturbance_status(self) -> int:
-        """Return the disturbance status for the motion node."""
-        return self.__get_disturbance_status(self.version)
-
-    def enable_monitoring(self) -> None:
-        """Enable monitoring for the motion node.
-
-        Raises:
-            IMMonitoringError: If monitoring cannot be enabled.
-        """
-        if self.__servo.monitoring_get_num_mapped_registers() == 0:
-            raise IMMonitoringError("There are no registers mapped for monitoring.")
-        self.__servo.monitoring_enable()
-        if not self.__is_monitoring_enabled():
-            raise IMMonitoringError("Error enabling monitoring.")
-
-    def disable_monitoring(self) -> None:
-        """Disable monitoring for the motion node.
-
-        Raises:
-            IMMonitoringError: If monitoring status cannot be read.
-        """
-        version = self.version
-        if not self.__is_monitoring_enabled():
-            return
-        self.__servo.monitoring_disable()
-        if version >= MonitoringVersion.MONITORING_V3:
-            self.__servo.monitoring_remove_data()
-
-    def enable_disturbance(self) -> None:
-        """Enable disturbance for the motion node.
-
-        Raises:
-            IMMonitoringError: If disturbance cannot be enabled.
-            NotImplementedError: If the drive does not support monitoring and disturbance.
-        """
-        version = self.version
-        if version < MonitoringVersion.MONITORING_V3:
-            self.__servo.monitoring_enable()
-        else:
-            self.__servo.disturbance_enable()
-        if not self.__is_disturbance_enabled(version):
-            raise IMMonitoringError("Error enabling disturbance.")
-
-    def disable_disturbance(self) -> None:
-        """Disable disturbance for the motion node.
-
-        Raises:
-            IMMonitoringError: If disturbance status cannot be read.
-            NotImplementedError: If the drive does not support monitoring and disturbance.
-        """
-        version = self.version
-        if not self.__is_disturbance_enabled(version):
-            return
-        if version < MonitoringVersion.MONITORING_V3:
-            self.disable_monitoring()
-            return
-        self.__servo.disturbance_disable()
-        self.__servo.disturbance_remove_data()

--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -219,7 +219,7 @@ class MotionNodeCapture:
         )
         for register, version in candidates:
             try:
-                self.__motion_node.read(register)
+                self.__servo.read(register, subnode=0)
             except ILRegisterNotFoundError:
                 continue
             except ILError:
@@ -242,7 +242,7 @@ class MotionNodeCapture:
             ILRegisterNotFoundError: If the register doesn't exist.
             TypeError: If the read value has a wrong type.
         """
-        value = self.__motion_node.read(register)
+        value = self.__servo.read(register, subnode=0)
         if not isinstance(value, int):
             raise TypeError(type_error_message)
         return value

--- a/ingeniamotion/capture.py
+++ b/ingeniamotion/capture.py
@@ -39,13 +39,13 @@ _REGISTER_ERRORS: Final[dict[type[Exception], type[Exception]]] = {
 class MotionNodeCapture:
     """Capture operations bound to a motion node."""
 
-    DISTURBANCE_STATUS_REGISTER = "DIST_STATUS"
-    MONITORING_STATUS_REGISTER = "MON_DIST_STATUS"
-    MONITORING_CURRENT_NUMBER_BYTES_REGISTER = "MON_CFG_BYTES_VALUE"
-    MONITORING_VERSION_REGISTER = "MON_DIST_VERSION"
+    _DISTURBANCE_STATUS_REGISTER = "DIST_STATUS"
+    _MONITORING_STATUS_REGISTER = "MON_DIST_STATUS"
+    _MONITORING_CURRENT_NUMBER_BYTES_REGISTER = "MON_CFG_BYTES_VALUE"
+    _MONITORING_VERSION_REGISTER = "MON_DIST_VERSION"
 
-    MONITORING_STATUS_ENABLED_BIT = 0x1
-    DISTURBANCE_STATUS_ENABLED_BIT = 0x1
+    _MONITORING_STATUS_ENABLED_BIT = 0x1
+    _DISTURBANCE_STATUS_ENABLED_BIT = 0x1
 
     __UNSUPPORTED_MESSAGE = (
         "The monitoring and disturbance features are not available for this drive"
@@ -99,7 +99,8 @@ class MotionNodeCapture:
             TypeError: If the read value has a wrong type.
         """
         return self.__read_status(
-            self.MONITORING_STATUS_REGISTER, "Monitoring status value has to be an integer"
+            self._MONITORING_STATUS_REGISTER,
+            "Monitoring status value has to be an integer",
         )
 
     def is_monitoring_enabled(self) -> bool:
@@ -111,7 +112,7 @@ class MotionNodeCapture:
         Raises:
             ILRegisterNotFoundError: If the register doesn't exist.
         """
-        return (self.get_monitoring_status() & self.MONITORING_STATUS_ENABLED_BIT) == 1
+        return (self.get_monitoring_status() & self._MONITORING_STATUS_ENABLED_BIT) == 1
 
     def get_disturbance_status(self) -> int:
         """Return the disturbance status of the motion node.
@@ -125,9 +126,9 @@ class MotionNodeCapture:
             TypeError: If the read value has a wrong type.
         """
         register = (
-            self.MONITORING_STATUS_REGISTER
+            self._MONITORING_STATUS_REGISTER
             if self.version < MonitoringVersion.MONITORING_V3
-            else self.DISTURBANCE_STATUS_REGISTER
+            else self._DISTURBANCE_STATUS_REGISTER
         )
         return self.__read_status(register, "Disturbance status value has to be an integer")
 
@@ -141,7 +142,7 @@ class MotionNodeCapture:
             ILRegisterNotFoundError: If the register doesn't exist.
             NotImplementedError: If the drive does not support monitoring and disturbance.
         """
-        return (self.get_disturbance_status() & self.DISTURBANCE_STATUS_ENABLED_BIT) == 1
+        return (self.get_disturbance_status() & self._DISTURBANCE_STATUS_ENABLED_BIT) == 1
 
     def enable_monitoring(self) -> None:
         """Enable monitoring for the motion node.
@@ -213,9 +214,9 @@ class MotionNodeCapture:
         """
         communication_failed = False
         candidates = (
-            (self.MONITORING_VERSION_REGISTER, MonitoringVersion.MONITORING_V3),
-            (self.MONITORING_CURRENT_NUMBER_BYTES_REGISTER, MonitoringVersion.MONITORING_V2),
-            (self.MONITORING_STATUS_REGISTER, MonitoringVersion.MONITORING_V1),
+            (self._MONITORING_VERSION_REGISTER, MonitoringVersion.MONITORING_V3),
+            (self._MONITORING_CURRENT_NUMBER_BYTES_REGISTER, MonitoringVersion.MONITORING_V2),
+            (self._MONITORING_STATUS_REGISTER, MonitoringVersion.MONITORING_V1),
         )
         for register, version in candidates:
             try:
@@ -251,21 +252,21 @@ class MotionNodeCapture:
 class Capture:
     """Capture."""
 
-    DISTURBANCE_STATUS_REGISTER = MotionNodeCapture.DISTURBANCE_STATUS_REGISTER
+    DISTURBANCE_STATUS_REGISTER = MotionNodeCapture._DISTURBANCE_STATUS_REGISTER
     DISTURBANCE_MAXIMUM_SAMPLE_SIZE_REGISTER = "DIST_MAX_SIZE"
-    MONITORING_STATUS_REGISTER = MotionNodeCapture.MONITORING_STATUS_REGISTER
+    MONITORING_STATUS_REGISTER = MotionNodeCapture._MONITORING_STATUS_REGISTER
     MONITORING_CURRENT_NUMBER_BYTES_REGISTER = (
-        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER
+        MotionNodeCapture._MONITORING_CURRENT_NUMBER_BYTES_REGISTER
     )
     MONITORING_MAXIMUM_SAMPLE_SIZE_REGISTER = "MON_MAX_SIZE"
     MONITORING_FREQUENCY_DIVIDER_REGISTER = "MON_DIST_FREQ_DIV"
 
     MINIMUM_BUFFER_SIZE = 8192
 
-    MONITORING_VERSION_REGISTER = MotionNodeCapture.MONITORING_VERSION_REGISTER
+    MONITORING_VERSION_REGISTER = MotionNodeCapture._MONITORING_VERSION_REGISTER
 
-    MONITORING_STATUS_ENABLED_BIT = MotionNodeCapture.MONITORING_STATUS_ENABLED_BIT
-    DISTURBANCE_STATUS_ENABLED_BIT = MotionNodeCapture.DISTURBANCE_STATUS_ENABLED_BIT
+    MONITORING_STATUS_ENABLED_BIT = MotionNodeCapture._MONITORING_STATUS_ENABLED_BIT
+    DISTURBANCE_STATUS_ENABLED_BIT = MotionNodeCapture._DISTURBANCE_STATUS_ENABLED_BIT
 
     MONITORING_STATUS_PROCESS_STAGE_BITS: Final[dict[MonitoringVersion, int]] = {
         MonitoringVersion.MONITORING_V1: 0x6,

--- a/ingeniamotion/motion_node.py
+++ b/ingeniamotion/motion_node.py
@@ -2,6 +2,7 @@ from collections.abc import Iterator
 from functools import cached_property
 
 from ingenialink import Network, Servo
+from ingenialink.utils._utils import REG_VALUE
 
 from ingeniamotion.axis import Axis
 from ingeniamotion.capture import MotionNodeCapture
@@ -36,6 +37,17 @@ class MotionNode:
     def network(self) -> Network:
         """Network associated with the motion node."""
         return self.__net
+
+    def read(self, reg_uid: str) -> REG_VALUE:
+        """Read a register of the motion node itself.
+
+        Args:
+            reg_uid: register UID to read.
+
+        Returns:
+            The register value.
+        """
+        return self.__servo.read(reg_uid, subnode=0)
 
     @property
     def axes(self) -> Iterator["Axis"]:

--- a/ingeniamotion/motion_node.py
+++ b/ingeniamotion/motion_node.py
@@ -4,6 +4,7 @@ from functools import cached_property
 from ingenialink import Network, Servo
 
 from ingeniamotion.axis import Axis
+from ingeniamotion.capture import MotionNodeCapture
 from ingeniamotion.errors import NodeErrors
 
 
@@ -67,3 +68,8 @@ class MotionNode:
             The error container, built on first access.
         """
         return NodeErrors(self)
+
+    @cached_property
+    def capture(self) -> "MotionNodeCapture":
+        """The capture operations of the motion node."""
+        return MotionNodeCapture(self)

--- a/ingeniamotion/motion_node.py
+++ b/ingeniamotion/motion_node.py
@@ -2,7 +2,6 @@ from collections.abc import Iterator
 from functools import cached_property
 
 from ingenialink import Network, Servo
-from ingenialink.utils._utils import REG_VALUE
 
 from ingeniamotion.axis import Axis
 from ingeniamotion.capture import MotionNodeCapture
@@ -37,17 +36,6 @@ class MotionNode:
     def network(self) -> Network:
         """Network associated with the motion node."""
         return self.__net
-
-    def read(self, reg_uid: str) -> REG_VALUE:
-        """Read a register of the motion node itself.
-
-        Args:
-            reg_uid: register UID to read.
-
-        Returns:
-            The register value.
-        """
-        return self.__servo.read(reg_uid, subnode=0)
 
     @property
     def axes(self) -> Iterator["Axis"]:

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -1,3 +1,4 @@
+import summit_drives_ci_configs.config_files as config_files
 from ingenialink.dictionary import Interface
 from summit_testing_framework.configuration.encoder_configurator import (
     EncoderConfiguration,
@@ -14,7 +15,6 @@ from summit_testing_framework.setups.specifiers import (
     VersionConfig,
 )
 
-import summit_drives_ci_configs.config_files as config_files
 from tests.conftest import BISS_C_CONFIG_MARKER, RANDOM_COMBINATIONS_SLICE_KEY
 
 __EXECUTION_POLICY_KEY: str = "execution_policy"

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -1,4 +1,3 @@
-import summit_drives_ci_configs.config_files as config_files
 from ingenialink.dictionary import Interface
 from summit_testing_framework.configuration.encoder_configurator import (
     EncoderConfiguration,
@@ -15,6 +14,7 @@ from summit_testing_framework.setups.specifiers import (
     VersionConfig,
 )
 
+import summit_drives_ci_configs.config_files as config_files
 from tests.conftest import BISS_C_CONFIG_MARKER, RANDOM_COMBINATIONS_SLICE_KEY
 
 __EXECUTION_POLICY_KEY: str = "execution_policy"

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from ingenialink.dictionary import Interface
 
+from ingeniamotion.capture import Capture
 from ingeniamotion.enums import (
     MonitoringProcessStage,
     MonitoringSoCConfig,
@@ -11,7 +12,7 @@ from ingeniamotion.enums import (
     MonitoringVersion,
     OperationMode,
 )
-from ingeniamotion.exceptions import IMMonitoringError, IMStatusWordError
+from ingeniamotion.exceptions import IMMonitoringError, IMRegisterNotExistError, IMStatusWordError
 
 
 def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
@@ -329,31 +330,109 @@ def test_check_monitoring_version_v3(mc, alias):
 
 
 @pytest.mark.virtual
+def test_motion_node_capture_version_is_cached(mocker, motion_node):
+    """Test that version detection reads the registers only once."""
+    read = mocker.spy(motion_node.servo, "read")
+
+    first_version = motion_node.capture.version
+    second_version = motion_node.capture.version
+
+    assert first_version == MonitoringVersion.MONITORING_V3
+    assert second_version == MonitoringVersion.MONITORING_V3
+    detection_registers = {
+        Capture.MONITORING_VERSION_REGISTER,
+        Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        Capture.MONITORING_STATUS_REGISTER,
+    }
+    detection_reads = [
+        call.args[0] for call in read.call_args_list if call.args[0] in detection_registers
+    ]
+    assert detection_reads == [Capture.MONITORING_VERSION_REGISTER]
+    detection_calls = [call for call in read.call_args_list if call.args[0] in detection_registers]
+    assert all(call.kwargs == {"subnode": 0} for call in detection_calls)
+
+
+@pytest.mark.virtual
+def test_motion_node_capture_unsupported_version_is_cached(mocker, motion_node):
+    """Test that unsupported monitoring detection is not repeated."""
+    detection_registers = {
+        Capture.MONITORING_VERSION_REGISTER,
+        Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        Capture.MONITORING_STATUS_REGISTER,
+    }
+    original_read = motion_node.servo.read
+
+    def read(register, *args, **kwargs):
+        if register in detection_registers:
+            raise IMRegisterNotExistError
+        return original_read(register, *args, **kwargs)
+
+    read_mock = mocker.patch.object(motion_node.servo, "read", side_effect=read)
+
+    with pytest.raises(NotImplementedError) as first_error:
+        motion_node.capture.version
+    with pytest.raises(NotImplementedError) as second_error:
+        motion_node.capture.version
+
+    assert first_error.value is not second_error.value
+    detection_reads = [call.args[0] for call in read_mock.call_args_list]
+    assert detection_reads == [
+        Capture.MONITORING_VERSION_REGISTER,
+        Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        Capture.MONITORING_STATUS_REGISTER,
+    ]
+    assert all(call.kwargs == {"subnode": 0} for call in read_mock.call_args_list)
+
+
+@pytest.mark.virtual
 def test_check_monitoring_version_v2(mocker, mc, alias):
-    mocker.patch.object(mc.capture, "MONITORING_VERSION_REGISTER", return_value="NON_EXISTING_UID")
+    mocker.patch.object(Capture, "MONITORING_VERSION_REGISTER", "NON_EXISTING_UID")
     version = mc.capture._check_version(servo=alias)
     assert version == MonitoringVersion.MONITORING_V2
 
 
 @pytest.mark.virtual
 def test_check_monitoring_version_v1(mocker, mc, alias):
-    mocker.patch.object(mc.capture, "MONITORING_VERSION_REGISTER", return_value="NON_EXISTING_UID")
-    mocker.patch.object(
-        mc.capture, "MONITORING_CURRENT_NUMBER_BYTES_REGISTER", return_value="NON_EXISTING_UID"
-    )
+    mocker.patch.object(Capture, "MONITORING_VERSION_REGISTER", "NON_EXISTING_UID")
+    mocker.patch.object(Capture, "MONITORING_CURRENT_NUMBER_BYTES_REGISTER", "NON_EXISTING_UID")
     version = mc.capture._check_version(servo=alias)
     assert version == MonitoringVersion.MONITORING_V1
 
 
 @pytest.mark.virtual
 def test_check_monitoring_version_not_available(mocker, mc, alias):
-    mocker.patch.object(mc.capture, "MONITORING_VERSION_REGISTER", return_value="NON_EXISTING_UID")
-    mocker.patch.object(
-        mc.capture, "MONITORING_CURRENT_NUMBER_BYTES_REGISTER", return_value="NON_EXISTING_UID"
-    )
-    mocker.patch.object(mc.capture, "MONITORING_STATUS_REGISTER", return_value="NON_EXISTING_UID")
+    motion_node = mc.motion_nodes[alias]
+
+    def read(_register, *args, **kwargs):
+        raise IMRegisterNotExistError
+
+    read_mock = mocker.patch.object(motion_node.servo, "read", side_effect=read)
     with pytest.raises(NotImplementedError):
         mc.capture._check_version(servo=alias)
+    assert [call.args[0] for call in read_mock.call_args_list] == [
+        Capture.MONITORING_VERSION_REGISTER,
+        Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        Capture.MONITORING_STATUS_REGISTER,
+    ]
+    assert all(call.kwargs == {"subnode": 0} for call in read_mock.call_args_list)
+
+
+@pytest.mark.virtual
+def test_capture_explicit_version_bypasses_detection(mocker, mc, alias):
+    """Test that an explicit facade version does not probe detection registers."""
+    read = mocker.spy(mc.servos[alias], "read")
+
+    mc.capture.disable_disturbance(servo=alias, version=MonitoringVersion.MONITORING_V3)
+
+    detection_registers = {
+        Capture.MONITORING_VERSION_REGISTER,
+        Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        Capture.MONITORING_STATUS_REGISTER,
+    }
+    detection_reads = [
+        call.args[0] for call in read.call_args_list if call.args[0] in detection_registers
+    ]
+    assert not detection_reads
 
 
 @pytest.mark.virtual
@@ -364,7 +443,7 @@ def test_enable_monitoring_exception(mocker, mc, alias):
         sample_time=0.1,
         servo=alias,
     )
-    mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
+    mocker.patch.object(mc.servos[alias], "read", return_value=0)
     with pytest.raises(IMMonitoringError):
         mc.capture.enable_monitoring(servo=alias)
 
@@ -372,9 +451,8 @@ def test_enable_monitoring_exception(mocker, mc, alias):
 @pytest.mark.virtual
 def test_enable_disturbance_exception(mocker, mc, alias):
     monitoring = mc.capture.create_empty_monitoring(alias)
-    mocker.patch.object(mc.capture, "is_disturbance_enabled", return_value=False)
-    mocker.patch.object(mc.capture, "is_monitoring_enabled", return_value=False)
     monitoring.map_registers([{"axis": 1, "name": "CL_POS_FBK_VALUE"}])
+    mocker.patch.object(mc.servos[alias], "read", return_value=0)
     with pytest.raises(IMMonitoringError):
         mc.capture.enable_disturbance(servo=alias)
 
@@ -385,7 +463,7 @@ def test_enable_disturbance_exception(mocker, mc, alias):
 )
 @pytest.mark.virtual
 def test_get_monitoring_disturbance_status_exception(mocker, mc, alias, function):
-    mocker.patch.object(mc.communication, "get_register", return_value="invalid_value")
+    mocker.patch.object(mc.servos[alias], "read", return_value="invalid_value")
     with pytest.raises(TypeError):
         getattr(mc.capture, function)(servo=alias)
 

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -3,8 +3,9 @@ import time
 import numpy as np
 import pytest
 from ingenialink.dictionary import Interface
+from ingenialink.exceptions import ILError, ILRegisterNotFoundError
 
-from ingeniamotion.capture import Capture
+from ingeniamotion.capture import MotionNodeCapture
 from ingeniamotion.enums import (
     MonitoringProcessStage,
     MonitoringSoCConfig,
@@ -12,7 +13,11 @@ from ingeniamotion.enums import (
     MonitoringVersion,
     OperationMode,
 )
-from ingeniamotion.exceptions import IMMonitoringError, IMRegisterNotExistError, IMStatusWordError
+from ingeniamotion.exceptions import (
+    IMMonitoringError,
+    IMRegisterNotExistError,
+    IMStatusWordError,
+)
 
 
 def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
@@ -340,14 +345,14 @@ def test_motion_node_capture_version_is_cached(mocker, motion_node):
     assert first_version == MonitoringVersion.MONITORING_V3
     assert second_version == MonitoringVersion.MONITORING_V3
     detection_registers = {
-        Capture.MONITORING_VERSION_REGISTER,
-        Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
-        Capture.MONITORING_STATUS_REGISTER,
+        MotionNodeCapture.MONITORING_VERSION_REGISTER,
+        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        MotionNodeCapture.MONITORING_STATUS_REGISTER,
     }
     detection_reads = [
         call.args[0] for call in read.call_args_list if call.args[0] in detection_registers
     ]
-    assert detection_reads == [Capture.MONITORING_VERSION_REGISTER]
+    assert detection_reads == [MotionNodeCapture.MONITORING_VERSION_REGISTER]
     detection_calls = [call for call in read.call_args_list if call.args[0] in detection_registers]
     assert all(call.kwargs == {"subnode": 0} for call in detection_calls)
 
@@ -356,15 +361,15 @@ def test_motion_node_capture_version_is_cached(mocker, motion_node):
 def test_motion_node_capture_unsupported_version_is_cached(mocker, motion_node):
     """Test that unsupported monitoring detection is not repeated."""
     detection_registers = {
-        Capture.MONITORING_VERSION_REGISTER,
-        Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
-        Capture.MONITORING_STATUS_REGISTER,
+        MotionNodeCapture.MONITORING_VERSION_REGISTER,
+        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        MotionNodeCapture.MONITORING_STATUS_REGISTER,
     }
     original_read = motion_node.servo.read
 
     def read(register, *args, **kwargs):
         if register in detection_registers:
-            raise IMRegisterNotExistError
+            raise ILRegisterNotFoundError
         return original_read(register, *args, **kwargs)
 
     read_mock = mocker.patch.object(motion_node.servo, "read", side_effect=read)
@@ -377,44 +382,88 @@ def test_motion_node_capture_unsupported_version_is_cached(mocker, motion_node):
     assert first_error.value is not second_error.value
     detection_reads = [call.args[0] for call in read_mock.call_args_list]
     assert detection_reads == [
-        Capture.MONITORING_VERSION_REGISTER,
-        Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
-        Capture.MONITORING_STATUS_REGISTER,
+        MotionNodeCapture.MONITORING_VERSION_REGISTER,
+        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        MotionNodeCapture.MONITORING_STATUS_REGISTER,
     ]
     assert all(call.kwargs == {"subnode": 0} for call in read_mock.call_args_list)
 
 
 @pytest.mark.virtual
+def test_motion_node_capture_raises_ingenialink_register_error(mocker, motion_node):
+    """Test that the motion node capture raises the ingenialink register error."""
+    mocker.patch.object(MotionNodeCapture, "MONITORING_STATUS_REGISTER", "NON_EXISTING_UID")
+    with pytest.raises(ILRegisterNotFoundError):
+        motion_node.capture.get_monitoring_status()
+
+
+@pytest.mark.virtual
+def test_capture_raises_ingeniamotion_register_error(mocker, mc, alias):
+    """Test that the facade keeps raising the ingeniamotion register error."""
+    mocker.patch.object(MotionNodeCapture, "MONITORING_STATUS_REGISTER", "NON_EXISTING_UID")
+    with pytest.raises(IMRegisterNotExistError):
+        mc.capture.get_monitoring_status(servo=alias)
+
+
+@pytest.mark.virtual
 def test_check_monitoring_version_v2(mocker, mc, alias):
-    mocker.patch.object(Capture, "MONITORING_VERSION_REGISTER", "NON_EXISTING_UID")
+    mocker.patch.object(MotionNodeCapture, "MONITORING_VERSION_REGISTER", "NON_EXISTING_UID")
     version = mc.capture._check_version(servo=alias)
     assert version == MonitoringVersion.MONITORING_V2
 
 
 @pytest.mark.virtual
 def test_check_monitoring_version_v1(mocker, mc, alias):
-    mocker.patch.object(Capture, "MONITORING_VERSION_REGISTER", "NON_EXISTING_UID")
-    mocker.patch.object(Capture, "MONITORING_CURRENT_NUMBER_BYTES_REGISTER", "NON_EXISTING_UID")
+    mocker.patch.object(MotionNodeCapture, "MONITORING_VERSION_REGISTER", "NON_EXISTING_UID")
+    mocker.patch.object(
+        MotionNodeCapture, "MONITORING_CURRENT_NUMBER_BYTES_REGISTER", "NON_EXISTING_UID"
+    )
     version = mc.capture._check_version(servo=alias)
     assert version == MonitoringVersion.MONITORING_V1
 
 
 @pytest.mark.virtual
 def test_check_monitoring_version_not_available(mocker, mc, alias):
-    motion_node = mc.motion_nodes[alias]
+    detection_registers = [
+        MotionNodeCapture.MONITORING_VERSION_REGISTER,
+        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        MotionNodeCapture.MONITORING_STATUS_REGISTER,
+    ]
+    servo = mc.servos[alias]
+    original_read = servo.read
 
-    def read(_register, *args, **kwargs):
-        raise IMRegisterNotExistError
+    def read(register, *args, **kwargs):
+        if register in detection_registers:
+            raise ILRegisterNotFoundError
+        return original_read(register, *args, **kwargs)
 
-    read_mock = mocker.patch.object(motion_node.servo, "read", side_effect=read)
+    read_mock = mocker.patch.object(servo, "read", side_effect=read)
     with pytest.raises(NotImplementedError):
         mc.capture._check_version(servo=alias)
-    assert [call.args[0] for call in read_mock.call_args_list] == [
-        Capture.MONITORING_VERSION_REGISTER,
-        Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
-        Capture.MONITORING_STATUS_REGISTER,
+    detection_calls = [
+        call for call in read_mock.call_args_list if call.args[0] in detection_registers
     ]
-    assert all(call.kwargs == {"subnode": 0} for call in read_mock.call_args_list)
+    assert [call.args[0] for call in detection_calls] == detection_registers
+    assert all(call.kwargs == {"subnode": 0} for call in detection_calls)
+
+
+@pytest.mark.virtual
+def test_motion_node_capture_version_is_not_cached_after_communication_error(mocker, motion_node):
+    """Test that a version detected after a communication error is detected again."""
+    original_read = motion_node.servo.read
+    failed = False
+
+    def read(register, *args, **kwargs):
+        nonlocal failed
+        if register == MotionNodeCapture.MONITORING_VERSION_REGISTER and not failed:
+            failed = True
+            raise ILError
+        return original_read(register, *args, **kwargs)
+
+    mocker.patch.object(motion_node.servo, "read", side_effect=read)
+
+    assert motion_node.capture.version == MonitoringVersion.MONITORING_V2
+    assert motion_node.capture.version == MonitoringVersion.MONITORING_V3
 
 
 @pytest.mark.virtual
@@ -425,9 +474,9 @@ def test_capture_explicit_version_bypasses_detection(mocker, mc, alias):
     mc.capture.disable_disturbance(servo=alias, version=MonitoringVersion.MONITORING_V3)
 
     detection_registers = {
-        Capture.MONITORING_VERSION_REGISTER,
-        Capture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
-        Capture.MONITORING_STATUS_REGISTER,
+        MotionNodeCapture.MONITORING_VERSION_REGISTER,
+        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        MotionNodeCapture.MONITORING_STATUS_REGISTER,
     }
     detection_reads = [
         call.args[0] for call in read.call_args_list if call.args[0] in detection_registers

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -39,9 +39,9 @@ def patch_monitoring_version(
     """Reset capture state and make higher monitoring versions unavailable."""
     reset_monitoring_cache(motion_node)
     detection_registers = (
-        "MONITORING_VERSION_REGISTER",
-        "MONITORING_CURRENT_NUMBER_BYTES_REGISTER",
-        "MONITORING_STATUS_REGISTER",
+        "_MONITORING_VERSION_REGISTER",
+        "_MONITORING_CURRENT_NUMBER_BYTES_REGISTER",
+        "_MONITORING_STATUS_REGISTER",
     )
     available_register_index = {
         MonitoringVersion.MONITORING_V3: 0,

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -484,12 +484,12 @@ def test_check_monitoring_version_v1(mocker, mc, alias, motion_node):
 
 @pytest.mark.virtual
 def test_check_monitoring_version_not_available(mocker, mc, alias, motion_node):
+    patch_monitoring_version(mocker, motion_node, None)
     detection_registers = [
         MotionNodeCapture._MONITORING_VERSION_REGISTER,
         MotionNodeCapture._MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
         MotionNodeCapture._MONITORING_STATUS_REGISTER,
     ]
-    patch_monitoring_version(mocker, motion_node, None)
     servo = mc.servos[alias]
     original_read = servo.read
 

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -407,14 +407,14 @@ def test_motion_node_capture_version_is_cached(mocker, motion_node):
     assert first_version == MonitoringVersion.MONITORING_V3
     assert second_version == MonitoringVersion.MONITORING_V3
     detection_registers = {
-        MotionNodeCapture.MONITORING_VERSION_REGISTER,
-        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
-        MotionNodeCapture.MONITORING_STATUS_REGISTER,
+        MotionNodeCapture._MONITORING_VERSION_REGISTER,
+        MotionNodeCapture._MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        MotionNodeCapture._MONITORING_STATUS_REGISTER,
     }
     detection_reads = [
         call.args[0] for call in read.call_args_list if call.args[0] in detection_registers
     ]
-    assert detection_reads == [MotionNodeCapture.MONITORING_VERSION_REGISTER]
+    assert detection_reads == [MotionNodeCapture._MONITORING_VERSION_REGISTER]
     detection_calls = [call for call in read.call_args_list if call.args[0] in detection_registers]
     assert all(call.kwargs == {"subnode": 0} for call in detection_calls)
 
@@ -424,9 +424,9 @@ def test_motion_node_capture_unsupported_version_is_cached(mocker, motion_node):
     """Test that unsupported monitoring detection is not repeated."""
     patch_monitoring_version(mocker, motion_node, None)
     detection_registers = {
-        MotionNodeCapture.MONITORING_VERSION_REGISTER,
-        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
-        MotionNodeCapture.MONITORING_STATUS_REGISTER,
+        MotionNodeCapture._MONITORING_VERSION_REGISTER,
+        MotionNodeCapture._MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        MotionNodeCapture._MONITORING_STATUS_REGISTER,
     }
     original_read = motion_node.servo.read
 
@@ -445,9 +445,9 @@ def test_motion_node_capture_unsupported_version_is_cached(mocker, motion_node):
     assert first_error.value is not second_error.value
     detection_reads = [call.args[0] for call in read_mock.call_args_list]
     assert detection_reads == [
-        MotionNodeCapture.MONITORING_VERSION_REGISTER,
-        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
-        MotionNodeCapture.MONITORING_STATUS_REGISTER,
+        MotionNodeCapture._MONITORING_VERSION_REGISTER,
+        MotionNodeCapture._MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        MotionNodeCapture._MONITORING_STATUS_REGISTER,
     ]
     assert all(call.kwargs == {"subnode": 0} for call in read_mock.call_args_list)
 
@@ -455,7 +455,7 @@ def test_motion_node_capture_unsupported_version_is_cached(mocker, motion_node):
 @pytest.mark.virtual
 def test_motion_node_capture_raises_ingenialink_register_error(mocker, motion_node):
     """Test that the motion node capture raises the ingenialink register error."""
-    mocker.patch.object(MotionNodeCapture, "MONITORING_STATUS_REGISTER", "NON_EXISTING_UID")
+    mocker.patch.object(MotionNodeCapture, "_MONITORING_STATUS_REGISTER", "NON_EXISTING_UID")
     with pytest.raises(ILRegisterNotFoundError):
         motion_node.capture.get_monitoring_status()
 
@@ -463,7 +463,7 @@ def test_motion_node_capture_raises_ingenialink_register_error(mocker, motion_no
 @pytest.mark.virtual
 def test_capture_raises_ingeniamotion_register_error(mocker, mc, alias):
     """Test that the facade keeps raising the ingeniamotion register error."""
-    mocker.patch.object(MotionNodeCapture, "MONITORING_STATUS_REGISTER", "NON_EXISTING_UID")
+    mocker.patch.object(MotionNodeCapture, "_MONITORING_STATUS_REGISTER", "NON_EXISTING_UID")
     with pytest.raises(IMRegisterNotExistError):
         mc.capture.get_monitoring_status(servo=alias)
 
@@ -485,9 +485,9 @@ def test_check_monitoring_version_v1(mocker, mc, alias, motion_node):
 @pytest.mark.virtual
 def test_check_monitoring_version_not_available(mocker, mc, alias, motion_node):
     detection_registers = [
-        MotionNodeCapture.MONITORING_VERSION_REGISTER,
-        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
-        MotionNodeCapture.MONITORING_STATUS_REGISTER,
+        MotionNodeCapture._MONITORING_VERSION_REGISTER,
+        MotionNodeCapture._MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        MotionNodeCapture._MONITORING_STATUS_REGISTER,
     ]
     patch_monitoring_version(mocker, motion_node, None)
     servo = mc.servos[alias]
@@ -517,7 +517,7 @@ def test_motion_node_capture_version_is_not_cached_after_communication_error(moc
 
     def read(register, *args, **kwargs):
         nonlocal failed
-        if register == MotionNodeCapture.MONITORING_VERSION_REGISTER and not failed:
+        if register == MotionNodeCapture._MONITORING_VERSION_REGISTER and not failed:
             failed = True
             raise ILError
         return original_read(register, *args, **kwargs)
@@ -536,9 +536,9 @@ def test_capture_explicit_version_bypasses_detection(mocker, mc, alias):
     mc.capture.disable_disturbance(servo=alias, version=MonitoringVersion.MONITORING_V3)
 
     detection_registers = {
-        MotionNodeCapture.MONITORING_VERSION_REGISTER,
-        MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
-        MotionNodeCapture.MONITORING_STATUS_REGISTER,
+        MotionNodeCapture._MONITORING_VERSION_REGISTER,
+        MotionNodeCapture._MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
+        MotionNodeCapture._MONITORING_STATUS_REGISTER,
     }
     detection_reads = [
         call.args[0] for call in read.call_args_list if call.args[0] in detection_registers

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,4 +1,5 @@
 import time
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 import pytest
@@ -18,6 +19,38 @@ from ingeniamotion.exceptions import (
     IMRegisterNotExistError,
     IMStatusWordError,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from ingeniamotion.motion_node import MotionNode
+
+
+def reset_monitoring_cache(motion_node: "MotionNode") -> None:
+    """Remove the cached capture object from a motion node."""
+    motion_node.__dict__.pop("capture", None)
+
+
+def patch_monitoring_version(
+    mocker: "MockerFixture",
+    motion_node: "MotionNode",
+    version: Optional[MonitoringVersion],
+) -> None:
+    """Reset capture state and make higher monitoring versions unavailable."""
+    reset_monitoring_cache(motion_node)
+    detection_registers = (
+        "MONITORING_VERSION_REGISTER",
+        "MONITORING_CURRENT_NUMBER_BYTES_REGISTER",
+        "MONITORING_STATUS_REGISTER",
+    )
+    available_register_index = {
+        MonitoringVersion.MONITORING_V3: 0,
+        MonitoringVersion.MONITORING_V2: 1,
+        MonitoringVersion.MONITORING_V1: 2,
+        None: 3,
+    }
+    for register in detection_registers[: available_register_index[version]]:
+        mocker.patch.object(MotionNodeCapture, register, "NON_EXISTING_UID")
 
 
 def __compare_signals(expected_signal, received_signal, fft_tol=0.05):
@@ -365,6 +398,7 @@ def test_check_monitoring_version_v3(mc, alias):
 @pytest.mark.virtual
 def test_motion_node_capture_version_is_cached(mocker, motion_node):
     """Test that version detection reads the registers only once."""
+    reset_monitoring_cache(motion_node)
     read = mocker.spy(motion_node.servo, "read")
 
     first_version = motion_node.capture.version
@@ -388,6 +422,7 @@ def test_motion_node_capture_version_is_cached(mocker, motion_node):
 @pytest.mark.virtual
 def test_motion_node_capture_unsupported_version_is_cached(mocker, motion_node):
     """Test that unsupported monitoring detection is not repeated."""
+    patch_monitoring_version(mocker, motion_node, None)
     detection_registers = {
         MotionNodeCapture.MONITORING_VERSION_REGISTER,
         MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
@@ -434,29 +469,27 @@ def test_capture_raises_ingeniamotion_register_error(mocker, mc, alias):
 
 
 @pytest.mark.virtual
-def test_check_monitoring_version_v2(mocker, mc, alias):
-    mocker.patch.object(MotionNodeCapture, "MONITORING_VERSION_REGISTER", "NON_EXISTING_UID")
+def test_check_monitoring_version_v2(mocker, mc, alias, motion_node):
+    patch_monitoring_version(mocker, motion_node, MonitoringVersion.MONITORING_V2)
     version = mc.capture._check_version(servo=alias)
     assert version == MonitoringVersion.MONITORING_V2
 
 
 @pytest.mark.virtual
-def test_check_monitoring_version_v1(mocker, mc, alias):
-    mocker.patch.object(MotionNodeCapture, "MONITORING_VERSION_REGISTER", "NON_EXISTING_UID")
-    mocker.patch.object(
-        MotionNodeCapture, "MONITORING_CURRENT_NUMBER_BYTES_REGISTER", "NON_EXISTING_UID"
-    )
+def test_check_monitoring_version_v1(mocker, mc, alias, motion_node):
+    patch_monitoring_version(mocker, motion_node, MonitoringVersion.MONITORING_V1)
     version = mc.capture._check_version(servo=alias)
     assert version == MonitoringVersion.MONITORING_V1
 
 
 @pytest.mark.virtual
-def test_check_monitoring_version_not_available(mocker, mc, alias):
+def test_check_monitoring_version_not_available(mocker, mc, alias, motion_node):
     detection_registers = [
         MotionNodeCapture.MONITORING_VERSION_REGISTER,
         MotionNodeCapture.MONITORING_CURRENT_NUMBER_BYTES_REGISTER,
         MotionNodeCapture.MONITORING_STATUS_REGISTER,
     ]
+    patch_monitoring_version(mocker, motion_node, None)
     servo = mc.servos[alias]
     original_read = servo.read
 
@@ -478,6 +511,7 @@ def test_check_monitoring_version_not_available(mocker, mc, alias):
 @pytest.mark.virtual
 def test_motion_node_capture_version_is_not_cached_after_communication_error(mocker, motion_node):
     """Test that a version detected after a communication error is detected again."""
+    reset_monitoring_cache(motion_node)
     original_read = motion_node.servo.read
     failed = False
 

--- a/tests/test_motion_node.py
+++ b/tests/test_motion_node.py
@@ -1,6 +1,7 @@
 import pytest
 from ingenialink.dictionary import SubnodeType
 
+from ingeniamotion.capture import MotionNodeCapture
 from ingeniamotion.motion_node import MotionNode
 
 
@@ -48,3 +49,10 @@ def test_axes_created_for_multi_axis_dictionary(mocker, servo, net):
     # Test KeyError for non-existent axis
     with pytest.raises(KeyError):
         motion_node.get_axis(3)
+
+
+@pytest.mark.virtual
+def test_capture_is_cached(motion_node):
+    """Test that a motion node returns the same capture object each time."""
+    assert motion_node.capture is motion_node.capture
+    assert isinstance(motion_node.capture, MotionNodeCapture)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@ import weakref
 
 import pytest
 
-from ingeniamotion._utils import weak_lru
-from ingeniamotion.exceptions import IMErrorQueueNotExistsError
+from ingeniamotion._utils import map_exceptions, weak_lru
+from ingeniamotion.exceptions import IMErrorQueueNotExistsError, IMStatusWordError
 
 
 class ExpensiveCalculator:
@@ -84,3 +84,17 @@ def test_exception_group_lets_non_catched_through():
         with IMErrorQueueNotExistsError.group("Message of the group") as eg:
             with eg.catch(KeyError, ValueError):
                 raise NotImplementedError("Test KeyError")
+
+
+@pytest.mark.virtual
+def test_map_exceptions_raises_the_mapped_exception():
+    with pytest.raises(IMStatusWordError) as error, map_exceptions({KeyError: IMStatusWordError}):
+        raise KeyError("missing")
+
+    assert isinstance(error.value.__cause__, KeyError)
+
+
+@pytest.mark.virtual
+def test_map_exceptions_leaves_unmapped_exceptions():
+    with pytest.raises(ValueError), map_exceptions({KeyError: IMStatusWordError}):
+        raise ValueError("unmapped")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,11 @@ class ExpensiveCalculator:
         return x * self.factor
 
 
+class NoArgumentError(Exception):
+    def __init__(self) -> None:
+        super().__init__()
+
+
 @pytest.mark.virtual
 def test_weak_lru_cache():
     calc = ExpensiveCalculator(10)
@@ -98,3 +103,14 @@ def test_map_exceptions_raises_the_mapped_exception():
 def test_map_exceptions_leaves_unmapped_exceptions():
     with pytest.raises(ValueError), map_exceptions({KeyError: IMStatusWordError}):
         raise ValueError("unmapped")
+
+
+@pytest.mark.virtual
+def test_map_exceptions_supports_no_argument_exception_factories():
+    """Mapped exceptions should not receive arguments from the original exception.
+
+    Raises:
+        KeyError: Raised inside the mapping context for the regression check.
+    """
+    with pytest.raises(NoArgumentError), map_exceptions({KeyError: NoArgumentError}):
+        raise KeyError("missing")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,11 +18,6 @@ class ExpensiveCalculator:
         return x * self.factor
 
 
-class NoArgumentError(Exception):
-    def __init__(self) -> None:
-        super().__init__()
-
-
 @pytest.mark.virtual
 def test_weak_lru_cache():
     calc = ExpensiveCalculator(10)
@@ -91,26 +86,34 @@ def test_exception_group_lets_non_catched_through():
                 raise NotImplementedError("Test KeyError")
 
 
-@pytest.mark.virtual
-def test_map_exceptions_raises_the_mapped_exception():
-    with pytest.raises(IMStatusWordError) as error, map_exceptions({KeyError: IMStatusWordError}):
-        raise KeyError("missing")
+class TestMapExceptions:
+    """Tests for exception type mapping."""
 
-    assert isinstance(error.value.__cause__, KeyError)
+    class NoArgumentError(Exception):
+        def __init__(self) -> None:
+            super().__init__()
 
+    @pytest.mark.virtual
+    def test_raises_the_mapped_exception(self):
+        with (
+            pytest.raises(IMStatusWordError) as error,
+            map_exceptions({KeyError: IMStatusWordError}),
+        ):
+            raise KeyError("missing")
 
-@pytest.mark.virtual
-def test_map_exceptions_leaves_unmapped_exceptions():
-    with pytest.raises(ValueError), map_exceptions({KeyError: IMStatusWordError}):
-        raise ValueError("unmapped")
+        assert isinstance(error.value.__cause__, KeyError)
 
+    @pytest.mark.virtual
+    def test_leaves_unmapped_exceptions(self):
+        with pytest.raises(ValueError), map_exceptions({KeyError: IMStatusWordError}):
+            raise ValueError("unmapped")
 
-@pytest.mark.virtual
-def test_map_exceptions_supports_no_argument_exception_factories():
-    """Mapped exceptions should not receive arguments from the original exception.
+    @pytest.mark.virtual
+    def test_supports_no_argument_exception_factories(self):
+        """Mapped exceptions should not receive arguments from the original exception.
 
-    Raises:
-        KeyError: Raised inside the mapping context for the regression check.
-    """
-    with pytest.raises(NoArgumentError), map_exceptions({KeyError: NoArgumentError}):
-        raise KeyError("missing")
+        Raises:
+            KeyError: Raised inside the mapping context for the regression check.
+        """
+        with pytest.raises(self.NoArgumentError), map_exceptions({KeyError: self.NoArgumentError}):
+            raise KeyError("missing")


### PR DESCRIPTION
Introduces `MotionNodeCapture`, an object-oriented API that binds monitoring and disturbance operations to a `MotionNode`.

Monitoring version detection is now cached per motion node, avoiding repeated register reads while ensuring results affected by communication errors are not cached.

The existing `Capture` API remains available as a backward-compatible facade.

## Changes

- Add `MotionNode.capture` as a cached `MotionNodeCapture` instance.
- Move monitoring and disturbance status, enable, disable, and version detection operations to `MotionNodeCapture`.
- Cache successfully detected monitoring versions.
- Cache drives confirmed not to support monitoring and disturbance.
- Do not cache version detection results affected by communication errors.
- Preserve explicit version arguments without probing version registers.
- Preserve the existing `Capture` API and its IngeniaMotion exception contract.
- Read capture registers directly through the motion node servo.
- Add tests covering the object cache, version cache, communication failures, unsupported drives, explicit versions, and facade compatibility.

## Testing

- Added virtual-drive tests for monitoring version detection and caching.
- Added tests for monitoring and disturbance operations through both `MotionNodeCapture` and the existing `Capture` facade.