### PR TITLE
Fix develop nightlies

### DIFF
--- a/tests/test_homing.py
+++ b/tests/test_homing.py
@@ -105,7 +105,6 @@ def test_homing_on_current_position(servo, mc, alias, homing_offset):
 @pytest.mark.ethernet
 @pytest.mark.soem
 @pytest.mark.canopen
-@pytest.mark.usefixtures("initial_position")
 @pytest.mark.parametrize("direction", [1, 0])
 def test_homing_on_switch_limit(servo, mc, alias, direction):
     with refresh_registers_for_test_rollback(

--- a/tests/test_homing.py
+++ b/tests/test_homing.py
@@ -309,8 +309,7 @@ def test_current_position_homing_restores_operation_mode_on_failure(mocker) -> N
 @pytest.mark.parametrize("direction", [1, 0])
 @pytest.mark.not_valid_version_for_product(
     part_number="EVE-*",
-    min="2.7.0",
-    max="2.8.1",
+    min="2.9.0",
     skip_reason="https://novantamotion.atlassian.net/browse/COMOCOAPP-493 (fixed in 2.9.0)",
 )
 def test_homing_on_index_pulse(servo, mc, alias, feedback_list, direction):


### PR DESCRIPTION
# Changes
* Updated invalid version of `EVE-XCR-E`: it was already known that there is an issue with some versions, but it was not confirmed by the firmware team which is the minimum version that was working. Apparently, 2.6.0 is not valid, so it has been disabled as well. See [pipeline](http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingeniamotion/job/develop/2197/stages/?selected-node=1271) (link may expire).
<img width="1367" height="214" alt="image" src="https://github.com/user-attachments/assets/dce5466b-86ae-4b39-96cd-36340a2f3e99" />
